### PR TITLE
Enhance health endpoint with uptime, sources, and library stats

### DIFF
--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -2,8 +2,20 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"runtime"
+	"time"
 )
+
+// Set at build time via -ldflags
+var (
+	Version   = "2.0.0"
+	BuildTime = "unknown"
+	GoVersion = runtime.Version()
+)
+
+var startTime = time.Now()
 
 func (s *Server) handleRoot(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -11,10 +23,52 @@ func (s *Server) handleRoot(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	uptime := time.Since(startTime)
+
+	// Count enabled sources
+	enabledSources := 0
+	sourceNames := []string{}
+	for _, src := range s.searchMgr.GetSources() {
+		if src.Enabled() {
+			enabledSources++
+			sourceNames = append(sourceNames, src.Name())
+		}
+	}
+
+	// Library stats
+	libraryTotal := 0
+	if stats, err := s.db.GetStats(); err == nil {
+		if total, ok := stats["total_items"]; ok {
+			if n, ok := total.(int); ok {
+				libraryTotal = n
+			}
+		}
+	}
+
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"status":  "ok",
-		"version": "2.0.0",
+		"status":          "ok",
+		"version":         Version,
+		"build_time":      BuildTime,
+		"go_version":      GoVersion,
+		"uptime_seconds":  int(uptime.Seconds()),
+		"uptime_human":    formatDuration(uptime),
+		"sources_enabled": enabledSources,
+		"sources":         sourceNames,
+		"library_items":   libraryTotal,
 	})
+}
+
+func formatDuration(d time.Duration) string {
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	mins := int(d.Minutes()) % 60
+	if days > 0 {
+		return fmt.Sprintf("%dd %dh %dm", days, hours, mins)
+	}
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm", hours, mins)
+	}
+	return fmt.Sprintf("%dm", mins)
 }
 
 func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"zero", 0, "0m"},
+		{"minutes", 5 * time.Minute, "5m"},
+		{"hours_minutes", 2*time.Hour + 30*time.Minute, "2h 30m"},
+		{"days_hours_minutes", 3*24*time.Hour + 5*time.Hour + 15*time.Minute, "3d 5h 15m"},
+		{"one_day", 24 * time.Hour, "1d 0h 0m"},
+		{"just_hours", 12 * time.Hour, "12h 0m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDuration(tt.d)
+			if got != tt.want {
+				t.Errorf("formatDuration(%v) = %q, want %q", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionVars(t *testing.T) {
+	if Version == "" {
+		t.Error("Version should not be empty")
+	}
+	if GoVersion == "" {
+		t.Error("GoVersion should not be empty")
+	}
+}


### PR DESCRIPTION
## Summary
- Health endpoint now returns uptime, enabled source count with names, library item count, build time, and Go version
- Added `formatDuration` helper for human-readable uptime
- New unit tests for duration formatting

## Changes
- `internal/api/health.go` — enhanced `/health` response with runtime info
- `internal/api/health_test.go` — new tests for `formatDuration` and version vars

## Test plan
- [ ] `go test ./...` passes (449 tests)
- [ ] `/health` endpoint returns new fields
- [ ] Build with ldflags sets version/build time