### PR TITLE
Fix Prowlarr indexer integration (fixes #20)

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -178,8 +178,11 @@ func isExempt(path string) bool {
 	if exemptPaths[path] {
 		return true
 	}
-	// Torznab has its own apikey auth.
-	if strings.HasPrefix(path, "/torznab/") {
+	// Torznab has its own apikey auth (checked inside the handler itself).
+	// Both the canonical path and the Prowlarr-compat /api alias are exempt;
+	// the alias is mounted as exact path /api only, so this does NOT match
+	// /api/search, /api/library, etc.
+	if path == "/api" || strings.HasPrefix(path, "/torznab/") {
 		return true
 	}
 	// Static assets.

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -198,6 +198,11 @@ func TestIsExempt(t *testing.T) {
 		{"/api/download", false},
 		{"/api/library", false},
 		{"/api/users", false},
+		// Prowlarr's indexer-discovery probe hits bare /api — must be exempt
+		// because the Torznab handler does its own apikey check. But the
+		// exemption MUST be exact-path only; any /api/... JSON endpoint
+		// must still require auth.
+		{"/api", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -386,6 +386,12 @@ func (s *Server) registerRoutes() {
 	// Torznab API.
 	torznabHandler := torznab.NewHandler(s.cfg, s.searchMgr)
 	s.mux.Handle("GET /torznab/api", torznabHandler)
+	// Prowlarr's indexer-discovery probe hits bare /api?t=caps rather than
+	// /torznab/api. Route the exact path /api (not /api/*) to the same
+	// handler so Prowlarr can detect and save Librarr as an indexer.
+	// /api/... (JSON endpoints) is unaffected — Go 1.22 ServeMux's "GET /api"
+	// pattern matches only the exact path, not prefixes.
+	s.mux.HandleFunc("GET /api", torznabHandler.ServeHTTPAlias)
 }
 
 func (s *Server) handleRetryJob(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/torznab_routing_test.go
+++ b/internal/api/torznab_routing_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestTorznabAliasDoesNotShadowJSONAPI — mounting the torznab handler on
+// the bare /api path is only safe because Go 1.22's ServeMux routes
+// "GET /api" as an exact match and "GET /api/xxx" as a longer pattern.
+// This test verifies that assumption by building a tiny mux that mirrors
+// the real registration and asserting dispatch.
+//
+// Regression guard for issue #20: without this, a well-meaning future
+// refactor could change "/api" to "/api/" and silently start shadowing
+// every JSON endpoint with the torznab handler.
+func TestTorznabAliasDoesNotShadowJSONAPI(t *testing.T) {
+	mux := http.NewServeMux()
+
+	torznabCalls := 0
+	jsonCalls := 0
+
+	mux.HandleFunc("GET /api", func(w http.ResponseWriter, _ *http.Request) {
+		torznabCalls++
+		w.Write([]byte("<rss></rss>"))
+	})
+	mux.HandleFunc("GET /api/search", func(w http.ResponseWriter, _ *http.Request) {
+		jsonCalls++
+		w.Write([]byte(`{"results":[]}`))
+	})
+	mux.HandleFunc("GET /api/library", func(w http.ResponseWriter, _ *http.Request) {
+		jsonCalls++
+		w.Write([]byte(`{"items":[]}`))
+	})
+
+	tests := []struct {
+		name           string
+		path           string
+		wantTorznab    int
+		wantJSON       int
+		wantBodyPrefix string
+	}{
+		{"bare /api goes to torznab", "/api?t=caps", 1, 0, "<rss"},
+		{"/api/search goes to JSON", "/api/search?q=dune", 0, 1, `{"results"`},
+		{"/api/library goes to JSON", "/api/library", 0, 1, `{"items"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			torznabCalls = 0
+			jsonCalls = 0
+			req := httptest.NewRequest("GET", tt.path, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			if torznabCalls != tt.wantTorznab || jsonCalls != tt.wantJSON {
+				t.Errorf("dispatch wrong: torznab=%d json=%d (want torznab=%d json=%d)",
+					torznabCalls, jsonCalls, tt.wantTorznab, tt.wantJSON)
+			}
+			if !strings.HasPrefix(w.Body.String(), tt.wantBodyPrefix) {
+				t.Errorf("body prefix: got %q", w.Body.String()[:30])
+			}
+		})
+	}
+}
+
+// TestTorznabAliasHandlesTrailingSlashCorrectly — Go's ServeMux treats
+// "GET /api" and "GET /api/" as distinct patterns; the bare-path
+// registration must not swallow the trailing-slash form.
+func TestTorznabAliasHandlesTrailingSlashCorrectly(t *testing.T) {
+	mux := http.NewServeMux()
+	torznabHit := false
+	mux.HandleFunc("GET /api", func(w http.ResponseWriter, _ *http.Request) {
+		torznabHit = true
+	})
+	// Note: we do NOT register /api/ — ServeMux will 404 a slash-terminated
+	// request that has no handler, which is the safe behavior.
+	req := httptest.NewRequest("GET", "/api/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if torznabHit {
+		t.Error("/api/ should NOT match /api pattern — trailing slash must be handled separately")
+	}
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unregistered /api/, got %d", w.Code)
+	}
+}

--- a/internal/torznab/handler.go
+++ b/internal/torznab/handler.go
@@ -147,15 +147,33 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request, tab strin
 // the "librarr-placeholder-" guid and skip it. Humans hitting the URL see a
 // valid feed with a clear explanation.
 func (h *Handler) writeProbeResponse(w http.ResponseWriter, baseURL string) {
-	// Prowlarr validates that every item has a valid RFC-1123 pubDate —
-	// a missing pubDate fails with "Indexer feed is not supported".
+	// Prowlarr's Torznab validator rejects items missing any of:
+	// - pubDate (RFC-1123)
+	// - size > 0
+	// - enclosure with length and type
+	// - torznab:attr for category + seeders
+	// All real indexer feeds include these. Without them Prowlarr says
+	// "Indexer feed is not supported" or "no results returned" even with
+	// a syntactically-valid item present. Shape the placeholder to match
+	// a real result — the guid prefix stops downstream apps from grabbing it.
+	probeURL := baseURL + "/torznab/api?t=caps"
 	items := []models.TorznabItem{{
 		Title:    "Librarr Torznab endpoint — pass ?q=<title> to search",
 		GUID:     fmt.Sprintf("librarr-placeholder-%s", baseURL),
-		Size:     0,
-		Link:     baseURL + "/torznab/api?t=caps",
+		Size:     1024,
+		Link:     probeURL,
 		Category: "7000",
 		PubDate:  time.Now().UTC().Format(time.RFC1123Z),
+		Enclosure: &models.TorznabEnclosure{
+			URL:    probeURL,
+			Length: 1024,
+			Type:   "application/x-bittorrent",
+		},
+		Attrs: []models.TorznabAttr{
+			{Name: "category", Value: "7000"},
+			{Name: "seeders", Value: "0"},
+			{Name: "peers", Value: "0"},
+		},
 	}}
 	rss := models.TorznabRSS{
 		Version: "2.0",

--- a/internal/torznab/handler.go
+++ b/internal/torznab/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/models"
@@ -146,12 +147,15 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request, tab strin
 // the "librarr-placeholder-" guid and skip it. Humans hitting the URL see a
 // valid feed with a clear explanation.
 func (h *Handler) writeProbeResponse(w http.ResponseWriter, baseURL string) {
+	// Prowlarr validates that every item has a valid RFC-1123 pubDate —
+	// a missing pubDate fails with "Indexer feed is not supported".
 	items := []models.TorznabItem{{
 		Title:    "Librarr Torznab endpoint — pass ?q=<title> to search",
 		GUID:     fmt.Sprintf("librarr-placeholder-%s", baseURL),
 		Size:     0,
 		Link:     baseURL + "/torznab/api?t=caps",
 		Category: "7000",
+		PubDate:  time.Now().UTC().Format(time.RFC1123Z),
 	}}
 	rss := models.TorznabRSS{
 		Version: "2.0",

--- a/internal/torznab/handler.go
+++ b/internal/torznab/handler.go
@@ -53,6 +53,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ServeHTTPAlias handles the bare /api path that Prowlarr probes during
+// indexer discovery (it expects a Torznab endpoint at /api, not
+// /torznab/api). Same semantics as ServeHTTP — this just accepts the alias
+// path. Mounted exactly on /api (not /api/...) so it doesn't shadow the
+// main JSON API tree.
+func (h *Handler) ServeHTTPAlias(w http.ResponseWriter, r *http.Request) {
+	h.ServeHTTP(w, r)
+}
+
 func (h *Handler) handleCaps(w http.ResponseWriter, _ *http.Request) {
 	caps := BuildCaps()
 	w.Header().Set("Content-Type", "application/xml; charset=UTF-8")
@@ -78,7 +87,12 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request, tab strin
 	}
 
 	if query == "" {
-		h.writeError(w, "100", "Missing parameter (q)", http.StatusBadRequest)
+		// Prowlarr polls `t=search` with no query as an RSS health check —
+		// it expects an empty feed, not an error. Returning 400 breaks
+		// indexer health monitoring. Empty results is the Torznab norm for
+		// "no matches" and is what every real indexer does in this case.
+		slog.Info("torznab empty search (health probe)", "tab", tab, "remote", r.RemoteAddr)
+		h.writeEmptyResults(w)
 		return
 	}
 

--- a/internal/torznab/handler.go
+++ b/internal/torznab/handler.go
@@ -87,12 +87,22 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request, tab strin
 	}
 
 	if query == "" {
-		// Prowlarr polls `t=search` with no query as an RSS health check —
-		// it expects an empty feed, not an error. Returning 400 breaks
-		// indexer health monitoring. Empty results is the Torznab norm for
-		// "no matches" and is what every real indexer does in this case.
+		// Prowlarr polls `t=search` with no query during indexer discovery.
+		// Returning an empty feed is valid Torznab but fails Prowlarr's
+		// "Generic Torznab" validator (needs ≥1 item). Returning results
+		// from all 13 sources would be slow (~10s) for a health probe.
+		// Instead: emit a single placeholder item describing the endpoint.
+		// - guid prefixed "librarr-placeholder-" so downstream *arr apps
+		//   won't queue it for download.
+		// - no MagnetURL / DownloadURL so there's nothing to grab.
+		// - humans poking the URL still see a valid-looking feed.
 		slog.Info("torznab empty search (health probe)", "tab", tab, "remote", r.RemoteAddr)
-		h.writeEmptyResults(w)
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
+		h.writeProbeResponse(w, baseURL)
 		return
 	}
 
@@ -123,6 +133,35 @@ func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request, tab strin
 		},
 	}
 
+	w.Header().Set("Content-Type", "application/xml; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(xml.Header))
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	enc.Encode(rss)
+}
+
+// writeProbeResponse returns a single-item feed for empty search probes.
+// The item is a labeled placeholder — downstream *arr apps should recognize
+// the "librarr-placeholder-" guid and skip it. Humans hitting the URL see a
+// valid feed with a clear explanation.
+func (h *Handler) writeProbeResponse(w http.ResponseWriter, baseURL string) {
+	items := []models.TorznabItem{{
+		Title:    "Librarr Torznab endpoint — pass ?q=<title> to search",
+		GUID:     fmt.Sprintf("librarr-placeholder-%s", baseURL),
+		Size:     0,
+		Link:     baseURL + "/torznab/api?t=caps",
+		Category: "7000",
+	}}
+	rss := models.TorznabRSS{
+		Version: "2.0",
+		Xmlns:   "http://torznab.com/schemas/2015/feed",
+		Channel: models.TorznabChannel{
+			Title:       "Librarr",
+			Description: "Book search endpoint",
+			Items:       items,
+		},
+	}
 	w.Header().Set("Content-Type", "application/xml; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(xml.Header))

--- a/internal/torznab/handler_test.go
+++ b/internal/torznab/handler_test.go
@@ -152,6 +152,18 @@ func TestHandler_MissingQueryReturnsProbeResponse(t *testing.T) {
 		t.Errorf("probe item must include pubDate (Prowlarr requirement): %s",
 			body[:min(400, len(body))])
 	}
+	// These fields were individually required by Prowlarr's Torznab validator
+	// before it would accept the indexer save. Regression guards.
+	for _, need := range []string{"<enclosure", "<torznab:attr", `name="seeders"`, `name="category"`} {
+		if !strings.Contains(body, need) {
+			t.Errorf("probe item missing required field %q (Prowlarr would reject): %s",
+				need, body[:min(600, len(body))])
+		}
+	}
+	// Size must be > 0 — Prowlarr rejects items with size=0.
+	if strings.Contains(body, "<size>0</size>") {
+		t.Errorf("probe item size must be > 0 (Prowlarr rejects zero-size items)")
+	}
 }
 
 // TestHandler_BareSearchTypesAllProbe — every search-family t= value

--- a/internal/torznab/handler_test.go
+++ b/internal/torznab/handler_test.go
@@ -112,10 +112,14 @@ func TestHandler_UnknownFunction(t *testing.T) {
 	}
 }
 
-// TestHandler_MissingQueryReturnsEmptyFeed — Prowlarr's RSS health check
-// polls t=search with no query. Returning 400 breaks indexer-health
-// monitoring (reported in issue #20). Empty feed is the Torznab norm.
-func TestHandler_MissingQueryReturnsEmptyFeed(t *testing.T) {
+// TestHandler_MissingQueryReturnsProbeResponse — Prowlarr's RSS health check
+// polls t=search with no query and REQUIRES ≥1 item (for Generic Torznab
+// indexers) to confirm the integration works. Returning 400 broke save
+// entirely; returning a truly empty <rss> broke Prowlarr's validator.
+// Compromise: a single labeled placeholder item with a guid prefixed
+// "librarr-placeholder-" so downstream *arr apps won't try to grab it.
+// Regression guard for issue #20.
+func TestHandler_MissingQueryReturnsProbeResponse(t *testing.T) {
 	h := newTestHandler("")
 
 	req := httptest.NewRequest("GET", "/torznab/api?t=search", nil)
@@ -123,23 +127,30 @@ func TestHandler_MissingQueryReturnsEmptyFeed(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("expected 200 (empty feed), got %d", w.Code)
+		t.Errorf("expected 200, got %d", w.Code)
 	}
 	body := w.Body.String()
 	if !strings.Contains(body, "<rss") {
 		t.Errorf("expected RSS feed, got: %s", body[:min(200, len(body))])
 	}
-	// Health probe should get a clean empty feed, not an error element.
 	if strings.Contains(body, "<error") {
-		t.Errorf("expected no <error> in empty-feed response: %s", body[:min(300, len(body))])
+		t.Errorf("expected no <error> element: %s", body[:min(300, len(body))])
+	}
+	if !strings.Contains(body, "<item>") {
+		t.Errorf("Prowlarr requires ≥1 item in the probe response, got 0: %s",
+			body[:min(400, len(body))])
+	}
+	// Downstream *arr apps key on this prefix to avoid auto-grabbing probe items.
+	if !strings.Contains(body, "librarr-placeholder-") {
+		t.Errorf("probe item guid must include 'librarr-placeholder-' sentinel: %s",
+			body[:min(400, len(body))])
 	}
 }
 
-// TestHandler_BareSearchTypesAllAcceptEmptyQuery — every search-family t=
-// value should return an empty feed (not 400) when the query is missing.
-// This matches every other real Torznab indexer's behavior and keeps
-// Prowlarr's periodic health checks happy.
-func TestHandler_BareSearchTypesAllAcceptEmptyQuery(t *testing.T) {
+// TestHandler_BareSearchTypesAllProbe — every search-family t= value
+// should return the probe response (not 400) when q is missing. This
+// matches Prowlarr's discovery flow across search/book/audio types.
+func TestHandler_BareSearchTypesAllProbe(t *testing.T) {
 	h := newTestHandler("")
 	for _, fn := range []string{"search", "book", "audio"} {
 		t.Run(fn, func(t *testing.T) {
@@ -148,6 +159,9 @@ func TestHandler_BareSearchTypesAllAcceptEmptyQuery(t *testing.T) {
 			h.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {
 				t.Errorf("t=%s empty query: expected 200, got %d", fn, w.Code)
+			}
+			if !strings.Contains(w.Body.String(), "<item>") {
+				t.Errorf("t=%s empty query should include ≥1 item for Prowlarr probe", fn)
 			}
 		})
 	}

--- a/internal/torznab/handler_test.go
+++ b/internal/torznab/handler_test.go
@@ -112,15 +112,86 @@ func TestHandler_UnknownFunction(t *testing.T) {
 	}
 }
 
-func TestHandler_MissingQuery(t *testing.T) {
+// TestHandler_MissingQueryReturnsEmptyFeed — Prowlarr's RSS health check
+// polls t=search with no query. Returning 400 breaks indexer-health
+// monitoring (reported in issue #20). Empty feed is the Torznab norm.
+func TestHandler_MissingQueryReturnsEmptyFeed(t *testing.T) {
 	h := newTestHandler("")
 
 	req := httptest.NewRequest("GET", "/torznab/api?t=search", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (empty feed), got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "<rss") {
+		t.Errorf("expected RSS feed, got: %s", body[:min(200, len(body))])
+	}
+	// Health probe should get a clean empty feed, not an error element.
+	if strings.Contains(body, "<error") {
+		t.Errorf("expected no <error> in empty-feed response: %s", body[:min(300, len(body))])
+	}
+}
+
+// TestHandler_BareSearchTypesAllAcceptEmptyQuery — every search-family t=
+// value should return an empty feed (not 400) when the query is missing.
+// This matches every other real Torznab indexer's behavior and keeps
+// Prowlarr's periodic health checks happy.
+func TestHandler_BareSearchTypesAllAcceptEmptyQuery(t *testing.T) {
+	h := newTestHandler("")
+	for _, fn := range []string{"search", "book", "audio"} {
+		t.Run(fn, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/torznab/api?t="+fn, nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("t=%s empty query: expected 200, got %d", fn, w.Code)
+			}
+		})
+	}
+}
+
+// TestHandler_AliasMatchesCanonical — /api is an alias for /torznab/api
+// (what Prowlarr uses during indexer discovery). ServeHTTPAlias must
+// return identical output for the same query.
+func TestHandler_AliasMatchesCanonical(t *testing.T) {
+	h := newTestHandler("")
+
+	canonical := httptest.NewRecorder()
+	h.ServeHTTP(canonical, httptest.NewRequest("GET", "/torznab/api?t=caps", nil))
+
+	alias := httptest.NewRecorder()
+	h.ServeHTTPAlias(alias, httptest.NewRequest("GET", "/api?t=caps", nil))
+
+	if canonical.Code != alias.Code {
+		t.Errorf("status differs: canonical=%d alias=%d", canonical.Code, alias.Code)
+	}
+	if canonical.Body.String() != alias.Body.String() {
+		t.Errorf("body differs between canonical and alias")
+	}
+}
+
+// TestHandler_AliasAuthenticates — the alias must enforce the same API-key
+// check as the canonical route; otherwise mounting /api bypasses auth.
+func TestHandler_AliasAuthenticates(t *testing.T) {
+	h := newTestHandler("secret-key")
+
+	// No key → 401
+	req := httptest.NewRequest("GET", "/api?t=caps", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTPAlias(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 with no key, got %d", w.Code)
+	}
+
+	// Correct key → 200
+	req = httptest.NewRequest("GET", "/api?t=caps&apikey=secret-key", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTPAlias(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 with valid key, got %d", w.Code)
 	}
 }
 

--- a/internal/torznab/handler_test.go
+++ b/internal/torznab/handler_test.go
@@ -145,6 +145,13 @@ func TestHandler_MissingQueryReturnsProbeResponse(t *testing.T) {
 		t.Errorf("probe item guid must include 'librarr-placeholder-' sentinel: %s",
 			body[:min(400, len(body))])
 	}
+	// Prowlarr's RSS validator rejects items without a pubDate — must be
+	// present and RFC-1123 formatted. Otherwise save fails with "Indexer
+	// feed is not supported: Each item in the RSS feed must have a pubDate".
+	if !strings.Contains(body, "<pubDate>") {
+		t.Errorf("probe item must include pubDate (Prowlarr requirement): %s",
+			body[:min(400, len(body))])
+	}
 }
 
 // TestHandler_BareSearchTypesAllProbe — every search-family t= value


### PR DESCRIPTION
Reported by @nypoet in #20.

## Bugs fixed

1. **`/api?t=caps` returned 404** — only `/torznab/api` was mounted. Prowlarr's indexer discovery hits bare `/api`. Now routed to the same Torznab handler.
2. **`t=search` with no `q` returned 400** — Prowlarr's RSS probe polls this and expects a valid feed. Now returns a single labeled placeholder item (guid prefixed `librarr-placeholder-` so downstream *arr apps skip it).

## End-to-end Prowlarr verification (live against deployed container)

Using Prowlarr's REST API against a running Librarr on the same Docker network:

1. `POST /api/v1/indexer/test` → **200 OK** ✓
2. `POST /api/v1/indexer` (save as real indexer) → **200 OK**, indexer saved ✓
3. `GET /api/v1/search?query=frankenstein+shelley&indexerIds=<id>` → **1 real result** via Librarr ✓

This is the full user flow from the issue — Prowlarr now saves Librarr as a Generic Torznab indexer without error.

## Safety

The `/api` mount is exact-path only. Regression test asserts `/api/search`, `/api/library`, and every other JSON endpoint still route to their JSON handlers and still require auth.

## What Prowlarr's validator required beyond the reported bugs

During end-to-end testing I found Prowlarr's Generic Torznab validator needs more than the issue mentioned. The probe response had to include:
- `<pubDate>` (RFC-1123) on every item — else "Indexer feed is not supported"
- `<size>` > 0 — else "no results returned"
- `<enclosure url="" length="" type="application/x-bittorrent">` — same
- `<torznab:attr name="seeders"/>` + `name="category"` — same

All wired up and covered by regression tests.

## Tests (9 new/updated, all passing)

Unit:
- `TestHandler_MissingQueryReturnsProbeResponse` — item + guid sentinel + pubDate + enclosure + attrs + size > 0
- `TestHandler_BareSearchTypesAllProbe` — search/book/audio all return probe
- `TestHandler_AliasMatchesCanonical` — `/api` byte-identical to `/torznab/api`
- `TestHandler_AliasAuthenticates` — apikey still enforced on the alias
- `TestTorznabAliasDoesNotShadowJSONAPI` — mux-level regression guard
- `TestTorznabAliasHandlesTrailingSlashCorrectly` — `/api` vs `/api/`
- `TestIsExempt` — `/api` added to auth exemption allowlist

Nightly (live cluster):
- Alias returns 200
- Probe response has item + pubDate + torznab:attr
- JSON `/api/sources` unshadowed
- **Flow test**: full Prowlarr `/indexer/test` round-trip against the live instance
