### PR TITLE
Fix qBittorrent 5.x login (fixes #35)

### DIFF
--- a/internal/download/qbittorrent.go
+++ b/internal/download/qbittorrent.go
@@ -80,13 +80,29 @@ func (q *QBittorrentClient) login() error {
 		return fmt.Errorf("IP banned by qBittorrent")
 	}
 
-	if bodyStr != "Ok." {
+	// qBittorrent 4.x returns 200 OK with body "Ok." on success.
+	// qBittorrent 5.x returns 204 No Content with an empty body; the session
+	// cookie (QBT_SID_*) in response headers signals success.
+	cookies := resp.Cookies()
+	hasSession := false
+	for _, c := range cookies {
+		if strings.HasPrefix(c.Name, "QBT_SID") {
+			hasSession = true
+			break
+		}
+	}
+	success := resp.StatusCode >= 200 && resp.StatusCode < 300 && (bodyStr == "Ok." || hasSession)
+
+	if !success {
 		q.nextLogin = now.Add(30 * time.Second)
 		q.authenticated = false
+		if bodyStr == "" {
+			return fmt.Errorf("login failed: HTTP %d", resp.StatusCode)
+		}
 		return fmt.Errorf("login failed: %s", bodyStr)
 	}
 
-	q.cookies = resp.Cookies()
+	q.cookies = cookies
 	q.authenticated = true
 	q.backoffSec = 3
 	q.nextLogin = time.Time{}

--- a/internal/download/qbittorrent_test.go
+++ b/internal/download/qbittorrent_test.go
@@ -1,8 +1,143 @@
 package download
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
 )
+
+func newTestQBClient(serverURL string) *QBittorrentClient {
+	cfg := &config.Config{
+		QBUrl:  serverURL,
+		QBUser: "admin",
+		QBPass: "adminadmin",
+	}
+	return NewQBittorrentClient(cfg)
+}
+
+// Simulates qBittorrent 4.x: HTTP 200 with body "Ok." and a session cookie.
+func TestLogin_QB4x_OkBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "SID", Value: "session4x"})
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Ok."))
+	}))
+	defer srv.Close()
+
+	q := newTestQBClient(srv.URL)
+	if err := q.Login(); err != nil {
+		t.Fatalf("expected qBittorrent 4.x login to succeed, got error: %v", err)
+	}
+	if !q.authenticated {
+		t.Errorf("expected authenticated=true after successful 4.x login")
+	}
+}
+
+// Simulates qBittorrent 5.x: HTTP 204 No Content with empty body and a QBT_SID_* cookie.
+func TestLogin_QB5x_NoContentWithSessionCookie(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID_8080", Value: "session5x"})
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	q := newTestQBClient(srv.URL)
+	if err := q.Login(); err != nil {
+		t.Fatalf("expected qBittorrent 5.x login to succeed, got error: %v", err)
+	}
+	if !q.authenticated {
+		t.Errorf("expected authenticated=true after successful 5.x login")
+	}
+	// Session cookie should be retained for subsequent requests.
+	found := false
+	for _, c := range q.cookies {
+		if c.Name == "QBT_SID_8080" && c.Value == "session5x" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected QBT_SID_8080 session cookie to be stored")
+	}
+}
+
+// Some 5.x deployments may return 200 OK with empty body but the session cookie set.
+func TestLogin_QB5x_EmptyBodyWithSessionCookie(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID_8080", Value: "session5x"})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	q := newTestQBClient(srv.URL)
+	if err := q.Login(); err != nil {
+		t.Fatalf("expected login with empty body + cookie to succeed, got error: %v", err)
+	}
+	if !q.authenticated {
+		t.Errorf("expected authenticated=true")
+	}
+}
+
+// Wrong credentials in 4.x: HTTP 200 with body "Fails." and no session cookie.
+func TestLogin_QB4x_FailsBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Fails."))
+	}))
+	defer srv.Close()
+
+	q := newTestQBClient(srv.URL)
+	err := q.Login()
+	if err == nil {
+		t.Fatalf("expected login to fail when body is 'Fails.'")
+	}
+	if !strings.Contains(err.Error(), "Fails.") {
+		t.Errorf("expected error to include 'Fails.', got: %v", err)
+	}
+	if q.authenticated {
+		t.Errorf("expected authenticated=false after failed login")
+	}
+}
+
+// IP ban response should be detected from body text.
+func TestLogin_Banned(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("Your IP address has been banned"))
+	}))
+	defer srv.Close()
+
+	q := newTestQBClient(srv.URL)
+	err := q.Login()
+	if err == nil || !strings.Contains(err.Error(), "banned") {
+		t.Fatalf("expected ban error, got: %v", err)
+	}
+	if q.authenticated {
+		t.Errorf("expected authenticated=false when banned")
+	}
+}
+
+// Empty body without a session cookie must fail (not be mistaken for 5.x success).
+func TestLogin_EmptyBodyNoCookieFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	q := newTestQBClient(srv.URL)
+	err := q.Login()
+	if err == nil {
+		t.Fatalf("expected login failure on 403 + empty body + no cookie")
+	}
+	if !strings.Contains(err.Error(), "HTTP 403") {
+		t.Errorf("expected error to mention HTTP 403, got: %v", err)
+	}
+	if q.authenticated {
+		t.Errorf("expected authenticated=false")
+	}
+}
 
 func TestMapTorrentStatus(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
qBit 5.x returns `204 No Content` with an empty body on successful login (only the `QBT_SID_*` cookie signals success), so the strict `body == "Ok."` check rejected it and the client entered a 30s cooldown loop. Login now succeeds on any 2xx status with either body `Ok.` (4.x) or a `QBT_SID_*` cookie present (5.x). Failure paths (`Fails.`, banned IP, non-2xx, empty body + no cookie) are preserved.

## Testing
- [x] `go test ./internal/download/` — added 6 new tests covering qBit 4.x success, 5.x 204+cookie success, 5.x 200+empty+cookie success, 4.x `Fails.` body, IP banned, and empty body without cookie (must fail).
- [x] `go test ./...` — full suite passes.
- [x] `go vet ./...` and `go build ./...` clean.

Fixes https://github.com/JeremiahM37/librarr/issues/35