### PR TITLE
Add UI fields for editing integration URLs and credentials

### DIFF
--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -115,6 +115,14 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	// Load existing settings and merge.
 	existing := s.loadSettings()
 	for k, v := range data {
+		// Clearing a string field deletes the override, so the env value (or
+		// default) reapplies on next startup. Without this, settings.json
+		// would hold "" and the UI would show "" while the runtime kept
+		// using the env value — those two views would disagree.
+		if str, isStr := v.(string); isStr && str == "" {
+			delete(existing, k)
+			continue
+		}
 		existing[k] = v
 	}
 

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -126,18 +126,22 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		existing[k] = v
 	}
 
-	// Write to file.
+	// Write to file. Server-side errors get logged with full context; the
+	// HTTP response stays generic so we don't leak the on-disk file path or
+	// underlying filesystem error to the browser.
 	jsonBytes, err := json.MarshalIndent(existing, "", "  ")
 	if err != nil {
+		slog.Error("settings marshal failed", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
-			"success": false, "error": err.Error(),
+			"success": false, "error": "Failed to save settings",
 		})
 		return
 	}
 
 	if err := os.WriteFile(s.cfg.SettingsFile, jsonBytes, 0600); err != nil {
+		slog.Error("settings write failed", "path", s.cfg.SettingsFile, "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
-			"success": false, "error": err.Error(),
+			"success": false, "error": "Failed to save settings",
 		})
 		return
 	}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -27,24 +27,45 @@ var sensitiveKeys = map[string]bool{
 func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
 	settings := s.loadSettings()
 
-	// Inject current config values as defaults.
+	// Inject current config values as defaults so the UI can render fields
+	// even when nothing has been saved to settings.json yet.
 	defaults := map[string]interface{}{
-		"file_org_enabled":    s.cfg.FileOrgEnabled,
-		"annas_archive_domain": s.cfg.AnnasArchiveDomain,
-		"ebook_dir":           s.cfg.EbookDir,
-		"audiobook_dir":       s.cfg.AudiobookDir,
-		"manga_dir":           s.cfg.MangaDir,
-		"incoming_dir":        s.cfg.IncomingDir,
-		"rate_limit_enabled":  s.cfg.RateLimitEnabled,
-		"metrics_enabled":     s.cfg.MetricsEnabled,
-		"webnovel_enabled":    s.cfg.WebNovelEnabled,
-		"mangadex_enabled":    s.cfg.MangaDexEnabled,
-		"max_retries":         s.cfg.MaxRetries,
-		"foreign_lang_filter": s.searchMgr.ForeignLangFilterEnabled(),
-		"flibusta_enabled":    s.cfg.FlibustaEnabled,
-		"flibusta_url":        s.cfg.FlibustaURL,
-		"zlibrary_enabled":    s.cfg.ZLibraryEnabled,
+		"file_org_enabled":            s.cfg.FileOrgEnabled,
+		"annas_archive_domain":        s.cfg.AnnasArchiveDomain,
+		"ebook_dir":                   s.cfg.EbookDir,
+		"audiobook_dir":               s.cfg.AudiobookDir,
+		"manga_dir":                   s.cfg.MangaDir,
+		"incoming_dir":                s.cfg.IncomingDir,
+		"rate_limit_enabled":          s.cfg.RateLimitEnabled,
+		"metrics_enabled":             s.cfg.MetricsEnabled,
+		"webnovel_enabled":            s.cfg.WebNovelEnabled,
+		"mangadex_enabled":            s.cfg.MangaDexEnabled,
+		"max_retries":                 s.cfg.MaxRetries,
+		"foreign_lang_filter":         s.searchMgr.ForeignLangFilterEnabled(),
+		"flibusta_enabled":            s.cfg.FlibustaEnabled,
+		"flibusta_url":                s.cfg.FlibustaURL,
+		"zlibrary_enabled":            s.cfg.ZLibraryEnabled,
 		"remove_torrent_after_import": s.cfg.RemoveTorrentAfterImport,
+
+		// Integration URLs and credentials (sensitive ones are masked below).
+		"qb_url":                    s.cfg.QBUrl,
+		"qb_user":                   s.cfg.QBUser,
+		"qb_pass":                   s.cfg.QBPass,
+		"prowlarr_url":              s.cfg.ProwlarrURL,
+		"prowlarr_api_key":          s.cfg.ProwlarrAPIKey,
+		"sabnzbd_url":               s.cfg.SABnzbdURL,
+		"sabnzbd_api_key":           s.cfg.SABnzbdAPIKey,
+		"sabnzbd_category":          s.cfg.SABnzbdCategory,
+		"abs_url":                   s.cfg.ABSURL,
+		"abs_token":                 s.cfg.ABSToken,
+		"kavita_url":                s.cfg.KavitaURL,
+		"kavita_user":               s.cfg.KavitaUser,
+		"kavita_pass":               s.cfg.KavitaPass,
+		"komga_url":                 s.cfg.KomgaURL,
+		"komga_user":                s.cfg.KomgaUser,
+		"komga_pass":                s.cfg.KomgaPass,
+		"calibre_url":               s.cfg.CalibreURL,
+		"calibre_library_path":      s.cfg.CalibreLibraryPath,
 	}
 
 	// Merge defaults under settings (settings override).

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/search"
+)
+
+// settingsTestServer builds the minimum Server needed for settings handler
+// tests: an on-disk SettingsFile, a real in-memory DB (LogActivity needs one),
+// and a search.Manager (ForeignLangFilterEnabled is read on GET).
+func settingsTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	cfg := &config.Config{
+		SettingsFile: settingsPath,
+		// Seed the env-layer values that the handler injects as defaults.
+		ProwlarrURL:    "http://env-prowlarr:9696",
+		ProwlarrAPIKey: "ENV_API_KEY",
+		QBUrl:          "http://env-qbit:8080",
+		QBUser:         "admin",
+		QBPass:         "env-qb-pass",
+	}
+
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	health := search.NewHealthTracker(3, 300)
+	searchMgr := search.NewManager(cfg, nil, health)
+
+	return &Server{cfg: cfg, db: database, searchMgr: searchMgr}, settingsPath
+}
+
+func saveSettings(t *testing.T, s *Server, payload map[string]interface{}) {
+	t.Helper()
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/settings", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), ctxUsername, "admin"))
+	rr := httptest.NewRecorder()
+	s.handleSaveSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("save returned %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func readSettingsFile(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Treat missing file as empty — that's the post-clear state.
+		return map[string]interface{}{}
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("settings.json malformed: %v", err)
+	}
+	return m
+}
+
+// TestSaveSettings_EmptyStringDeletesKey — regression guard for the bug found
+// in E2E. Clearing a UI field must remove the override from settings.json so
+// the env value reapplies; persisting "" would make /api/settings disagree
+// with the runtime cfg.
+func TestSaveSettings_EmptyStringDeletesKey(t *testing.T) {
+	s, path := settingsTestServer(t)
+
+	saveSettings(t, s, map[string]interface{}{"prowlarr_url": "http://custom:9696"})
+	if got := readSettingsFile(t, path)["prowlarr_url"]; got != "http://custom:9696" {
+		t.Fatalf("setup: expected URL persisted, got %v", got)
+	}
+
+	saveSettings(t, s, map[string]interface{}{"prowlarr_url": ""})
+
+	stored := readSettingsFile(t, path)
+	if _, present := stored["prowlarr_url"]; present {
+		t.Errorf("empty-string save should delete the key, but it is still present: %v", stored)
+	}
+}
+
+// TestSaveSettings_FalseBoolPersists — the empty-string-delete rule must NOT
+// drop legitimate falsy values like bool false. Toggles depend on this.
+func TestSaveSettings_FalseBoolPersists(t *testing.T) {
+	s, path := settingsTestServer(t)
+
+	saveSettings(t, s, map[string]interface{}{"remove_torrent_after_import": false})
+
+	stored := readSettingsFile(t, path)
+	v, present := stored["remove_torrent_after_import"]
+	if !present {
+		t.Fatal("bool false should be persisted, but key was deleted")
+	}
+	if b, ok := v.(bool); !ok || b != false {
+		t.Errorf("expected false, got %v (%T)", v, v)
+	}
+}
+
+// TestSaveSettings_MaskedSentinelPreservesRealValue — when a user saves a form
+// without touching a sensitive field, the JS sends back the masked sentinel
+// "--------". The handler must drop that key entirely so the previously-saved
+// real value remains on disk. Without this, a single UI save could wipe every
+// API key in settings.json.
+func TestSaveSettings_MaskedSentinelPreservesRealValue(t *testing.T) {
+	s, path := settingsTestServer(t)
+
+	saveSettings(t, s, map[string]interface{}{
+		"prowlarr_url":     "http://saved:9696",
+		"prowlarr_api_key": "REAL_SECRET_KEY",
+	})
+
+	// User edits only the URL and submits the form; API key field still holds
+	// the "--------" mask the GET handler returned.
+	saveSettings(t, s, map[string]interface{}{
+		"prowlarr_url":     "http://updated:9696",
+		"prowlarr_api_key": maskedValue,
+	})
+
+	stored := readSettingsFile(t, path)
+	if got := stored["prowlarr_url"]; got != "http://updated:9696" {
+		t.Errorf("URL should have updated, got %v", got)
+	}
+	if got := stored["prowlarr_api_key"]; got != "REAL_SECRET_KEY" {
+		t.Errorf("real API key should have been preserved, got %v", got)
+	}
+}
+
+// TestGetSettings_MasksSensitiveValues — non-empty sensitive values must come
+// back as the sentinel, never as plaintext. Empty values stay empty so the UI
+// can distinguish "unset" from "set but hidden".
+func TestGetSettings_MasksSensitiveValues(t *testing.T) {
+	s, _ := settingsTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rr := httptest.NewRecorder()
+	s.handleGetSettings(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET returned %d", rr.Code)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Prowlarr API key is set in env, must be masked.
+	if got := resp["prowlarr_api_key"]; got != maskedValue {
+		t.Errorf("prowlarr_api_key should be masked, got %v", got)
+	}
+	if got := resp["qb_pass"]; got != maskedValue {
+		t.Errorf("qb_pass should be masked, got %v", got)
+	}
+	// Non-sensitive URL is exposed.
+	if got := resp["prowlarr_url"]; got != "http://env-prowlarr:9696" {
+		t.Errorf("URL should be exposed, got %v", got)
+	}
+	// Unset sensitive (no env, no file) stays empty — empty is distinguishable
+	// from masked so the UI can show a placeholder.
+	if got := resp["abs_token"]; got != "" {
+		t.Errorf("unset abs_token should be empty string, got %v", got)
+	}
+}

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -138,6 +138,37 @@ func TestSaveSettings_MaskedSentinelPreservesRealValue(t *testing.T) {
 	}
 }
 
+// TestSaveSettings_WriteFailureDoesNotLeakPath — when the on-disk write fails
+// (e.g. permission denied) the HTTP response must stay generic. Previously the
+// raw err.Error() was returned, which included the absolute filesystem path
+// of settings.json — useful to an attacker probing the deployment layout.
+func TestSaveSettings_WriteFailureDoesNotLeakPath(t *testing.T) {
+	s, path := settingsTestServer(t)
+
+	// Make the file unwritable. WriteFile on a 0444 file returns
+	// "permission denied" with the full path in the message.
+	if err := os.WriteFile(path, []byte("{}"), 0444); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	defer os.Chmod(path, 0600)
+
+	body, _ := json.Marshal(map[string]interface{}{"prowlarr_url": "http://x:9696"})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), ctxUsername, "admin"))
+	rr := httptest.NewRecorder()
+	s.handleSaveSettings(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on write failure, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if bytes.Contains(rr.Body.Bytes(), []byte(path)) {
+		t.Errorf("response leaks settings file path: %s", rr.Body.String())
+	}
+	if bytes.Contains(rr.Body.Bytes(), []byte("permission denied")) {
+		t.Errorf("response leaks underlying OS error: %s", rr.Body.String())
+	}
+}
+
 // TestGetSettings_MasksSensitiveValues — non-empty sensitive values must come
 // back as the sentinel, never as plaintext. Empty values stay empty so the UI
 // can distinguish "unset" from "set but hidden".

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"strconv"
 )
@@ -173,8 +174,17 @@ type Config struct {
 	AuthorCheckIntervalDays   int
 }
 
-// Load reads configuration from environment variables with sensible defaults.
+// Load reads configuration from environment variables with sensible defaults,
+// then applies overrides from the settings file (if present) so values saved
+// from the UI persist across restarts.
 func Load() *Config {
+	cfg := buildFromEnv()
+	cfg.applySettingsFileOverrides()
+	return cfg
+}
+
+// buildFromEnv returns a Config populated from environment variables and defaults.
+func buildFromEnv() *Config {
 	return &Config{
 		Port:   getEnvInt("LIBRARR_PORT", 5050),
 		DBPath: getEnv("LIBRARR_DB_PATH", "/data/librarr.db"),
@@ -382,6 +392,94 @@ func (c *Config) HasZLibrary() bool {
 // HasBookTracker returns true if BookTracker is configured and enabled.
 func (c *Config) HasBookTracker() bool {
 	return c.BookTrackerEnabled && c.BookTrackerURL != "" && c.BookTrackerUser != "" && c.BookTrackerPass != ""
+}
+
+// applySettingsFileOverrides reads the JSON settings file at c.SettingsFile (if
+// it exists) and overrides matching string/bool/int fields on the Config.
+// Missing or unparseable files are silently ignored so the env-only path keeps
+// working — this is best-effort layering, not a hard config source.
+func (c *Config) applySettingsFileOverrides() {
+	if c.SettingsFile == "" {
+		return
+	}
+	data, err := os.ReadFile(c.SettingsFile)
+	if err != nil {
+		return
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return
+	}
+
+	strPtrs := map[string]*string{
+		"qb_url":                   &c.QBUrl,
+		"qb_user":                  &c.QBUser,
+		"qb_pass":                  &c.QBPass,
+		"prowlarr_url":             &c.ProwlarrURL,
+		"prowlarr_api_key":         &c.ProwlarrAPIKey,
+		"sabnzbd_url":              &c.SABnzbdURL,
+		"sabnzbd_api_key":          &c.SABnzbdAPIKey,
+		"sabnzbd_category":         &c.SABnzbdCategory,
+		"abs_url":                  &c.ABSURL,
+		"abs_token":                &c.ABSToken,
+		"abs_library_id":           &c.ABSLibraryID,
+		"abs_ebook_library_id":     &c.ABSEbookLibraryID,
+		"abs_public_url":           &c.ABSPublicURL,
+		"kavita_url":               &c.KavitaURL,
+		"kavita_user":              &c.KavitaUser,
+		"kavita_pass":              &c.KavitaPass,
+		"kavita_library_path":      &c.KavitaLibraryPath,
+		"kavita_manga_library_path": &c.KavitaMangaLibraryPath,
+		"kavita_public_url":        &c.KavitaPublicURL,
+		"komga_url":                &c.KomgaURL,
+		"komga_user":                &c.KomgaUser,
+		"komga_pass":               &c.KomgaPass,
+		"komga_library_id":         &c.KomgaLibraryID,
+		"komga_library_path":       &c.KomgaLibraryPath,
+		"calibre_url":              &c.CalibreURL,
+		"calibre_library_path":     &c.CalibreLibraryPath,
+		"annas_archive_domain":     &c.AnnasArchiveDomain,
+		"ebook_dir":                &c.EbookDir,
+		"audiobook_dir":            &c.AudiobookDir,
+		"manga_dir":                &c.MangaDir,
+		"incoming_dir":             &c.IncomingDir,
+		"manga_incoming_dir":       &c.MangaIncomingDir,
+		"flibusta_url":             &c.FlibustaURL,
+	}
+	for key, fieldPtr := range strPtrs {
+		v, ok := raw[key]
+		if !ok {
+			continue
+		}
+		s, isStr := v.(string)
+		if !isStr || s == "" {
+			continue
+		}
+		*fieldPtr = s
+	}
+
+	boolPtrs := map[string]*bool{
+		"file_org_enabled":             &c.FileOrgEnabled,
+		"rate_limit_enabled":           &c.RateLimitEnabled,
+		"metrics_enabled":              &c.MetricsEnabled,
+		"webnovel_enabled":             &c.WebNovelEnabled,
+		"mangadex_enabled":             &c.MangaDexEnabled,
+		"flibusta_enabled":             &c.FlibustaEnabled,
+		"zlibrary_enabled":             &c.ZLibraryEnabled,
+		"remove_torrent_after_import":  &c.RemoveTorrentAfterImport,
+		"foreign_lang_filter":          &c.ForeignLangFilter,
+	}
+	for key, fieldPtr := range boolPtrs {
+		v, ok := raw[key]
+		if !ok {
+			continue
+		}
+		b, isBool := v.(bool)
+		if !isBool {
+			continue
+		}
+		*fieldPtr = b
+	}
 }
 
 func getEnv(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -161,6 +161,40 @@ func TestLoad_SettingsFileMissing_NoError(t *testing.T) {
 	}
 }
 
+func TestLoad_SettingsFileTypeMismatch_IgnoresBadValues(t *testing.T) {
+	// A JSON number where the field expects a string, and a string where the
+	// field expects a bool — neither should override the env value. Without
+	// the type guards in applySettingsFileOverrides, the runtime cfg would
+	// hold nonsense values that the rest of the app would then dereference.
+	os.Setenv("PROWLARR_URL", "http://env-only:9696")
+	os.Setenv("FILE_ORG_ENABLED", "true")
+	defer func() {
+		os.Unsetenv("PROWLARR_URL")
+		os.Unsetenv("FILE_ORG_ENABLED")
+	}()
+
+	dir := t.TempDir()
+	settingsPath := dir + "/settings.json"
+	body := `{
+		"prowlarr_url": 12345,
+		"file_org_enabled": "not_a_bool"
+	}`
+	if err := os.WriteFile(settingsPath, []byte(body), 0600); err != nil {
+		t.Fatalf("write settings file: %v", err)
+	}
+	os.Setenv("SETTINGS_FILE", settingsPath)
+	defer os.Unsetenv("SETTINGS_FILE")
+
+	cfg := Load()
+
+	if cfg.ProwlarrURL != "http://env-only:9696" {
+		t.Errorf("number value for string field should be ignored, got %q", cfg.ProwlarrURL)
+	}
+	if !cfg.FileOrgEnabled {
+		t.Error("string value for bool field should be ignored, env true should persist")
+	}
+}
+
 func TestLoad_SettingsFileMalformed_NoError(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := dir + "/settings.json"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,76 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	}
 }
 
+func TestLoad_SettingsFileOverridesEnv(t *testing.T) {
+	// Env says one thing; settings file should win.
+	os.Setenv("PROWLARR_URL", "http://from-env:9696")
+	os.Setenv("PROWLARR_API_KEY", "env-key")
+	os.Setenv("REMOVE_TORRENT_AFTER_IMPORT", "true")
+	defer func() {
+		os.Unsetenv("PROWLARR_URL")
+		os.Unsetenv("PROWLARR_API_KEY")
+		os.Unsetenv("REMOVE_TORRENT_AFTER_IMPORT")
+	}()
+
+	dir := t.TempDir()
+	settingsPath := dir + "/settings.json"
+	body := `{
+		"prowlarr_url": "http://from-file:9696",
+		"prowlarr_api_key": "file-key",
+		"remove_torrent_after_import": false
+	}`
+	if err := os.WriteFile(settingsPath, []byte(body), 0600); err != nil {
+		t.Fatalf("write settings file: %v", err)
+	}
+	os.Setenv("SETTINGS_FILE", settingsPath)
+	defer os.Unsetenv("SETTINGS_FILE")
+
+	cfg := Load()
+
+	if cfg.ProwlarrURL != "http://from-file:9696" {
+		t.Errorf("settings file should override env URL, got %q", cfg.ProwlarrURL)
+	}
+	if cfg.ProwlarrAPIKey != "file-key" {
+		t.Errorf("settings file should override env API key, got %q", cfg.ProwlarrAPIKey)
+	}
+	if cfg.RemoveTorrentAfterImport {
+		t.Error("settings file should override env bool")
+	}
+}
+
+func TestLoad_SettingsFileMissing_NoError(t *testing.T) {
+	os.Setenv("SETTINGS_FILE", "/nonexistent/path/settings.json")
+	os.Setenv("PROWLARR_URL", "http://env-only:9696")
+	defer func() {
+		os.Unsetenv("SETTINGS_FILE")
+		os.Unsetenv("PROWLARR_URL")
+	}()
+
+	cfg := Load()
+	if cfg.ProwlarrURL != "http://env-only:9696" {
+		t.Errorf("missing settings file should not clobber env values, got %q", cfg.ProwlarrURL)
+	}
+}
+
+func TestLoad_SettingsFileMalformed_NoError(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := dir + "/settings.json"
+	if err := os.WriteFile(settingsPath, []byte("{ this is not valid json"), 0600); err != nil {
+		t.Fatalf("write settings file: %v", err)
+	}
+	os.Setenv("SETTINGS_FILE", settingsPath)
+	os.Setenv("PROWLARR_URL", "http://env-only:9696")
+	defer func() {
+		os.Unsetenv("SETTINGS_FILE")
+		os.Unsetenv("PROWLARR_URL")
+	}()
+
+	cfg := Load()
+	if cfg.ProwlarrURL != "http://env-only:9696" {
+		t.Errorf("malformed settings file should not clobber env values, got %q", cfg.ProwlarrURL)
+	}
+}
+
 func TestGetEnvInt_InvalidFallback(t *testing.T) {
 	os.Setenv("TEST_INT_INVALID", "not_a_number")
 	defer os.Unsetenv("TEST_INT_INVALID")

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -89,6 +89,7 @@ func (d *DB) migrate() error {
 			detail TEXT NOT NULL DEFAULT '',
 			library_item_id INTEGER,
 			job_id TEXT NOT NULL DEFAULT '',
+			user TEXT NOT NULL DEFAULT '',
 			timestamp REAL NOT NULL DEFAULT (strftime('%s','now'))
 		)`,
 		`CREATE TABLE IF NOT EXISTS download_jobs (
@@ -299,22 +300,27 @@ func (d *DB) migrate() error {
 		created_at REAL NOT NULL DEFAULT (strftime('%s','now'))
 	)`)
 
-	// Additive migrations — add columns that may not exist yet.
+	for _, m := range migrations {
+		if _, err := d.db.Exec(m); err != nil {
+			return fmt.Errorf("migration failed: %w\nSQL: %s", err, m)
+		}
+	}
+
+	// Additive migrations — add columns that may not exist on databases
+	// created by older versions of the schema. Run AFTER the CREATE TABLE
+	// migrations so the target tables already exist; otherwise the ALTER
+	// silently no-ops on a fresh DB and a later INSERT against the column
+	// fails. Duplicate-column errors are expected on already-upgraded DBs
+	// and are ignored.
 	addColumns := []string{
 		`ALTER TABLE download_jobs ADD COLUMN status_history TEXT NOT NULL DEFAULT '[]'`,
 		`ALTER TABLE activity_log ADD COLUMN user TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE reading_history ADD COLUMN status TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range addColumns {
-		// Ignore "duplicate column" errors.
 		d.db.Exec(stmt)
 	}
 
-	for _, m := range migrations {
-		if _, err := d.db.Exec(m); err != nil {
-			return fmt.Errorf("migration failed: %w\nSQL: %s", err, m)
-		}
-	}
 	return nil
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -559,6 +559,31 @@ func TestActivityLog(t *testing.T) {
 			t.Errorf("expected 1, got %d", count)
 		}
 	})
+
+	// LogActivity inserts into the activity_log.user column. On older
+	// schemas that column was added via ALTER TABLE in an additive migration
+	// that ran *before* the CREATE TABLE, so on a fresh DB the column did
+	// not exist and the INSERT failed silently with "no column named user".
+	// This test guards against that regression by reading the row back.
+	t.Run("LogActivity persists user column on fresh DB", func(t *testing.T) {
+		d2 := newTestDB(t)
+		d2.LogActivity("alice", "settings_changed", "settings", "Settings updated")
+
+		entries, err := d2.GetActivityLog("", "", 10, 0)
+		if err != nil {
+			t.Fatalf("GetActivityLog failed: %v", err)
+		}
+		found := false
+		for _, e := range entries {
+			if e.User == "alice" && e.Action == "settings_changed" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("LogActivity did not persist user=alice; entries=%+v", entries)
+		}
+	})
 }
 
 func TestGetStats(t *testing.T) {

--- a/web/index.html
+++ b/web/index.html
@@ -469,6 +469,161 @@ tailwind.config = {
         </div>
       </div>
 
+      <!-- Integrations -->
+      <div class="bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6">
+        <div class="flex items-start justify-between mb-4 gap-3">
+          <div>
+            <h3 class="text-sm font-semibold text-slate-300 uppercase tracking-wider">Integrations</h3>
+            <p class="text-xs text-slate-500 mt-1">Edit URLs and credentials without restarting the container. Saved values override the env vars in your compose file on next restart.</p>
+          </div>
+        </div>
+        <div class="space-y-4">
+
+          <!-- Prowlarr -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">Prowlarr</h4>
+              <button onclick="saveIntegration('prowlarr')" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">URL</label>
+                <input type="text" id="setting-prowlarr_url" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="http://prowlarr:9696">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">API Key</label>
+                <input type="password" id="setting-prowlarr_api_key" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+            </div>
+          </div>
+
+          <!-- qBittorrent -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">qBittorrent</h4>
+              <button onclick="saveIntegration('qbittorrent')" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">URL</label>
+                <input type="text" id="setting-qb_url" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="http://qbittorrent:8080">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Username</label>
+                <input type="text" id="setting-qb_user" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="admin">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Password</label>
+                <input type="password" id="setting-qb_pass" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+            </div>
+          </div>
+
+          <!-- SABnzbd -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">SABnzbd</h4>
+              <button onclick="saveIntegration('sabnzbd')" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">URL</label>
+                <input type="text" id="setting-sabnzbd_url" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="http://sabnzbd:8080">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">API Key</label>
+                <input type="password" id="setting-sabnzbd_api_key" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Category</label>
+                <input type="text" id="setting-sabnzbd_category" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="librarr">
+              </div>
+            </div>
+          </div>
+
+          <!-- Audiobookshelf -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">Audiobookshelf</h4>
+              <button onclick="saveIntegration('audiobookshelf')" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">URL</label>
+                <input type="text" id="setting-abs_url" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="http://audiobookshelf:13378">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">API Token</label>
+                <input type="password" id="setting-abs_token" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+            </div>
+          </div>
+
+          <!-- Kavita -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">Kavita</h4>
+              <button onclick="saveIntegration('kavita')" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">URL</label>
+                <input type="text" id="setting-kavita_url" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="http://kavita:5000">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Username</label>
+                <input type="text" id="setting-kavita_user" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Password</label>
+                <input type="password" id="setting-kavita_pass" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+            </div>
+          </div>
+
+          <!-- Komga -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">Komga</h4>
+              <button onclick="saveIntegration('komga')" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">URL</label>
+                <input type="text" id="setting-komga_url" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="http://komga:25600">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Username</label>
+                <input type="text" id="setting-komga_user" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Password</label>
+                <input type="password" id="setting-komga_pass" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+            </div>
+          </div>
+
+          <!-- Calibre -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">Calibre</h4>
+              <button onclick="saveIntegration('calibre')" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">URL</label>
+                <input type="text" id="setting-calibre_url" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="http://calibre-web:8083">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Library Path</label>
+                <input type="text" id="setting-calibre_library_path" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="/calibre">
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
       <!-- Connection Tests -->
       <div class="bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6">
         <h3 class="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4" data-i18n="s_connection_tests">Connection Tests</h3>
@@ -2107,6 +2262,18 @@ async function loadSettings() {
   }
 }
 
+// Settings keys backed by an input in the Integrations section, grouped by the
+// integration name passed to saveIntegration().
+const INTEGRATION_FIELDS = {
+  prowlarr:       ['prowlarr_url', 'prowlarr_api_key'],
+  qbittorrent:    ['qb_url', 'qb_user', 'qb_pass'],
+  sabnzbd:        ['sabnzbd_url', 'sabnzbd_api_key', 'sabnzbd_category'],
+  audiobookshelf: ['abs_url', 'abs_token'],
+  kavita:         ['kavita_url', 'kavita_user', 'kavita_pass'],
+  komga:          ['komga_url', 'komga_user', 'komga_pass'],
+  calibre:        ['calibre_url', 'calibre_library_path'],
+};
+
 async function loadSettingToggles() {
   try {
     const data = await apiJson('/api/settings');
@@ -2118,7 +2285,44 @@ async function loadSettingToggles() {
     if (langFilter && data.foreign_lang_filter !== undefined) {
       langFilter.checked = data.foreign_lang_filter;
     }
+    // Populate integration inputs. Sensitive values come back as "--------"
+    // from the server; the save handler drops that sentinel before writing.
+    for (const fields of Object.values(INTEGRATION_FIELDS)) {
+      for (const key of fields) {
+        const el = document.getElementById(`setting-${key}`);
+        if (el && data[key] !== undefined && data[key] !== null) {
+          el.value = data[key];
+        }
+      }
+    }
   } catch (err) {}
+}
+
+async function saveIntegration(name) {
+  const fields = INTEGRATION_FIELDS[name];
+  if (!fields) return;
+  const payload = {};
+  for (const key of fields) {
+    const el = document.getElementById(`setting-${key}`);
+    if (!el) continue;
+    payload[key] = el.value;
+  }
+  try {
+    const res = await apiJson('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (res.success) {
+      showToast('Saved. Restart the container for new URLs/credentials to take effect.', 'success');
+    } else {
+      showToast(res.error || 'Failed to save', 'error');
+    }
+  } catch (err) {
+    if (err.message !== 'Unauthorized') {
+      showToast('Failed to save', 'error');
+    }
+  }
 }
 
 async function loadConfig() {

--- a/web/index.html
+++ b/web/index.html
@@ -492,7 +492,7 @@ tailwind.config = {
               </div>
               <div>
                 <label class="block text-xs text-slate-500 mb-1">API Key</label>
-                <input type="password" id="setting-prowlarr_api_key" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+                <input type="password" id="setting-prowlarr_api_key" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
               </div>
             </div>
           </div>
@@ -514,7 +514,7 @@ tailwind.config = {
               </div>
               <div>
                 <label class="block text-xs text-slate-500 mb-1">Password</label>
-                <input type="password" id="setting-qb_pass" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+                <input type="password" id="setting-qb_pass" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
               </div>
             </div>
           </div>
@@ -532,7 +532,7 @@ tailwind.config = {
               </div>
               <div>
                 <label class="block text-xs text-slate-500 mb-1">API Key</label>
-                <input type="password" id="setting-sabnzbd_api_key" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+                <input type="password" id="setting-sabnzbd_api_key" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
               </div>
               <div>
                 <label class="block text-xs text-slate-500 mb-1">Category</label>
@@ -554,7 +554,7 @@ tailwind.config = {
               </div>
               <div>
                 <label class="block text-xs text-slate-500 mb-1">API Token</label>
-                <input type="password" id="setting-abs_token" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+                <input type="password" id="setting-abs_token" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
               </div>
             </div>
           </div>
@@ -576,7 +576,7 @@ tailwind.config = {
               </div>
               <div>
                 <label class="block text-xs text-slate-500 mb-1">Password</label>
-                <input type="password" id="setting-kavita_pass" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+                <input type="password" id="setting-kavita_pass" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
               </div>
             </div>
           </div>
@@ -598,7 +598,7 @@ tailwind.config = {
               </div>
               <div>
                 <label class="block text-xs text-slate-500 mb-1">Password</label>
-                <input type="password" id="setting-komga_pass" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+                <input type="password" id="setting-komga_pass" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Most integration settings (URLs, API keys, passwords) had to be set in `docker-compose` env vars and required editing the compose file + restarting to change. This adds editable form fields in the Settings tab so they can be managed from the UI.

- **Backend** — `config.Load()` now reads `settings.json` after env-loading and overrides matching string/bool fields. Missing or malformed files are ignored silently; env remains the boot floor.
- **Settings API** — the GET defaults map now surfaces URL/credential fields for each integration. Sensitive keys (`prowlarr_api_key`, `qb_pass`, `abs_token`, `kavita_pass`, `komga_pass`, `sabnzbd_api_key`) are already masked by the existing handler, and saves that leave the `--------` sentinel in place are dropped before writing.
- **Web UI** — new "Integrations" section with per-integration save buttons for Prowlarr, qBittorrent, SABnzbd, Audiobookshelf, Kavita, Komga, and Calibre. Each section has its own Save button so you can change one integration without touching another.
- **Restart requirement** — the save toast notes that a container restart is needed for new URLs / credentials to take effect, since clients (qBit, Prowlarr, SAB, etc.) are constructed once from `cfg` at startup. Hot-reload of integration clients is out of scope for this PR.

## Test plan

- [x] `go test ./...` — all packages pass, including three new config tests covering settings-file overrides env, missing file is a no-op, malformed file is a no-op.
- [x] `go vet ./...` and `staticcheck ./...` — clean.
- [ ] Manual: load the Settings tab, edit a Prowlarr URL + API key, save, restart the container, verify the new values are used and the API key shows as `--------` in the UI after reload.
- [ ] Manual: leave a masked field (`--------`) in place, change only the URL, save, restart, verify the original API key is preserved.

## Out of scope (intentionally)

- Switching the on-disk store (SQLite/Postgres/etc.).
- Encryption-at-rest for the settings file — keeps parity with the rest of the *arr ecosystem and avoids a key-lifecycle problem. `settings.json` is written with `0600` like before.
- Hot-reloading integration clients after save — fine follow-up if there's demand.