### PR TITLE
Add settings toggle for torrent removal after import (fixes #22)

### DIFF
--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -44,6 +44,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
 		"flibusta_enabled":    s.cfg.FlibustaEnabled,
 		"flibusta_url":        s.cfg.FlibustaURL,
 		"zlibrary_enabled":    s.cfg.ZLibraryEnabled,
+		"remove_torrent_after_import": s.cfg.RemoveTorrentAfterImport,
 	}
 
 	// Merge defaults under settings (settings override).
@@ -120,6 +121,12 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		if b, ok := v.(bool); ok {
 			s.searchMgr.SetForeignLangFilter(b)
 			slog.Info("foreign language filter updated", "enabled", b)
+		}
+	}
+	if v, ok := data["remove_torrent_after_import"]; ok {
+		if b, ok := v.(bool); ok {
+			s.cfg.RemoveTorrentAfterImport = b
+			slog.Info("remove torrent after import updated", "enabled", b)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,9 @@ type Config struct {
 	QBPriority  int
 	SABPriority int
 
+	// Post-import torrent handling
+	RemoveTorrentAfterImport bool
+
 	// Flibusta
 	FlibustaURL     string
 	FlibustaEnabled bool
@@ -241,6 +244,8 @@ func Load() *Config {
 
 		QBPriority:  getEnvInt("QB_PRIORITY", 1),
 		SABPriority: getEnvInt("SAB_PRIORITY", 2),
+
+		RemoveTorrentAfterImport: getEnvBool("REMOVE_TORRENT_AFTER_IMPORT", true),
 
 		RateLimitEnabled: getEnvBool("RATE_LIMIT_ENABLED", true),
 		MetricsEnabled:   getEnvBool("METRICS_ENABLED", true),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -286,3 +286,20 @@ func TestHas_Methods(t *testing.T) {
 		}
 	})
 }
+
+func TestRemoveTorrentAfterImportDefault(t *testing.T) {
+	os.Unsetenv("REMOVE_TORRENT_AFTER_IMPORT")
+	cfg := Load()
+	if !cfg.RemoveTorrentAfterImport {
+		t.Error("RemoveTorrentAfterImport should default to true (remove after import)")
+	}
+}
+
+func TestRemoveTorrentAfterImportDisabled(t *testing.T) {
+	os.Setenv("REMOVE_TORRENT_AFTER_IMPORT", "false")
+	defer os.Unsetenv("REMOVE_TORRENT_AFTER_IMPORT")
+	cfg := Load()
+	if cfg.RemoveTorrentAfterImport {
+		t.Error("RemoveTorrentAfterImport should be false when explicitly disabled")
+	}
+}

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -123,11 +123,16 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 		return
 	}
 
-	// Remove torrent from qBit (keep files).
-	if err := w.qb.DeleteTorrent(t.Hash, false); err != nil {
-		slog.Warn("failed to remove torrent after import", "hash", t.Hash, "error", err)
+	// Optionally remove torrent from qBit after import. Default is to leave
+	// it seeding — users who want auto-removal set REMOVE_TORRENT_AFTER_IMPORT=true.
+	if w.cfg.RemoveTorrentAfterImport {
+		if err := w.qb.DeleteTorrent(t.Hash, false); err != nil {
+			slog.Warn("failed to remove torrent after import", "hash", t.Hash, "error", err)
+		} else {
+			slog.Info("removed completed torrent", "name", t.Name)
+		}
 	} else {
-		slog.Info("removed completed torrent", "name", t.Name)
+		slog.Info("torrent left seeding after import", "name", t.Name, "hash", t.Hash)
 	}
 
 	// Mark as imported.

--- a/web/index.html
+++ b/web/index.html
@@ -522,6 +522,21 @@ tailwind.config = {
         </div>
       </div>
 
+      <!-- Download Behavior -->
+      <div class="bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6">
+        <h3 class="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">Download Behavior</h3>
+        <div class="flex items-center justify-between py-2">
+          <div>
+            <p class="text-sm text-slate-300">Remove torrents after import</p>
+            <p class="text-xs text-slate-500 mt-1">When enabled, torrents are removed from qBittorrent after files are imported. Disable to keep seeding.</p>
+          </div>
+          <label class="relative inline-flex items-center cursor-pointer ml-4 shrink-0">
+            <input type="checkbox" id="remove-torrent-toggle" class="sr-only peer" checked onchange="toggleRemoveTorrent()">
+            <div class="w-11 h-6 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-indigo-600"></div>
+          </label>
+        </div>
+      </div>
+
       <!-- Sources -->
       <div class="bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6">
         <h3 class="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4" data-i18n="s_search_sources">Search Sources</h3>
@@ -2041,9 +2056,24 @@ async function loadSettings() {
   loadConfig();
   loadSources();
   loadTOTPStatus();
+  loadSettingToggles();
   if (state.currentRole === 'admin') {
     loadUsers();
   }
+}
+
+async function loadSettingToggles() {
+  try {
+    const data = await apiJson('/api/settings');
+    const removeTorrent = document.getElementById('remove-torrent-toggle');
+    if (removeTorrent && data.remove_torrent_after_import !== undefined) {
+      removeTorrent.checked = data.remove_torrent_after_import;
+    }
+    const langFilter = document.getElementById('foreign-lang-filter-toggle');
+    if (langFilter && data.foreign_lang_filter !== undefined) {
+      langFilter.checked = data.foreign_lang_filter;
+    }
+  } catch (err) {}
 }
 
 async function loadConfig() {
@@ -2133,6 +2163,30 @@ async function toggleForeignLangFilter() {
     toggle.checked = !enabled;
     if (err.message !== 'Unauthorized') {
       showToast(t('filter_save_failed'), 'error');
+    }
+  }
+}
+
+async function toggleRemoveTorrent() {
+  const toggle = document.getElementById('remove-torrent-toggle');
+  if (!toggle) return;
+  const enabled = toggle.checked;
+  try {
+    const res = await apiJson('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ remove_torrent_after_import: enabled })
+    });
+    if (res.success) {
+      showToast(enabled ? 'Torrents will be removed after import' : 'Torrents will keep seeding after import', 'success');
+    } else {
+      toggle.checked = !enabled;
+      showToast('Failed to update setting', 'error');
+    }
+  } catch (err) {
+    toggle.checked = !enabled;
+    if (err.message !== 'Unauthorized') {
+      showToast('Failed to save setting', 'error');
     }
   }
 }


### PR DESCRIPTION
Torrents are removed from qBittorrent after import by default. Added a toggle in Settings to keep seeding instead.