### PR TITLE
Add invite code registration

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -500,12 +500,15 @@ func handleLoginTOTP(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 }
 
 // handleRegister handles POST /api/register — create a new user.
-// First user becomes admin. After that, only admins can register new users.
+// First user becomes admin. After that, registration requires either:
+//   - An admin session (admin creating users directly), OR
+//   - A valid invite code (self-registration with a code the admin shared).
 func handleRegister(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
-			Username string `json:"username"`
-			Password string `json:"password"`
+			Username   string `json:"username"`
+			Password   string `json:"password"`
+			InviteCode string `json:"invite_code"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]interface{}{
@@ -533,21 +536,34 @@ func handleRegister(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 		userCount, _ := database.CountUsers()
 		isFirstUser := userCount == 0
 
-		// After first user, only admins can register.
-		if !isFirstUser {
-			role, _ := r.Context().Value(ctxUserRole).(string)
-			if role != "admin" {
-				writeJSON(w, http.StatusForbidden, map[string]interface{}{
-					"success": false,
-					"error":   "Only admins can create new users",
-				})
-				return
-			}
-		}
-
 		role := "user"
 		if isFirstUser {
 			role = "admin"
+		}
+
+		// After first user, require either admin session or valid invite code.
+		if !isFirstUser {
+			ctxRole, _ := r.Context().Value(ctxUserRole).(string)
+			isAdmin := ctxRole == "admin"
+
+			if req.InviteCode != "" {
+				// Validate invite code.
+				inviteRole, err := database.ValidateInviteCode(req.InviteCode)
+				if err != nil {
+					writeJSON(w, http.StatusForbidden, map[string]interface{}{
+						"success": false,
+						"error":   err.Error(),
+					})
+					return
+				}
+				role = inviteRole
+			} else if !isAdmin {
+				writeJSON(w, http.StatusForbidden, map[string]interface{}{
+					"success": false,
+					"error":   "Registration requires an invite code",
+				})
+				return
+			}
 		}
 
 		hash, err := hashPassword(req.Password)
@@ -573,6 +589,11 @@ func handleRegister(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 				"error":   "Failed to create user",
 			})
 			return
+		}
+
+		// Mark invite code as used.
+		if req.InviteCode != "" {
+			_ = database.UseInviteCode(req.InviteCode)
 		}
 
 		slog.Info("user registered", "id", id, "username", req.Username, "role", role)

--- a/internal/api/invites.go
+++ b/internal/api/invites.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func (s *Server) handleListInvites(w http.ResponseWriter, _ *http.Request) {
+	codes, err := s.db.ListInviteCodes()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"success": false, "error": err.Error(),
+		})
+		return
+	}
+	if codes == nil {
+		codes = []map[string]interface{}{}
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"invites": codes})
+}
+
+func (s *Server) handleCreateInvite(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Role       string `json:"role"`
+		MaxUses    int    `json:"max_uses"`
+		ExpiresIn  int    `json:"expires_in"` // seconds from now; 0 = no expiry
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"success": false, "error": "Invalid request",
+		})
+		return
+	}
+
+	if req.Role == "" {
+		req.Role = "user"
+	}
+	if req.Role != "user" && req.Role != "admin" {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"success": false, "error": "Role must be 'user' or 'admin'",
+		})
+		return
+	}
+	if req.MaxUses <= 0 {
+		req.MaxUses = 1
+	}
+
+	// Generate a secure random code.
+	codeBytes := make([]byte, 16)
+	if _, err := rand.Read(codeBytes); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"success": false, "error": "Failed to generate code",
+		})
+		return
+	}
+	code := hex.EncodeToString(codeBytes)
+
+	var expiresAt *float64
+	if req.ExpiresIn > 0 {
+		t := float64(time.Now().Unix()) + float64(req.ExpiresIn)
+		expiresAt = &t
+	}
+
+	// Get admin user ID from context.
+	userID := int64(0)
+	if id, ok := r.Context().Value(ctxUserID).(int64); ok {
+		userID = id
+	}
+
+	id, err := s.db.CreateInviteCode(code, userID, req.Role, req.MaxUses, expiresAt)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"success": false, "error": err.Error(),
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"success": true,
+		"id":      id,
+		"code":    code,
+		"role":    req.Role,
+		"max_uses": req.MaxUses,
+	})
+}
+
+func (s *Server) handleDeleteInvite(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"success": false, "error": "Invalid ID",
+		})
+		return
+	}
+	if err := s.db.DeleteInviteCode(id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"success": false, "error": err.Error(),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"success": true})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -195,6 +195,11 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("PATCH /api/users/{id}", requireAdmin(handleUpdateUser(s.db)))
 	s.mux.HandleFunc("DELETE /api/users/{id}", requireAdmin(handleDeleteUser(s.db)))
 
+	// Invite codes (admin only).
+	s.mux.HandleFunc("GET /api/invites", requireAdmin(s.handleListInvites))
+	s.mux.HandleFunc("POST /api/invites", requireAdmin(s.handleCreateInvite))
+	s.mux.HandleFunc("DELETE /api/invites/{id}", requireAdmin(s.handleDeleteInvite))
+
 	// TOTP 2FA.
 	s.mux.HandleFunc("POST /api/totp/setup", handleTOTPSetup(s.db))
 	s.mux.HandleFunc("POST /api/totp/verify", handleTOTPVerify(s.db))

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -287,6 +287,18 @@ func (d *DB) migrate() error {
 		check_interval_days INTEGER NOT NULL DEFAULT 7
 	)`)
 
+	// Invite codes for secure self-registration.
+	migrations = append(migrations, `CREATE TABLE IF NOT EXISTS invite_codes (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		code TEXT UNIQUE NOT NULL,
+		created_by INTEGER NOT NULL,
+		role TEXT NOT NULL DEFAULT 'user',
+		max_uses INTEGER NOT NULL DEFAULT 1,
+		uses INTEGER NOT NULL DEFAULT 0,
+		expires_at REAL,
+		created_at REAL NOT NULL DEFAULT (strftime('%s','now'))
+	)`)
+
 	// Additive migrations — add columns that may not exist yet.
 	addColumns := []string{
 		`ALTER TABLE download_jobs ADD COLUMN status_history TEXT NOT NULL DEFAULT '[]'`,
@@ -304,6 +316,90 @@ func (d *DB) migrate() error {
 		}
 	}
 	return nil
+}
+
+// --- Invite Codes ---
+
+// CreateInviteCode generates a new invite code.
+func (d *DB) CreateInviteCode(code string, createdBy int64, role string, maxUses int, expiresAt *float64) (int64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	result, err := d.db.Exec(
+		"INSERT INTO invite_codes (code, created_by, role, max_uses, expires_at) VALUES (?, ?, ?, ?, ?)",
+		code, createdBy, role, maxUses, expiresAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+
+// ValidateInviteCode checks if an invite code is valid (exists, not expired, uses remaining).
+// Returns the role the new user should get, or an error.
+func (d *DB) ValidateInviteCode(code string) (string, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var role string
+	var maxUses, uses int
+	var expiresAt *float64
+	err := d.db.QueryRow(
+		"SELECT role, max_uses, uses, expires_at FROM invite_codes WHERE code = ?", code,
+	).Scan(&role, &maxUses, &uses, &expiresAt)
+	if err != nil {
+		return "", fmt.Errorf("invalid invite code")
+	}
+	if uses >= maxUses {
+		return "", fmt.Errorf("invite code has been used")
+	}
+	if expiresAt != nil {
+		now := float64(time.Now().Unix())
+		if now > *expiresAt {
+			return "", fmt.Errorf("invite code has expired")
+		}
+	}
+	return role, nil
+}
+
+// UseInviteCode increments the use count.
+func (d *DB) UseInviteCode(code string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, err := d.db.Exec("UPDATE invite_codes SET uses = uses + 1 WHERE code = ?", code)
+	return err
+}
+
+// ListInviteCodes returns all invite codes for admin display.
+func (d *DB) ListInviteCodes() ([]map[string]interface{}, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	rows, err := d.db.Query("SELECT id, code, role, max_uses, uses, expires_at, created_at FROM invite_codes ORDER BY id DESC")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var codes []map[string]interface{}
+	for rows.Next() {
+		var id, maxUses, uses int
+		var code, role string
+		var expiresAt *float64
+		var createdAt float64
+		rows.Scan(&id, &code, &role, &maxUses, &uses, &expiresAt, &createdAt)
+		codes = append(codes, map[string]interface{}{
+			"id": id, "code": code, "role": role,
+			"max_uses": maxUses, "uses": uses,
+			"expires_at": expiresAt, "created_at": createdAt,
+		})
+	}
+	return codes, nil
+}
+
+// DeleteInviteCode removes an invite code.
+func (d *DB) DeleteInviteCode(id int64) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, err := d.db.Exec("DELETE FROM invite_codes WHERE id = ?", id)
+	return err
 }
 
 // --- Users ---

--- a/web/index.html
+++ b/web/index.html
@@ -192,6 +192,10 @@ tailwind.config = {
         <label class="block text-sm font-medium text-slate-300 mb-1" data-i18n="label_password">Password</label>
         <input type="password" id="register-password" class="w-full bg-slate-800 border border-slate-600 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500" placeholder="Min 6 characters" data-i18n-placeholder="ph_min_6_chars" autocomplete="new-password">
       </div>
+      <div id="invite-code-field">
+        <label class="block text-sm font-medium text-slate-300 mb-1">Invite Code</label>
+        <input type="text" id="register-invite-code" class="w-full bg-slate-800 border border-slate-600 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500" placeholder="Enter invite code from admin" autocomplete="off">
+      </div>
       <div id="register-error" class="text-red-400 text-sm hidden"></div>
       <button type="submit" class="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-semibold py-2.5 rounded-lg transition-colors" data-i18n="create_account">
         Create Account
@@ -1152,13 +1156,16 @@ function showLoginModal() {
       hideLoginModal();
       return;
     }
-    // Show register link if no users exist yet.
+    // Always show register link — invite codes make self-registration secure.
+    // First user creates admin (no invite needed). After that, invite code required.
     const regLink = document.getElementById('login-register-link');
+    regLink.classList.remove('hidden');
     if (!data.has_users) {
-      regLink.classList.remove('hidden');
       document.getElementById('login-subtitle').textContent = t('create_admin_account');
+      // Hide invite code field for first user.
+      const invField = document.getElementById('invite-code-field');
+      if (invField) invField.classList.add('hidden');
     } else {
-      regLink.classList.add('hidden');
       document.getElementById('login-subtitle').textContent = t('login_subtitle');
     }
   }).catch(() => {});
@@ -1288,6 +1295,7 @@ document.getElementById('register-form').addEventListener('submit', async (e) =>
 
   const username = document.getElementById('register-username').value.trim();
   const password = document.getElementById('register-password').value;
+  const inviteCode = (document.getElementById('register-invite-code')?.value || '').trim();
 
   if (!username || !password) {
     errEl.textContent = t('err_credentials_required');
@@ -1296,11 +1304,13 @@ document.getElementById('register-form').addEventListener('submit', async (e) =>
   }
 
   try {
+    const body = { username, password };
+    if (inviteCode) body.invite_code = inviteCode;
     const resp = await fetch('/api/register', {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify(body),
     });
 
     const data = await resp.json().catch(() => ({}));


### PR DESCRIPTION
New users can self-register using an invite code without needing an admin to be logged in. Admins generate codes via `POST /api/invites` with configurable role, max uses, and expiry. Registration form now always visible with an invite code field. First user still becomes admin with no code needed.