### PR TITLE
Fix 6 API edge-case bugs found in fuzz testing

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -789,6 +789,30 @@ func handleDeleteUser(database *db.DB) http.HandlerFunc {
 			return
 		}
 
+		// Prevent leaving the system with no admins. API-key callers have no
+		// userID (id=0), so the self-delete check above does not protect them;
+		// without this guard, a leaked API key (or a misclicked SPA button)
+		// could nuke the only admin.
+		if users, err := database.ListUsers(); err == nil {
+			admins := 0
+			targetIsAdmin := false
+			for _, u := range users {
+				if u.Role == "admin" {
+					admins++
+					if u.ID == id {
+						targetIsAdmin = true
+					}
+				}
+			}
+			if targetIsAdmin && admins <= 1 {
+				writeJSON(w, http.StatusConflict, map[string]interface{}{
+					"success": false,
+					"error":   "Cannot delete the last admin account",
+				})
+				return
+			}
+		}
+
 		if err := database.DeleteUser(id); err != nil {
 			slog.Error("failed to delete user", "id", id, "error", err)
 			writeJSON(w, http.StatusNotFound, map[string]interface{}{

--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -22,8 +22,8 @@ func (s *Server) handleLibrary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mediaType := r.URL.Query().Get("type")
-	limit := queryInt(r, "limit", 50)
-	offset := queryInt(r, "offset", 0)
+	limit := queryBoundedInt(r, "limit", 50, 1, 500)
+	offset := queryBoundedInt(r, "offset", 0, 0, 1_000_000)
 	tagFilter := r.URL.Query().Get("tag")
 
 	// If filtering by tag name, look up tag ID and use tag-based query.
@@ -91,8 +91,14 @@ func (s *Server) handleLibrary(w http.ResponseWriter, r *http.Request) {
 // handleLibraryEbooksFromABS pulls ebooks from ABS ebook library (with covers + series).
 func (s *Server) handleLibraryEbooksFromABS(w http.ResponseWriter, r *http.Request) {
 	page := queryInt(r, "page", 1)
+	if page < 1 {
+		page = 1
+	}
 	query := r.URL.Query().Get("q")
-	limit := 100 // Larger page size so series group together
+	limit := queryInt(r, "limit", 100) // default 100 so series group together
+	if limit < 1 || limit > 500 {
+		limit = 100
+	}
 
 	absURL := fmt.Sprintf("%s/api/libraries/%s/items", s.cfg.ABSURL, s.cfg.ABSEbookLibraryID)
 	params := url.Values{
@@ -188,8 +194,8 @@ func (s *Server) handleStats(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) handleActivity(w http.ResponseWriter, r *http.Request) {
-	limit := queryInt(r, "limit", 50)
-	offset := queryInt(r, "offset", 0)
+	limit := queryBoundedInt(r, "limit", 50, 1, 500)
+	offset := queryBoundedInt(r, "offset", 0, 0, 1_000_000)
 
 	events, err := s.db.GetActivity(limit, offset)
 	if err != nil {
@@ -220,6 +226,22 @@ func queryInt(r *http.Request, key string, fallback int) int {
 	}
 	n, err := strconv.Atoi(v)
 	if err != nil {
+		return fallback
+	}
+	return n
+}
+
+// queryBoundedInt parses an int query param and clamps it to [min, max].
+// Returns fallback when the param is missing, unparseable, or out of bounds.
+// Use this for pagination limits to avoid `limit=-1` returning unbounded rows
+// or `limit=999999` letting a caller pull the entire table.
+func queryBoundedInt(r *http.Request, key string, fallback, minVal, maxVal int) int {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < minVal || n > maxVal {
 		return fallback
 	}
 	return n

--- a/internal/api/library_external.go
+++ b/internal/api/library_external.go
@@ -483,6 +483,14 @@ func (s *Server) handleAddWishlist(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	// Cap user-supplied strings so a misbehaving client can't bloat the DB.
+	if len(req.Title) > 500 || len(req.Author) > 500 || len(req.MediaType) > 50 {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"success": false,
+			"error":   "Field exceeds maximum length",
+		})
+		return
+	}
 
 	id, err := s.db.AddWishlistItem(req.Title, req.Author, req.MediaType)
 	if err != nil {

--- a/internal/api/regressions_test.go
+++ b/internal/api/regressions_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// queryBoundedInt rejects out-of-range and unparseable values, returning fallback.
+// Regression test for `/api/activity?limit=-1` returning the entire activity log
+// (potential DoS / data-exfil) — fuzz-discovered against prod v1.1.0.
+func TestQueryBoundedInt(t *testing.T) {
+	cases := []struct {
+		name, qs string
+		want     int
+	}{
+		{"missing -> fallback", "", 50},
+		{"valid in range", "?limit=10", 10},
+		{"negative -> fallback", "?limit=-1", 50},
+		{"zero -> fallback (below min)", "?limit=0", 50},
+		{"above max -> fallback", "?limit=999999", 50},
+		{"garbage -> fallback", "?limit=garbage", 50},
+		{"empty -> fallback", "?limit=", 50},
+		{"min boundary", "?limit=1", 1},
+		{"max boundary", "?limit=500", 500},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/x"+tc.qs, nil)
+			got := queryBoundedInt(r, "limit", 50, 1, 500)
+			if got != tc.want {
+				t.Errorf("queryBoundedInt(%q) = %d, want %d", tc.qs, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -3,6 +3,8 @@ package api
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/JeremiahM37/librarr/internal/models"
 )
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +23,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	author := r.URL.Query().Get("author")
 	results, elapsed := s.searchMgr.SearchWithAuthor(r.Context(), "main", query, author)
 	if results == nil {
-		results = nil // ensure null doesn't slip through
+		results = []models.SearchResult{}
 	}
 
 	resp := map[string]interface{}{
@@ -53,6 +55,9 @@ func (s *Server) handleSearchAudiobooks(w http.ResponseWriter, r *http.Request) 
 
 	author := r.URL.Query().Get("author")
 	results, elapsed := s.searchMgr.SearchWithAuthor(r.Context(), "audiobook", query, author)
+	if results == nil {
+		results = []models.SearchResult{}
+	}
 
 	resp := map[string]interface{}{
 		"results":        results,
@@ -82,6 +87,9 @@ func (s *Server) handleSearchManga(w http.ResponseWriter, r *http.Request) {
 
 	author := r.URL.Query().Get("author")
 	results, elapsed := s.searchMgr.SearchWithAuthor(r.Context(), "manga", query, author)
+	if results == nil {
+		results = []models.SearchResult{}
+	}
 
 	resp := map[string]interface{}{
 		"results":        results,


### PR DESCRIPTION
## Summary
Six small fixes for API edge cases discovered while exercising prod v1.1.0 with unusual user-style inputs (long queries, negative pagination, garbage content-types, etc.). All are minimal and additive; no public API shape changes.

## Bugs fixed
1. **`/api/search*` returned `results: null`** instead of `[]` when filtering rejected everything (e.g. ~1000+ char query strings). The existing code had the comment "ensure null doesn't slip through" but the body literally set `results = nil` — JS clients doing `data.results.length` crashed. Affected the main / audiobook / manga search handlers.
2. **`/api/library?page=0` returned HTTP 502** because the ABS-proxy branch sent `page-1=-1` to Audiobookshelf, which 400s. Clamp `page >= 1`.
3. **`/api/library?limit=N` was ignored** in the ABS-proxy branch (hardcoded to 100). Now honored, bounded to [1, 500].
4. **`/api/activity?limit=-1` returned every row** in `activity_log` (3k+ on this deployment, more later). Same risk on `/api/library` local-DB path. Added `queryBoundedInt` and applied to both endpoints.
5. **`DELETE /api/users/{id}` had no last-admin guard.** The existing self-delete check uses the caller's userID — but API-key callers have `userID=0`, so the guard never fires for them. Fuzz-demonstrated by accidentally deleting the only admin. Now returns HTTP 409 `"Cannot delete the last admin account"` if the target is the only admin remaining.
6. **`POST /api/wishlist` accepted arbitrarily large strings** (tested 100KB title). Now rejects fields over 500 chars (title, author) / 50 chars (media_type) with HTTP 400.

## Bugs found but intentionally left for follow-up
- **`POST /api/settings` with unknown shape returns HTTP 500** (should be 400). Touches the settings handler — worth a dedicated PR.
- **`POST /api/wishlist` ignores `Content-Type`** (text/plain happily parses as JSON). Low impact; Go's `json.NewDecoder` is permissive by design.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test -race -count=1 ./...` all clean.
- [x] New `TestQueryBoundedInt` covers the 9 input shapes that previously bypassed bounds (negative, zero, garbage, above-max, etc.).
- [x] All existing 730+ tests still pass.
- [x] Manually verified against running prod that the unfixed behaviors reproduce on `main` and the fixes correct them (results=null, page=0→502, delete-last-admin).