### PR TITLE
Multi-user UX: self-service password change, invite codes UI, first-run hint

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -766,6 +766,86 @@ func handleUpdateUser(database *db.DB) http.HandlerFunc {
 	}
 }
 
+// handleChangeOwnPassword handles POST /api/me/password — any authenticated user.
+// Verifies the current password before updating so a stolen session can't reset
+// the password without knowing the existing one.
+func handleChangeOwnPassword(database *db.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID := getUserIDFromContext(r)
+		if userID == 0 {
+			writeJSON(w, http.StatusUnauthorized, map[string]interface{}{
+				"success": false,
+				"error":   "Authentication required",
+			})
+			return
+		}
+
+		var req struct {
+			CurrentPassword string `json:"current_password"`
+			NewPassword     string `json:"new_password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+				"success": false,
+				"error":   "Invalid request body",
+			})
+			return
+		}
+
+		if req.CurrentPassword == "" || req.NewPassword == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+				"success": false,
+				"error":   "Both current_password and new_password are required",
+			})
+			return
+		}
+
+		if len(req.NewPassword) < 6 {
+			writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+				"success": false,
+				"error":   "New password must be at least 6 characters",
+			})
+			return
+		}
+
+		user, err := database.GetUser(userID)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]interface{}{
+				"success": false,
+				"error":   "User not found",
+			})
+			return
+		}
+
+		if !checkPassword(req.CurrentPassword, user.PasswordHash) {
+			writeJSON(w, http.StatusUnauthorized, map[string]interface{}{
+				"success": false,
+				"error":   "Current password is incorrect",
+			})
+			return
+		}
+
+		hash, err := hashPassword(req.NewPassword)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+				"success": false,
+				"error":   "Failed to hash password",
+			})
+			return
+		}
+		if err := database.UpdateUserPassword(userID, hash); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+				"success": false,
+				"error":   "Failed to update password",
+			})
+			return
+		}
+
+		database.LogActivity(user.Username, "password_changed", "self", "User changed their own password")
+		writeJSON(w, http.StatusOK, map[string]interface{}{"success": true})
+	}
+}
+
 // handleDeleteUser handles DELETE /api/users/{id} — admin only.
 func handleDeleteUser(database *db.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/me_password_test.go
+++ b/internal/api/me_password_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/db"
+)
+
+// changePwTestSetup creates an in-memory DB, registers a user, and returns the
+// handler + that user's ID. Mirrors the fixture style used by settings_test.go.
+func changePwTestSetup(t *testing.T) (http.HandlerFunc, *db.DB, int64) {
+	t.Helper()
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	hash, err := hashPassword("originalpw")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	id, err := database.CreateUser("alice", hash, "admin")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return handleChangeOwnPassword(database), database, id
+}
+
+func postChangePw(t *testing.T, h http.HandlerFunc, userID int64, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/me/password", bytes.NewReader(b))
+	if userID > 0 {
+		req = req.WithContext(context.WithValue(req.Context(), ctxUserID, userID))
+	}
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	return rr
+}
+
+// TestChangeOwnPassword_HappyPath — correct current pw + valid new pw updates.
+func TestChangeOwnPassword_HappyPath(t *testing.T) {
+	h, database, id := changePwTestSetup(t)
+
+	rr := postChangePw(t, h, id, map[string]string{
+		"current_password": "originalpw",
+		"new_password":     "newpassword1",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify the new password actually works.
+	user, _ := database.GetUserByUsername("alice")
+	if !checkPassword("newpassword1", user.PasswordHash) {
+		t.Error("new password does not verify after change")
+	}
+	if checkPassword("originalpw", user.PasswordHash) {
+		t.Error("old password still works after change — hash was not updated")
+	}
+}
+
+// TestChangeOwnPassword_WrongCurrent — must reject with 401 without updating.
+func TestChangeOwnPassword_WrongCurrent(t *testing.T) {
+	h, database, id := changePwTestSetup(t)
+
+	rr := postChangePw(t, h, id, map[string]string{
+		"current_password": "wrong-password",
+		"new_password":     "newpassword1",
+	})
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 on wrong current pw, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	user, _ := database.GetUserByUsername("alice")
+	if !checkPassword("originalpw", user.PasswordHash) {
+		t.Error("password changed despite wrong current_password — security regression")
+	}
+}
+
+// TestChangeOwnPassword_Unauthenticated — no userID in context → 401.
+func TestChangeOwnPassword_Unauthenticated(t *testing.T) {
+	h, _, _ := changePwTestSetup(t)
+
+	rr := postChangePw(t, h, 0, map[string]string{
+		"current_password": "originalpw",
+		"new_password":     "newpassword1",
+	})
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestChangeOwnPassword_TooShort — server-side guard against short new pw.
+func TestChangeOwnPassword_TooShort(t *testing.T) {
+	h, _, id := changePwTestSetup(t)
+
+	rr := postChangePw(t, h, id, map[string]string{
+		"current_password": "originalpw",
+		"new_password":     "abc",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 on short pw, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestChangeOwnPassword_MissingFields — both fields required.
+func TestChangeOwnPassword_MissingFields(t *testing.T) {
+	h, _, id := changePwTestSetup(t)
+
+	rr := postChangePw(t, h, id, map[string]string{
+		"current_password": "originalpw",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 when new_password missing, got %d", rr.Code)
+	}
+
+	rr = postChangePw(t, h, id, map[string]string{
+		"new_password": "newpassword1",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 when current_password missing, got %d", rr.Code)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -200,6 +200,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /api/invites", requireAdmin(s.handleCreateInvite))
 	s.mux.HandleFunc("DELETE /api/invites/{id}", requireAdmin(s.handleDeleteInvite))
 
+	// Self-service account.
+	s.mux.HandleFunc("POST /api/me/password", handleChangeOwnPassword(s.db))
+
 	// TOTP 2FA.
 	s.mux.HandleFunc("POST /api/totp/setup", handleTOTPSetup(s.db))
 	s.mux.HandleFunc("POST /api/totp/verify", handleTOTPVerify(s.db))

--- a/web/index.html
+++ b/web/index.html
@@ -143,6 +143,12 @@ tailwind.config = {
       </div>
     </div>
 
+    <!-- First-run welcome banner (shown only when has_users=false) -->
+    <div id="first-run-banner" class="hidden mb-5 px-3 py-2 rounded-lg bg-indigo-500/10 border border-indigo-500/30 flex items-center gap-2">
+      <span class="text-[10px] font-semibold uppercase tracking-wider bg-indigo-500 text-white px-2 py-0.5 rounded">Setup</span>
+      <span class="text-xs text-slate-300">First-run: create your admin account below.</span>
+    </div>
+
     <!-- Login Form -->
     <form id="login-form" class="space-y-4">
       <div>
@@ -449,6 +455,27 @@ tailwind.config = {
         </div>
       </div>
 
+      <!-- Change Password (any authenticated multi-user account) -->
+      <div id="change-password-section" class="bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6 hidden">
+        <h3 class="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">Change Password</h3>
+        <form id="change-password-form" class="space-y-3 max-w-md">
+          <div>
+            <label class="block text-xs text-slate-500 mb-1">Current Password</label>
+            <input type="password" id="cp-current" autocomplete="current-password" class="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-500" placeholder="">
+          </div>
+          <div>
+            <label class="block text-xs text-slate-500 mb-1">New Password</label>
+            <input type="password" id="cp-new" autocomplete="new-password" class="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-500" placeholder="Min 6 characters">
+          </div>
+          <div>
+            <label class="block text-xs text-slate-500 mb-1">Confirm New Password</label>
+            <input type="password" id="cp-confirm" autocomplete="new-password" class="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-500" placeholder="">
+          </div>
+          <div id="cp-error" class="text-sm text-red-400 hidden"></div>
+          <button type="submit" class="px-4 py-2 text-sm bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors">Update password</button>
+        </form>
+      </div>
+
       <!-- User Management (admin only) -->
       <div id="user-management" class="bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6 hidden">
         <h3 class="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4" data-i18n="s_user_mgmt_title">User Management</h3>
@@ -466,6 +493,31 @@ tailwind.config = {
             </div>
             <button onclick="addUser()" class="px-4 py-2 text-sm bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors" data-i18n="add_user_btn">Add User</button>
           </div>
+        </div>
+
+        <!-- Invite Codes -->
+        <div class="border-t border-slate-800 pt-4 mt-4">
+          <h4 class="text-sm font-medium text-slate-300 mb-1">Invite Codes</h4>
+          <p class="text-xs text-slate-500 mb-3">Share a code so someone can self-register with the role you choose. Single-use by default.</p>
+          <div class="flex items-end flex-wrap gap-2 mb-4">
+            <div>
+              <label class="block text-xs text-slate-500 mb-1">Role</label>
+              <select id="invite-role" class="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm">
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-xs text-slate-500 mb-1">Max uses</label>
+              <input type="number" id="invite-max-uses" min="1" value="1" class="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm w-24">
+            </div>
+            <div>
+              <label class="block text-xs text-slate-500 mb-1">Expires in (days, 0 = never)</label>
+              <input type="number" id="invite-expires-days" min="0" value="7" class="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm w-28">
+            </div>
+            <button onclick="generateInviteCode()" class="px-4 py-2 text-sm bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors">Generate</button>
+          </div>
+          <div id="invite-codes-list" class="space-y-2"></div>
         </div>
       </div>
 
@@ -1316,12 +1368,20 @@ function showLoginModal() {
     const regLink = document.getElementById('login-register-link');
     regLink.classList.remove('hidden');
     if (!data.has_users) {
+      // First-run: default to the register form with a welcome banner. The
+      // login form has nothing to log into yet, so showing it first wastes a
+      // click and hides the actual setup step behind a "Register" link.
       document.getElementById('login-subtitle').textContent = t('create_admin_account');
-      // Hide invite code field for first user.
+      document.getElementById('first-run-banner').classList.remove('hidden');
       const invField = document.getElementById('invite-code-field');
       if (invField) invField.classList.add('hidden');
+      showRegisterForm();
+      // No accounts exist — hide the "Back to login" link in register form.
+      const backLinks = document.querySelectorAll('#register-form a[onclick*="showLoginForm"]');
+      backLinks.forEach(a => a.parentElement.classList.add('hidden'));
     } else {
       document.getElementById('login-subtitle').textContent = t('login_subtitle');
+      document.getElementById('first-run-banner').classList.add('hidden');
     }
   }).catch(() => {});
 
@@ -2257,10 +2317,72 @@ async function loadSettings() {
   loadSources();
   loadTOTPStatus();
   loadSettingToggles();
+  showChangePasswordIfMultiUser();
   if (state.currentRole === 'admin') {
     loadUsers();
+    loadInviteCodes();
   }
 }
+
+// Show the self-service change-password card only when the user is logged in
+// against a DB account. Env-credential single-user installs can't change pw
+// here — those creds are sourced from AUTH_USERNAME / AUTH_PASSWORD.
+async function showChangePasswordIfMultiUser() {
+  try {
+    const data = await apiJson('/api/auth/status');
+    if (data.authenticated && data.user_id) {
+      document.getElementById('change-password-section').classList.remove('hidden');
+    }
+  } catch (err) {}
+}
+
+document.getElementById('change-password-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const errEl = document.getElementById('cp-error');
+  errEl.classList.add('hidden');
+
+  const current = document.getElementById('cp-current').value;
+  const next = document.getElementById('cp-new').value;
+  const confirm = document.getElementById('cp-confirm').value;
+
+  if (!current || !next || !confirm) {
+    errEl.textContent = 'All three fields are required';
+    errEl.classList.remove('hidden');
+    return;
+  }
+  if (next.length < 6) {
+    errEl.textContent = 'New password must be at least 6 characters';
+    errEl.classList.remove('hidden');
+    return;
+  }
+  if (next !== confirm) {
+    errEl.textContent = 'New password and confirmation do not match';
+    errEl.classList.remove('hidden');
+    return;
+  }
+
+  try {
+    const res = await apiJson('/api/me/password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ current_password: current, new_password: next }),
+    });
+    if (res.success) {
+      document.getElementById('cp-current').value = '';
+      document.getElementById('cp-new').value = '';
+      document.getElementById('cp-confirm').value = '';
+      showToast('Password updated', 'success');
+    } else {
+      errEl.textContent = res.error || 'Failed to update password';
+      errEl.classList.remove('hidden');
+    }
+  } catch (err) {
+    if (err.message !== 'Unauthorized') {
+      errEl.textContent = 'Failed to update password';
+      errEl.classList.remove('hidden');
+    }
+  }
+});
 
 // Settings keys backed by an input in the Integrations section, grouped by the
 // integration name passed to saveIntegration().
@@ -2662,6 +2784,95 @@ async function addUser() {
     }
   } catch (err) {
     showToast(t('failed_create_user'), 'error');
+  }
+}
+
+// ============================================================
+// INVITE CODES (admin)
+// ============================================================
+async function loadInviteCodes() {
+  try {
+    const data = await apiJson('/api/invites');
+    const list = data.invites || [];
+    const el = document.getElementById('invite-codes-list');
+    if (list.length === 0) {
+      el.innerHTML = `<p class="text-xs text-slate-500">No invite codes yet.</p>`;
+      return;
+    }
+    el.innerHTML = list.map(inv => {
+      const expires = inv.expires_at
+        ? new Date(inv.expires_at * 1000).toLocaleDateString()
+        : 'Never';
+      const usesLabel = `${inv.uses} / ${inv.max_uses}`;
+      const exhausted = inv.uses >= inv.max_uses;
+      return `
+        <div class="flex items-center justify-between bg-slate-800/50 rounded-lg px-3 py-2 text-sm">
+          <div class="flex items-center gap-3 flex-1 min-w-0">
+            <code class="text-indigo-400 font-mono text-xs truncate">${escapeHtml(inv.code)}</code>
+            <span class="text-xs text-slate-500">role: ${escapeHtml(inv.role)}</span>
+            <span class="text-xs ${exhausted ? 'text-amber-400' : 'text-slate-500'}">uses: ${usesLabel}</span>
+            <span class="text-xs text-slate-500">expires: ${escapeHtml(expires)}</span>
+          </div>
+          <div class="flex items-center gap-1 flex-shrink-0">
+            <button onclick="copyInviteCode('${escapeHtml(inv.code)}')" class="px-2 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-slate-300 rounded transition-colors" title="Copy">Copy</button>
+            <button onclick="revokeInviteCode(${inv.id})" class="px-2 py-1 text-xs bg-red-700 hover:bg-red-600 text-white rounded transition-colors" title="Revoke">Revoke</button>
+          </div>
+        </div>`;
+    }).join('');
+  } catch (err) {
+    if (err.message !== 'Unauthorized') {
+      document.getElementById('invite-codes-list').innerHTML = `<p class="text-xs text-red-400">Failed to load invite codes</p>`;
+    }
+  }
+}
+
+async function generateInviteCode() {
+  const role = document.getElementById('invite-role').value;
+  const maxUses = parseInt(document.getElementById('invite-max-uses').value, 10) || 1;
+  const expiresDays = parseInt(document.getElementById('invite-expires-days').value, 10) || 0;
+  const expiresIn = expiresDays > 0 ? expiresDays * 86400 : 0;
+  try {
+    const res = await apiJson('/api/invites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role, max_uses: maxUses, expires_in: expiresIn }),
+    });
+    if (res.success) {
+      showToast('Invite code generated', 'success');
+      loadInviteCodes();
+    } else {
+      showToast(res.error || 'Failed to generate', 'error');
+    }
+  } catch (err) {
+    if (err.message !== 'Unauthorized') {
+      showToast('Failed to generate invite', 'error');
+    }
+  }
+}
+
+async function copyInviteCode(code) {
+  try {
+    await navigator.clipboard.writeText(code);
+    showToast('Copied', 'success');
+  } catch (err) {
+    showToast('Copy failed — select the code manually', 'warning');
+  }
+}
+
+async function revokeInviteCode(id) {
+  if (!confirm('Revoke this invite code? Anyone with it will no longer be able to register.')) return;
+  try {
+    const res = await apiJson(`/api/invites/${id}`, { method: 'DELETE' });
+    if (res.success) {
+      showToast('Invite revoked', 'success');
+      loadInviteCodes();
+    } else {
+      showToast(res.error || 'Failed to revoke', 'error');
+    }
+  } catch (err) {
+    if (err.message !== 'Unauthorized') {
+      showToast('Failed to revoke', 'error');
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Three small UX gaps in the existing multi-user system. The DB schema, register flow, invite-code backend, and admin user list were already there — these changes make them actually usable from the UI.

### 1. Self-service password change

- **New endpoint:** `POST /api/me/password` (new, auth required, not admin-only).
- Verifies the current password before applying the new one, so a stolen session cookie can't silently lock the user out.
- New **"Change Password"** card in the Settings tab (current / new / confirm). Hidden for env-credential / single-user installs where there's no DB account to mutate.

### 2. Invite codes UI

- New section inside Settings → User Management (admin only).
- Generate with role (user/admin), max uses, and expires-in (days). Lists existing codes with uses counter and revoke. "Copy" uses `navigator.clipboard`.
- Wires the existing GET/POST/DELETE `/api/invites` endpoints — no backend change.

### 3. First-run hint on login modal

- Kept deliberately small (a banner, not a wizard) — matches the Jellyfin / Jellyseerr first-run convention.
- When `has_users=false`: shows the register form by default with a small "Setup" badge and welcome line; hides the "back to login" link (no accounts to log into yet).
- Once an admin exists, the modal returns to its normal login-first behavior.

## Test plan

Backend unit tests (`internal/api/me_password_test.go`):
- [x] happy path — current correct, new pw applied
- [x] wrong current password — 401 AND hash must not mutate (security regression guard)
- [x] missing auth context — 401
- [x] short new password (<6) — 400
- [x] missing required fields — 400
- [x] all pre-existing tests still pass with `-race`

Local E2E against a freshly-booted binary:
- [x] first-run banner element renders, `has_users=false`
- [x] first register creates admin, `has_users` flips true
- [x] change own password: happy, wrong-current (401), short-new (400), unauthed (401)
- [x] old password rejected after change; new password works
- [x] generate invite (role=user, max_uses=2, expires=7d), register two users with it, third attempt blocked with "has been used", revoke clears the list

## Out of scope

- **Username change** — touches sessions, audit logs, OIDC mapping, TOTP issuer label. Non-trivial and a much rarer ask. Separate issue if there's demand.
- **Pre-merge / first-run wizard with multiple steps** — deliberately avoided; a single banner respects the existing aesthetic better than a multi-page setup flow.