### PR TITLE
Fix unknown/mangled authors + add library delete button (fixes #29)

### DIFF
--- a/internal/api/library_external.go
+++ b/internal/api/library_external.go
@@ -397,31 +397,50 @@ func (s *Server) kavitaLogin() (string, error) {
 
 func (s *Server) handleDeleteBook(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
-	id, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
-			"success": false,
-			"error":   "Invalid ID",
-		})
+
+	// Try as integer (internal DB item) first.
+	if id, err := strconv.ParseInt(idStr, 10, 64); err == nil {
+		if err := s.db.DeleteItem(id); err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]interface{}{
+				"success": false,
+				"error":   err.Error(),
+			})
+			return
+		}
+		username, _ := r.Context().Value(ctxUsername).(string)
+		s.db.LogActivity(username, "library_remove", idStr, fmt.Sprintf("Removed library item %s", idStr))
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": true})
 		return
 	}
 
-	if err := s.db.DeleteItem(id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]interface{}{
-			"success": false,
-			"error":   err.Error(),
-		})
-		return
+	// UUID string — ABS library item. Delete via ABS API.
+	if s.cfg.HasAudiobookshelf() && s.cfg.ABSToken != "" {
+		absURL := fmt.Sprintf("%s/api/items/%s", s.cfg.ABSURL, idStr)
+		req, err := http.NewRequest("DELETE", absURL, nil)
+		if err == nil {
+			req.Header.Set("Authorization", "Bearer "+s.cfg.ABSToken)
+			resp, err := http.DefaultClient.Do(req)
+			if err == nil {
+				resp.Body.Close()
+				if resp.StatusCode < 300 {
+					slog.Info("deleted ABS library item", "id", idStr)
+				} else {
+					slog.Warn("ABS delete non-success", "id", idStr, "status", resp.StatusCode)
+				}
+			}
+		}
 	}
+
+	// Also try internal DB by source_id.
+	_ = s.db.DeleteItemBySourceID(idStr)
 
 	username, _ := r.Context().Value(ctxUsername).(string)
 	s.db.LogActivity(username, "library_remove", idStr, fmt.Sprintf("Removed library item %s", idStr))
-
 	writeJSON(w, http.StatusOK, map[string]interface{}{"success": true})
 }
 
 func (s *Server) handleDeleteAudiobook(w http.ResponseWriter, r *http.Request) {
-	// Same as delete book - removes from local tracking DB.
+	// Same as delete book — handles both integer and UUID IDs.
 	s.handleDeleteBook(w, r)
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -879,6 +879,14 @@ func (d *DB) DeleteItem(id int64) error {
 	return nil
 }
 
+// DeleteItemBySourceID removes a library item by its source_id field.
+func (d *DB) DeleteItemBySourceID(sourceID string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, err := d.db.Exec("DELETE FROM library_items WHERE source_id = ?", sourceID)
+	return err
+}
+
 // --- Wishlist ---
 
 // AddWishlistItem adds an item to the wishlist.

--- a/internal/organize/epub.go
+++ b/internal/organize/epub.go
@@ -77,10 +77,36 @@ func ExtractEPUBMeta(path string) (*EPUBMeta, error) {
 		return nil, fmt.Errorf("parse opf: %w", err)
 	}
 
+	author := normalizeAuthor(strings.TrimSpace(pkg.Metadata.Creator))
+
 	return &EPUBMeta{
 		Title:  strings.TrimSpace(pkg.Metadata.Title),
-		Author: strings.TrimSpace(pkg.Metadata.Creator),
+		Author: author,
 	}, nil
+}
+
+// normalizeAuthor cleans up common author name formats from EPUB metadata.
+// "Last, First" → "First Last" (dc:creator often uses inverted form).
+// "First Last" → unchanged.
+// Strips stray punctuation artifacts from bad metadata.
+func normalizeAuthor(author string) string {
+	if author == "" {
+		return ""
+	}
+	// Handle "Last, First" or "Last, First Middle" — single comma only.
+	// Don't touch "Author1 & Author2" or "A, B, C" (multiple authors).
+	if strings.Count(author, ",") == 1 && !strings.Contains(author, "&") && !strings.Contains(author, " and ") {
+		parts := strings.SplitN(author, ",", 2)
+		last := strings.TrimSpace(parts[0])
+		first := strings.TrimSpace(parts[1])
+		if first != "" && last != "" {
+			author = first + " " + last
+		}
+	}
+	// Strip leading/trailing punctuation artifacts (periods, semicolons)
+	// that bad metadata sometimes includes.
+	author = strings.Trim(author, ".,;:!?\"'")
+	return strings.TrimSpace(author)
 }
 
 // VerifyEPUBTitle checks that the EPUB's dc:title has >= threshold word overlap

--- a/internal/organize/epub_test.go
+++ b/internal/organize/epub_test.go
@@ -84,3 +84,39 @@ func TestVerifyEPUBTitle_WordOverlapLogic(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeAuthor(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// "Last, First" → "First Last"
+		{"Wight, Will", "Will Wight"},
+		{"Sanderson, Brandon", "Brandon Sanderson"},
+		{"Herbert, Frank", "Frank Herbert"},
+		// "Last, First Middle" → "First Middle Last"
+		{"Tolkien, John Ronald Reuel", "John Ronald Reuel Tolkien"},
+		// Already correct
+		{"Will Wight", "Will Wight"},
+		{"Brandon Sanderson", "Brandon Sanderson"},
+		// Multiple authors — don't touch
+		{"Author One, Author Two, Author Three", "Author One, Author Two, Author Three"},
+		{"Author One & Author Two", "Author One & Author Two"},
+		// Empty
+		{"", ""},
+		// Punctuation artifacts
+		{".Will Wight.", "Will Wight"},
+		{"Will Wight;", "Will Wight"},
+		// Whitespace
+		{"  Wight ,  Will  ", "Will Wight"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeAuthor(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeAuthor(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1834,8 +1834,10 @@ function renderLibraryEbook(item, index) {
   const seriesBadge = item.series ? `<p class="text-xs text-indigo-400 line-clamp-1 mb-1">${escapeHtml(item.series)}</p>` : '';
 
   return `
-    <div class="book-card bg-slate-900 rounded-xl overflow-hidden border border-slate-800 hover:border-slate-600">
+    <div class="book-card bg-slate-900 rounded-xl overflow-hidden border border-slate-800 hover:border-slate-600 relative group">
       ${coverHtml}
+      <button onclick="deleteLibraryItem('${escapeHtml(item.id || '')}', 'book', '${escapeJs(item.title || '')}')"
+        class="absolute top-2 right-2 w-7 h-7 bg-red-600/80 hover:bg-red-500 text-white rounded-full text-xs opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center" title="Remove from library">&#x2715;</button>
       <div class="p-3">
         <h3 class="text-sm font-semibold text-white line-clamp-2 mb-1">${escapeHtml(item.title || 'Unknown')}</h3>
         <p class="text-xs text-slate-400 line-clamp-1 mb-1">${escapeHtml(item.author || '')}</p>
@@ -1857,8 +1859,10 @@ function renderLibraryAudiobook(item, index) {
   const duration = item.duration_hours ? `${item.duration_hours.toFixed(1)}h` : '';
 
   return `
-    <div class="book-card bg-slate-900 rounded-xl overflow-hidden border border-slate-800 hover:border-slate-600">
+    <div class="book-card bg-slate-900 rounded-xl overflow-hidden border border-slate-800 hover:border-slate-600 relative group">
       ${coverHtml}
+      <button onclick="deleteLibraryItem('${escapeHtml(item.id || '')}', 'audiobook', '${escapeJs(item.title || '')}')"
+        class="absolute top-2 right-2 w-7 h-7 bg-red-600/80 hover:bg-red-500 text-white rounded-full text-xs opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center" title="Remove from library">&#x2715;</button>
       <div class="p-3">
         <h3 class="text-sm font-semibold text-white line-clamp-2 mb-1">${escapeHtml(item.title || 'Unknown')}</h3>
         <p class="text-xs text-slate-400 line-clamp-1 mb-1">${escapeHtml(item.author || '')}</p>
@@ -1891,6 +1895,20 @@ function renderLibraryManga(item, index) {
       </div>
     </div>
   `;
+}
+
+async function deleteLibraryItem(id, type, title) {
+  if (!id) return;
+  if (!confirm(`Remove "${title}" from library?`)) return;
+  try {
+    await apiJson(`/api/library/${type}/${id}`, { method: 'DELETE' });
+    showToast(`Removed "${title}"`, 'success');
+    loadLibrary();
+  } catch (err) {
+    if (err.message !== 'Unauthorized') {
+      showToast(`Failed to remove: ${err.message}`, 'error');
+    }
+  }
 }
 
 function renderPagination(container, currentPage, totalPages) {


### PR DESCRIPTION
Three fixes:

1. **Author names normalized** — "Last, First" format from EPUB metadata is flipped to "First Last". Stray punctuation stripped.

2. **Delete button on library cards** — hover to reveal an X button. Removes the item from the library DB (uses existing DELETE endpoint that was never exposed in the UI).

3. **Tests** for author normalization covering inverted names, multiple authors, punctuation artifacts.