### PR TITLE
Fix: libgen mirror fallback + helpful Prowlarr error messages (fixes #7)

### DIFF
--- a/internal/download/direct.go
+++ b/internal/download/direct.go
@@ -28,6 +28,17 @@ func NewDirectDownloader(cfg *config.Config, client *http.Client) *DirectDownloa
 
 var getLinkRe = regexp.MustCompile(`href="(get\.php\?md5=[^"]+)"`)
 
+// libgenMirrors are alternative libgen front-ends that implement the
+// ads.php → get.php download flow. Tried in order when one fails.
+// (Other libgen domains like .is / .rs use a different URL scheme.)
+var libgenMirrors = []string{
+	"https://libgen.li",
+	"https://libgen.la",
+	"https://libgen.bz",
+	"https://libgen.gl",
+	"https://libgen.vg",
+}
+
 // DownloadFromAnnas downloads a file from Anna's Archive via libgen.
 // Returns the local file path and size, or an error.
 func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(string)) (string, int64, error) {
@@ -35,40 +46,22 @@ func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(
 		progressFn("Fetching download link from Anna's Archive...")
 	}
 
-	// Step 1: Get the download key from libgen ads page.
-	adsURL := fmt.Sprintf("https://libgen.li/ads.php?md5=%s", md5)
-	req, err := http.NewRequest("GET", adsURL, nil)
-	if err != nil {
-		return "", 0, err
-	}
-	req.Header.Set("User-Agent", d.cfg.UserAgent)
-
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return "", 0, fmt.Errorf("fetch libgen ads page: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024)) // 2MB max for HTML pages
-	if resp.StatusCode != 200 {
-		return "", 0, fmt.Errorf("libgen ads page HTTP %d", resp.StatusCode)
-	}
-
-	match := getLinkRe.FindSubmatch(body)
-	if len(match) < 2 {
-		// Try alternative MD5 hashes by re-searching Anna's Archive.
+	// Step 1: Try each libgen mirror to get the download key.
+	downloadURL, mirrorErr := d.fetchLibgenDownloadURL(md5, progressFn)
+	if mirrorErr != nil {
+		// All libgen mirrors failed. Try alternative MD5 hashes by re-searching
+		// Anna's Archive — the same book often has multiple MD5s across mirrors.
 		if progressFn != nil {
-			progressFn("No direct link found, trying alternative mirrors...")
+			progressFn("All libgen mirrors failed, trying alternative MD5s...")
 		}
 		altURL, altErr := d.tryAltMD5(title, md5, progressFn)
 		if altErr != nil {
-			return "", 0, fmt.Errorf("no get.php link found on libgen for md5=%s (alt search also failed: %v)", md5, altErr)
+			return "", 0, fmt.Errorf("all libgen mirrors failed (%v); alt search also failed: %v", mirrorErr, altErr)
 		}
 		return d.downloadFile(altURL, title, progressFn)
 	}
 
-	downloadURL := fmt.Sprintf("https://libgen.li/%s", string(match[1]))
-	slog.Info("found libgen download link", "title", title, "url", downloadURL[:60])
+	slog.Info("found libgen download link", "title", title, "url", downloadURL[:min(60, len(downloadURL))])
 
 	if progressFn != nil {
 		progressFn("Downloading...")
@@ -76,6 +69,51 @@ func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(
 
 	// Step 2: Download the file.
 	return d.downloadFile(downloadURL, title, progressFn)
+}
+
+// fetchLibgenDownloadURL tries each libgen mirror to find a valid get.php
+// download link. Returns the full URL on success, or the last error if all
+// mirrors fail. Transient errors (5xx, network) move on to the next mirror;
+// "link not found" on one mirror also tries the next since mirrors sometimes
+// have the book while others don't.
+func (d *DirectDownloader) fetchLibgenDownloadURL(md5 string, progressFn func(string)) (string, error) {
+	var lastErr error
+	for i, mirror := range libgenMirrors {
+		if i > 0 && progressFn != nil {
+			progressFn(fmt.Sprintf("Trying mirror: %s", mirror))
+		}
+
+		adsURL := fmt.Sprintf("%s/ads.php?md5=%s", mirror, md5)
+		req, err := http.NewRequest("GET", adsURL, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("User-Agent", d.cfg.UserAgent)
+
+		resp, err := d.client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("%s: %w", mirror, err)
+			continue
+		}
+
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+		resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			lastErr = fmt.Errorf("%s HTTP %d", mirror, resp.StatusCode)
+			continue
+		}
+
+		match := getLinkRe.FindSubmatch(body)
+		if len(match) < 2 {
+			lastErr = fmt.Errorf("%s: no get.php link for md5=%s", mirror, md5)
+			continue
+		}
+
+		return fmt.Sprintf("%s/%s", mirror, string(match[1])), nil
+	}
+	return "", lastErr
 }
 
 // DownloadFromURL downloads a file from any direct URL.

--- a/internal/download/libgen_mirrors_test.go
+++ b/internal/download/libgen_mirrors_test.go
@@ -1,0 +1,201 @@
+package download
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+)
+
+// Helper: swap libgenMirrors for a test and restore afterwards.
+func withMirrors(t *testing.T, mirrors []string) {
+	t.Helper()
+	orig := libgenMirrors
+	libgenMirrors = mirrors
+	t.Cleanup(func() { libgenMirrors = orig })
+}
+
+// TestFetchLibgenDownloadURL_FirstMirrorWorks is the happy path.
+func TestFetchLibgenDownloadURL_FirstMirrorWorks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html><a href="get.php?md5=abc123&key=XYZ">GET</a></html>`))
+	}))
+	defer server.Close()
+
+	withMirrors(t, []string{server.URL})
+	cfg := &config.Config{UserAgent: "test"}
+	d := NewDirectDownloader(cfg, server.Client())
+
+	url, err := d.fetchLibgenDownloadURL("abc123", nil)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if !strings.Contains(url, "get.php?md5=abc123") {
+		t.Errorf("unexpected URL: %s", url)
+	}
+}
+
+// TestFetchLibgenDownloadURL_FailsOverOn500 — issue #7 regression test.
+// First mirror returns HTTP 500, second mirror succeeds.
+func TestFetchLibgenDownloadURL_FailsOverOn500(t *testing.T) {
+	brokenCalls := int32(0)
+	workingCalls := int32(0)
+
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&brokenCalls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer broken.Close()
+
+	working := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&workingCalls, 1)
+		_, _ = w.Write([]byte(`<a href="get.php?md5=abc&key=ZZZ">GET</a>`))
+	}))
+	defer working.Close()
+
+	withMirrors(t, []string{broken.URL, working.URL})
+	cfg := &config.Config{UserAgent: "test"}
+	d := NewDirectDownloader(cfg, working.Client())
+
+	url, err := d.fetchLibgenDownloadURL("abc", nil)
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got: %v", err)
+	}
+	if !strings.HasPrefix(url, working.URL+"/") {
+		t.Errorf("URL should be from working mirror, got: %s", url)
+	}
+	if atomic.LoadInt32(&brokenCalls) != 1 {
+		t.Errorf("broken mirror should be tried once, got %d", brokenCalls)
+	}
+	if atomic.LoadInt32(&workingCalls) != 1 {
+		t.Errorf("working mirror should be tried once, got %d", workingCalls)
+	}
+}
+
+// TestFetchLibgenDownloadURL_AllMirrorsFail — all mirrors down.
+func TestFetchLibgenDownloadURL_AllMirrorsFail(t *testing.T) {
+	m1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer m1.Close()
+	m2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer m2.Close()
+
+	withMirrors(t, []string{m1.URL, m2.URL})
+	cfg := &config.Config{UserAgent: "test"}
+	d := NewDirectDownloader(cfg, m1.Client())
+
+	_, err := d.fetchLibgenDownloadURL("abc", nil)
+	if err == nil {
+		t.Fatal("expected error when all mirrors fail, got nil")
+	}
+	// Should report the LAST mirror's error
+	if !strings.Contains(err.Error(), "HTTP") {
+		t.Errorf("error should mention HTTP status: %v", err)
+	}
+}
+
+// TestFetchLibgenDownloadURL_MirrorLacksBook — some mirrors don't have the MD5.
+func TestFetchLibgenDownloadURL_MirrorLacksBook(t *testing.T) {
+	m1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Returns 200 but no get.php link (book not present on this mirror)
+		_, _ = w.Write([]byte(`<html><body>File not found</body></html>`))
+	}))
+	defer m1.Close()
+	m2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<a href="get.php?md5=xyz&key=ABC">GET</a>`))
+	}))
+	defer m2.Close()
+
+	withMirrors(t, []string{m1.URL, m2.URL})
+	cfg := &config.Config{UserAgent: "test"}
+	d := NewDirectDownloader(cfg, m1.Client())
+
+	url, err := d.fetchLibgenDownloadURL("xyz", nil)
+	if err != nil {
+		t.Fatalf("expected fallback to mirror with the book, got: %v", err)
+	}
+	if !strings.HasPrefix(url, m2.URL+"/") {
+		t.Errorf("URL should be from m2, got: %s", url)
+	}
+}
+
+// TestFetchLibgenDownloadURL_NetworkErrorFailsOver — connection refused on one mirror.
+func TestFetchLibgenDownloadURL_NetworkErrorFailsOver(t *testing.T) {
+	working := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<a href="get.php?md5=abc&key=XXX">GET</a>`))
+	}))
+	defer working.Close()
+
+	// Point to a port that's closed
+	withMirrors(t, []string{"http://127.0.0.1:1", working.URL})
+	cfg := &config.Config{UserAgent: "test"}
+	d := NewDirectDownloader(cfg, working.Client())
+
+	url, err := d.fetchLibgenDownloadURL("abc", nil)
+	if err != nil {
+		t.Fatalf("expected fallback on network error, got: %v", err)
+	}
+	if !strings.HasPrefix(url, working.URL+"/") {
+		t.Errorf("URL should be from working mirror, got: %s", url)
+	}
+}
+
+// TestFetchLibgenDownloadURL_ProgressCallback verifies progress updates.
+func TestFetchLibgenDownloadURL_ProgressCallback(t *testing.T) {
+	m1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer m1.Close()
+	m2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<a href="get.php?md5=a&key=B">GET</a>`))
+	}))
+	defer m2.Close()
+
+	withMirrors(t, []string{m1.URL, m2.URL})
+	cfg := &config.Config{UserAgent: "test"}
+	d := NewDirectDownloader(cfg, m1.Client())
+
+	var messages []string
+	_, err := d.fetchLibgenDownloadURL("a", func(msg string) {
+		messages = append(messages, msg)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(messages) == 0 {
+		t.Error("expected progress messages, got none")
+	}
+	found := false
+	for _, m := range messages {
+		if strings.Contains(m, "Trying mirror") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'Trying mirror' message, got: %v", messages)
+	}
+}
+
+// TestLibgenMirrors_Configured ensures we have multiple mirrors so a single
+// mirror outage doesn't break downloads entirely.
+func TestLibgenMirrors_Configured(t *testing.T) {
+	if len(libgenMirrors) < 3 {
+		t.Errorf("should have at least 3 libgen mirrors for redundancy, got %d", len(libgenMirrors))
+	}
+	for _, m := range libgenMirrors {
+		if !strings.HasPrefix(m, "https://libgen.") {
+			t.Errorf("unexpected mirror URL: %s", m)
+		}
+	}
+}
+
+// Avoid unused-import linter errors when only some tests are built
+var _ = fmt.Sprintf

--- a/internal/search/prowlarr.go
+++ b/internal/search/prowlarr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -139,8 +140,26 @@ func (p *Prowlarr) doSearch(ctx context.Context, params prowlarrSearchParams) ([
 		return nil, fmt.Errorf("prowlarr HTTP %d", resp.StatusCode)
 	}
 
+	// Read body first so we can diagnose HTML error pages (which happen when
+	// the user's API key is wrong, a reverse proxy is intercepting the request,
+	// or Prowlarr is starting up and serving a placeholder page).
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read prowlarr response: %w", err)
+	}
+
+	trimmed := strings.TrimSpace(string(bodyBytes))
+	if strings.HasPrefix(trimmed, "<") {
+		ct := resp.Header.Get("Content-Type")
+		preview := trimmed
+		if len(preview) > 200 {
+			preview = preview[:200]
+		}
+		return nil, fmt.Errorf("prowlarr returned HTML instead of JSON (content-type=%q, likely wrong API key or reverse proxy issue): %s", ct, preview)
+	}
+
 	var items []prowlarrItem
-	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+	if err := json.Unmarshal(bodyBytes, &items); err != nil {
 		return nil, fmt.Errorf("decode prowlarr response: %w", err)
 	}
 

--- a/internal/search/prowlarr_test.go
+++ b/internal/search/prowlarr_test.go
@@ -299,3 +299,117 @@ func TestIsNZBURL_NewznabPattern(t *testing.T) {
 		t.Error("expected &t=get& in URL")
 	}
 }
+
+// --- Tests for issue #7: better Prowlarr error messages ---
+
+// TestProwlarr_HTMLResponse — when Prowlarr returns HTML instead of JSON (e.g.,
+// reverse proxy intercept or wrong API key), the error should be descriptive
+// rather than the cryptic "invalid character '<'" JSON decode error.
+func TestProwlarr_HTMLResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<!DOCTYPE html>\n<html><body>Login required</body></html>"))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{ProwlarrURL: server.URL, ProwlarrAPIKey: "key"}
+	p := NewProwlarr(cfg, server.Client(), "main")
+
+	_, err := p.doSearch(context.Background(), prowlarrSearchParams{query: "test", limit: 10})
+	if err == nil {
+		t.Fatal("expected error for HTML response, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "HTML") {
+		t.Errorf("error should mention HTML, got: %v", err)
+	}
+	if !strings.Contains(msg, "reverse proxy") && !strings.Contains(msg, "API key") {
+		t.Errorf("error should suggest cause (proxy/API key), got: %v", err)
+	}
+}
+
+func TestProwlarr_HTMLWithLeadingWhitespace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("\n\n  <html><body>error</body></html>"))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{ProwlarrURL: server.URL, ProwlarrAPIKey: "key"}
+	p := NewProwlarr(cfg, server.Client(), "main")
+
+	_, err := p.doSearch(context.Background(), prowlarrSearchParams{query: "test", limit: 10})
+	if err == nil {
+		t.Fatal("expected error for HTML response, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTML") {
+		t.Errorf("error should mention HTML, got: %v", err)
+	}
+}
+
+// TestProwlarr_RealAuthelia401 — Authelia returns an HTML 401 login page when
+// the session cookie is missing. Prowlarr also uses this pattern for some
+// reverse proxy setups.
+func TestProwlarr_RealAuthelia401(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK) // Authelia actually returns 200 with HTML login page
+		_, _ = w.Write([]byte(`<!DOCTYPE html><html><head><title>Authelia</title></head><body><div id="authelia">...</div></body></html>`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{ProwlarrURL: server.URL, ProwlarrAPIKey: "key"}
+	p := NewProwlarr(cfg, server.Client(), "main")
+
+	_, err := p.doSearch(context.Background(), prowlarrSearchParams{query: "test", limit: 10})
+	if err == nil {
+		t.Fatal("expected error for Authelia HTML response")
+	}
+	if !strings.Contains(err.Error(), "HTML") {
+		t.Errorf("error should say HTML, got: %v", err)
+	}
+}
+
+// TestProwlarr_ValidJSONStillWorks — sanity check that the new body-read +
+// HTML-detection path doesn't break the success case.
+func TestProwlarr_ValidJSONStillWorks(t *testing.T) {
+	items := []prowlarrItem{
+		{Title: "A Book", Size: 1024 * 1024, Seeders: 10, Protocol: "torrent"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(items)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{ProwlarrURL: server.URL, ProwlarrAPIKey: "key"}
+	p := NewProwlarr(cfg, server.Client(), "main")
+
+	results, err := p.doSearch(context.Background(), prowlarrSearchParams{query: "a book", limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+}
+
+// TestProwlarr_TruncatedJSON — server starts sending JSON but cuts off mid-stream.
+// Should return a clear error mentioning decode failure, not panic.
+func TestProwlarr_TruncatedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"title":"Partial`)) // truncated JSON
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{ProwlarrURL: server.URL, ProwlarrAPIKey: "key"}
+	p := NewProwlarr(cfg, server.Client(), "main")
+
+	_, err := p.doSearch(context.Background(), prowlarrSearchParams{query: "test", limit: 10})
+	if err == nil {
+		t.Fatal("expected error for truncated JSON")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Errorf("expected decode error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #7.

Two independent root causes both surfaced in this issue.

## 1. libgen.li returning HTTP 500 breaks all Anna's Archive downloads

The old code only tried a single mirror. At time of filing (and still today, in spot-checks), `libgen.li` returns 500 on `ads.php`, which takes out every download.

**Fix:** try a list of libgen mirrors in sequence. If one returns a transient error, a non-200, or simply doesn't have the book, move on to the next before falling back to the alternative-MD5 search path.

Mirrors tried (verified live):
- libgen.li
- libgen.la
- libgen.bz
- libgen.gl
- libgen.vg

These are the libgen front-ends that implement the same `ads.php` → `get.php` flow. (Other libgen domains like `.is` / `.rs` use a different URL scheme and aren't included here.)

## 2. Prowlarr HTML response

The error in the issue — `decode prowlarr response: invalid character '<' looking for beginning of value` — means Prowlarr returned HTML where JSON was expected. This happens when:

- the configured API key doesn't match Prowlarr's `/settings/general`
- a reverse proxy (nginx, authelia, cloudflare) is intercepting and returning its own login page
- Prowlarr is starting up and serving a placeholder

**Fix:** before JSON-decoding, check if the body starts with `<`. If so, produce a descriptive error that names the likely causes and includes a 200-char preview of the returned HTML. The existing retry-across-search-variants logic continues to work — this is purely a better error message for when all variants fail.

## Tests

**12 new tests:**

`internal/download/libgen_mirrors_test.go` — 7 tests:
- `TestFetchLibgenDownloadURL_FirstMirrorWorks` — happy path
- `TestFetchLibgenDownloadURL_FailsOverOn500` — the exact issue #7 scenario
- `TestFetchLibgenDownloadURL_AllMirrorsFail` — all-down error propagation
- `TestFetchLibgenDownloadURL_MirrorLacksBook` — 200 but no `get.php` link on one mirror, fallback to another
- `TestFetchLibgenDownloadURL_NetworkErrorFailsOver` — connection refused on one mirror
- `TestFetchLibgenDownloadURL_ProgressCallback` — progress UI updates fire
- `TestLibgenMirrors_Configured` — sanity check on the mirror list

`internal/search/prowlarr_test.go` — 5 added:
- `TestProwlarr_HTMLResponse` — basic HTML detection + helpful error message
- `TestProwlarr_HTMLWithLeadingWhitespace` — robust to `\n\n  <html>`
- `TestProwlarr_RealAuthelia401` — realistic Authelia login page scenario
- `TestProwlarr_ValidJSONStillWorks` — sanity check happy path
- `TestProwlarr_TruncatedJSON` — truncated response returns descriptive error, doesn't panic

All pass. CI will run them on this PR.

## Not fixed here

The issue also mentioned **Open Library HTTP 422** — that's a separate third-party flakiness issue. Since the other sources still return results, it doesn't need to block this PR.