### PR TITLE
Fix: PWA library appears empty — CORS accepts apikey query param

### DIFF
--- a/internal/api/cors_test.go
+++ b/internal/api/cors_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestCORS_APIKeyInQueryParamSetsOrigin — clients that fetch() from a PWA
+// cannot set custom headers (X-Api-Key) without triggering a preflight the
+// browser refuses to send the key on. They must pass the key as ?apikey=.
+// Regression test: the CORS middleware must recognize the query-param form
+// and emit Access-Control-Allow-Origin, otherwise the browser drops the
+// response and the library appears empty.
+func TestCORS_APIKeyInQueryParamSetsOrigin(t *testing.T) {
+	s := &Server{}
+	handler := s.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+
+	req := httptest.NewRequest("GET", "/api/library?apikey=test-key", nil)
+	req.Header.Set("Origin", "http://mobile.pwa.example")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://mobile.pwa.example" {
+		t.Errorf("expected Allow-Origin to reflect request origin for apikey query param, got %q", got)
+	}
+}
+
+// TestCORS_APIKeyInHeaderStillWorks — don't regress the header path.
+func TestCORS_APIKeyInHeaderStillWorks(t *testing.T) {
+	s := &Server{}
+	handler := s.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := httptest.NewRequest("GET", "/api/library", nil)
+	req.Header.Set("Origin", "http://client.example")
+	req.Header.Set("X-Api-Key", "k")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://client.example" {
+		t.Errorf("expected Allow-Origin for X-Api-Key header, got %q", got)
+	}
+}
+
+// TestCORS_NoCredsNoOrigin — cross-origin unauthenticated requests must NOT
+// receive an Allow-Origin (would break the same-origin+credentials protection).
+func TestCORS_NoCredsNoOrigin(t *testing.T) {
+	s := &Server{}
+	handler := s.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := httptest.NewRequest("GET", "/api/library", nil)
+	req.Header.Set("Origin", "http://attacker.example")
+	req.Host = "librarr.local"
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected no Allow-Origin for unauthenticated cross-origin, got %q", got)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -452,7 +452,11 @@ func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 				w.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
 			// For API-key-only requests (no cookies), allow any origin.
-			if r.Header.Get("X-Api-Key") != "" {
+			// Accept the key via X-Api-Key header OR ?apikey= query param —
+			// clients like the Homelab PWA use the query-param form because
+			// they fetch() without custom headers (which would force a CORS
+			// preflight the browser never sends the key on).
+			if r.Header.Get("X-Api-Key") != "" || r.URL.Query().Get("apikey") != "" {
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 			}
 		}


### PR DESCRIPTION
## Symptom
On the mobile PWA's Books tab, the Library view shows "Library empty" for ebooks, audiobooks, and manga — even though the library has thousands of items. Server-side the library endpoints return data correctly.

## Root cause
The CORS middleware (added in the April 3 security audit) only sets `Access-Control-Allow-Origin` when one of:
1. The request origin is same-origin with Host, or
2. An `X-Api-Key` **header** is present

The mobile PWA uses `fetch()` with `?apikey=` as a **query param** because setting `X-Api-Key` as a custom header forces a CORS preflight, and browsers never send arbitrary query params or auth on preflights. Query-param auth = no custom headers = no preflight needed.

Result: the browser receives the JSON body but drops it because `Allow-Origin` is missing. `apiFetch` catches the network error and returns `null`, rendering "Library empty".

## Fix
CORS middleware now also treats `?apikey=` as credentials-present and emits the origin header.

## Tests
3 regression tests in `internal/api/cors_test.go`:
- apikey query param → Allow-Origin emitted
- X-Api-Key header (existing path) → still works
- no credentials + cross-origin → no Allow-Origin (security-preserving)

## Verification
Confirmed pre-fix: `curl -I -H "Origin: http://..." http://librarr/api/library?apikey=...` returns **no** `Access-Control-Allow-Origin`. Post-fix (local tests): header is emitted.