### PR TITLE
docs: how to use Librarr from Claude / MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,68 @@ Librarr serves an OPDS 1.2 catalog at `/opds` for e-reader apps (KOReader, Moon+
 
 **Setup:** Add `http://your-librarr-host:5050/opds` as an OPDS catalog in your e-reader. If auth is enabled, enter your Librarr username and password.
 
+## Using Librarr with Claude / MCP
+
+Librarr's REST API is the integration surface, so any [Model Context Protocol](https://modelcontextprotocol.io/) server can expose Librarr's search, download, and library tools to an LLM (Claude Desktop, Claude Code, Open WebUI, Cursor, etc.). There's no built-in MCP server in Librarr — you wire it into the MCP server you already run.
+
+**Auth:** every endpoint accepts an `X-Api-Key` header or `?apikey=` query param. Set `API_KEY` in your `docker-compose.yml` and reuse it from your MCP server.
+
+**Minimal Python example** using [`fastmcp`](https://github.com/jlowin/fastmcp):
+
+```python
+# librarr_mcp.py — run as: fastmcp run librarr_mcp.py
+import os, httpx
+from fastmcp import FastMCP
+
+LIBRARR = os.environ["LIBRARR_URL"]       # e.g. http://librarr.lan:5050
+API_KEY = os.environ["LIBRARR_API_KEY"]
+HEADERS = {"X-Api-Key": API_KEY}
+
+mcp = FastMCP("librarr")
+
+@mcp.tool()
+async def search_books(query: str) -> list[dict]:
+    """Search for an ebook across all configured sources."""
+    async with httpx.AsyncClient() as c:
+        r = await c.get(f"{LIBRARR}/api/search", params={"q": query}, headers=HEADERS)
+        return r.json()
+
+@mcp.tool()
+async def download_book(result: dict) -> dict:
+    """Queue an ebook download. Pass a result object returned by search_books — it
+    already contains `source`, `title`, and the source-specific URL field
+    (`download_url` / `magnet_url` / `md5` / etc.)."""
+    async with httpx.AsyncClient() as c:
+        r = await c.post(f"{LIBRARR}/api/download", json=result, headers=HEADERS)
+        return r.json()
+
+@mcp.tool()
+async def list_downloads() -> list[dict]:
+    """List active and recent download jobs with status."""
+    async with httpx.AsyncClient() as c:
+        r = await c.get(f"{LIBRARR}/api/downloads", headers=HEADERS)
+        return r.json()
+```
+
+**Register with Claude Desktop / Claude Code** (`~/.claude.json` or `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "librarr": {
+      "command": "fastmcp",
+      "args": ["run", "/path/to/librarr_mcp.py"],
+      "env": {
+        "LIBRARR_URL": "http://librarr.lan:5050",
+        "LIBRARR_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+The same pattern works for audiobooks (`/api/search/audiobooks`, `/api/download/audiobook`) and manga (`/api/search/manga`, `/api/download/torrent`). Wrap whichever subset of the [API Endpoints](#api-endpoints) above is useful to your assistant.
+
 ## Architecture
 
 Single static binary, zero CGO dependencies, pure-Go SQLite via `modernc.org/sqlite`.


### PR DESCRIPTION
## Summary

Adds a `## Using Librarr with Claude / MCP` section to the README, between OPDS and Architecture. Documents the pattern for wiring Librarr into an MCP server (Claude Desktop, Claude Code, Open WebUI, Cursor, etc.) using the existing REST API — no new code, no new dependency, no built-in MCP server.

Includes a working minimal `fastmcp` example showing `search_books`, `download_book`, and `list_downloads`, plus a sample `~/.claude.json` / `claude_desktop_config.json` registration block.

## Why doc-only instead of a built-in `--mcp` mode

- Adding a Go MCP SDK pulls a dependency into every Librarr install for a feature most users won't touch.
- Per-deployment MCP wrappers are the better pattern: each user picks which subset of tools their assistant should see, and which credentials to pass.
- The `X-Api-Key` header / `?apikey=` param already make Librarr trivially MCP-able from any language.

If user demand for a built-in option shows up later, the doc section is the right launchpad — show people the pattern first, ship code only if there's signal.

## Test plan

- [x] Verified the `DownloadRequest` shape in `internal/models/book.go` matches the example (pass through the search result object; `source`, `title`, plus source-specific URL field).
- [x] Section renders cleanly between OPDS and Architecture; TOC stays sensible.