### PR TITLE
Add OpenAPI 3.1 spec at /api/openapi.json

### DIFF
--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed openapi.json
+var openapiSpec []byte
+
+// handleOpenAPI serves the OpenAPI 3.1 spec describing Librarr's HTTP API.
+// AI agents and tooling can introspect this to discover endpoints, request
+// shapes, and response shapes without prior knowledge of the codebase.
+func (s *Server) handleOpenAPI(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.Header().Set("Cache-Control", "public, max-age=600")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(openapiSpec)
+}

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -1,0 +1,318 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Librarr API",
+    "description": "Self-hosted book, audiobook, and manga search and download manager — the *arr for books. The HTTP/JSON API powers both the SPA and any external tooling (CLI scripts, AI agents, *arr-family integrations).",
+    "version": "1.x",
+    "license": {"name": "MIT", "identifier": "MIT"}
+  },
+  "servers": [
+    {"url": "http://localhost:5050", "description": "Default local install"}
+  ],
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Api-Key",
+        "description": "API key for programmatic access. Also accepted via ?apikey= query parameter."
+      },
+      "session": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "librarr_session",
+        "description": "Set by POST /api/login. Used by the SPA."
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "required": ["success", "error"],
+        "properties": {
+          "success": {"type": "boolean", "enum": [false]},
+          "error":   {"type": "string"}
+        }
+      },
+      "SearchResult": {
+        "type": "object",
+        "description": "A single search hit. Fields are populated per driver — direct-download drivers omit seeders/leechers; torrent drivers usually omit MD5.",
+        "properties": {
+          "title":        {"type": "string"},
+          "author":       {"type": "string"},
+          "source":       {"type": "string", "description": "Driver identifier (e.g. annas, gutenberg, prowlarr)."},
+          "size":         {"type": "integer", "format": "int64"},
+          "size_human":   {"type": "string"},
+          "seeders":      {"type": "integer"},
+          "leechers":     {"type": "integer"},
+          "magnet_url":   {"type": "string"},
+          "download_url": {"type": "string", "format": "uri"},
+          "md5":          {"type": "string"},
+          "info_hash":    {"type": "string"},
+          "url":          {"type": "string", "format": "uri"},
+          "cover_url":    {"type": "string", "format": "uri"},
+          "format":       {"type": "string", "description": "epub, pdf, mobi, mp3, m4b, cbz, etc."},
+          "score":        {"type": "integer", "description": "0-100 confidence score."},
+          "media_type":   {"type": "string", "enum": ["ebook", "audiobook", "manga"]}
+        }
+      },
+      "WishlistItem": {
+        "type": "object",
+        "required": ["title"],
+        "properties": {
+          "id":         {"type": "integer", "format": "int64"},
+          "title":      {"type": "string"},
+          "author":     {"type": "string"},
+          "media_type": {"type": "string", "enum": ["ebook", "audiobook", "manga"]}
+        }
+      },
+      "PaginatedList": {
+        "type": "object",
+        "description": "Standard list response shape used across /api/library, /api/activity, etc.",
+        "properties": {
+          "items":  {"type": "array", "items": {"type": "object"}},
+          "total":  {"type": "integer"},
+          "limit":  {"type": "integer"},
+          "offset": {"type": "integer"}
+        }
+      }
+    }
+  },
+  "security": [{"apiKey": []}, {"session": []}],
+  "paths": {
+    "/api/health": {
+      "get": {
+        "summary": "Health check",
+        "description": "Liveness probe. Returns 200 if the binary is running. No auth required.",
+        "security": [],
+        "responses": {"200": {"description": "OK"}}
+      }
+    },
+    "/api/openapi.json": {
+      "get": {
+        "summary": "This OpenAPI spec",
+        "description": "Returns this OpenAPI 3.1 document. AI agents can fetch this to discover endpoints.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "OpenAPI 3.1 document",
+            "content": {"application/json": {"schema": {"type": "object"}}}
+          }
+        }
+      }
+    },
+    "/api/auth/status": {
+      "get": {"summary": "Current auth state"}
+    },
+    "/api/login":  {"post": {"summary": "Session login", "security": []}},
+    "/api/login/totp": {"post": {"summary": "TOTP 2FA verification step", "security": []}},
+    "/api/logout": {"post": {"summary": "End session"}},
+    "/api/register": {"post": {"summary": "Register new user (requires invite code when configured)", "security": []}},
+
+    "/api/search": {
+      "get": {
+        "summary": "Search ebooks across all configured sources",
+        "parameters": [
+          {"name": "q",      "in": "query", "required": true,  "schema": {"type": "string"}, "description": "Search query."},
+          {"name": "author", "in": "query", "required": false, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results":        {"type": "array", "items": {"$ref": "#/components/schemas/SearchResult"}},
+                    "search_time_ms": {"type": "integer"},
+                    "sources":        {"type": "array", "items": {"type": "object"}}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/search/audiobooks": {
+      "get": {
+        "summary": "Search audiobooks",
+        "parameters": [
+          {"name": "q",      "in": "query", "required": true,  "schema": {"type": "string"}},
+          {"name": "author", "in": "query", "required": false, "schema": {"type": "string"}}
+        ]
+      }
+    },
+    "/api/search/manga": {
+      "get": {
+        "summary": "Search manga",
+        "parameters": [{"name": "q", "in": "query", "required": true, "schema": {"type": "string"}}]
+      }
+    },
+
+    "/api/sources": {
+      "get": {
+        "summary": "List configured search sources + health",
+        "description": "Returns each registered driver with enabled state, circuit-breaker status, last success/fail counters. Useful for AI agents debugging why a source isn't returning results."
+      }
+    },
+
+    "/api/library": {
+      "get": {
+        "summary": "List ebooks in the library",
+        "parameters": [
+          {"name": "limit",  "in": "query", "schema": {"type": "integer", "minimum": 1, "maximum": 500, "default": 50}},
+          {"name": "offset", "in": "query", "schema": {"type": "integer", "minimum": 0, "default": 0}},
+          {"name": "type",   "in": "query", "schema": {"type": "string", "enum": ["ebook", "audiobook", "manga"]}},
+          {"name": "tag",    "in": "query", "schema": {"type": "string"}, "description": "Filter by tag name."}
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated library items",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PaginatedList"}}}
+          }
+        }
+      }
+    },
+    "/api/library/audiobooks": {"get": {"summary": "List audiobooks (proxied from Audiobookshelf when configured)"}},
+    "/api/library/manga":      {"get": {"summary": "List manga"}},
+    "/api/library/book/{id}":      {"delete": {"summary": "Remove an ebook from the library", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}]}},
+    "/api/library/audiobook/{id}": {"delete": {"summary": "Remove an audiobook", "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}]}},
+    "/api/library/{id}/tags":      {"get":  {"summary": "List tags for a library item"}, "post": {"summary": "Add a tag to a library item"}},
+    "/api/library/{id}/tags/{tagId}": {"delete": {"summary": "Remove a tag from a library item"}},
+
+    "/api/wishlist": {
+      "get":  {"summary": "List wishlist items"},
+      "post": {
+        "summary": "Add a wishlist item",
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WishlistItem"}}}
+        },
+        "responses": {
+          "201": {"description": "Created"},
+          "400": {"description": "Validation error", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}}
+        }
+      }
+    },
+    "/api/wishlist/{id}": {
+      "delete": {
+        "summary": "Delete a wishlist item",
+        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "integer"}}]
+      }
+    },
+
+    "/api/requests": {
+      "get":  {"summary": "List requests"},
+      "post": {"summary": "Create a request"}
+    },
+    "/api/requests/{id}":          {"get": {"summary": "Get a request"}, "delete": {"summary": "Delete a request"}},
+    "/api/requests/{id}/search":   {"post": {"summary": "Trigger a search for a request"}},
+    "/api/requests/{id}/download": {"post": {"summary": "Trigger a download for a request"}},
+
+    "/api/downloads": {
+      "get": {"summary": "List active and recent downloads"}
+    },
+    "/api/downloads/torrent/{hash}": {"delete": {"summary": "Remove a torrent download"}},
+    "/api/downloads/novel/{jobID}":  {"delete": {"summary": "Remove a novel download job"}},
+    "/api/downloads/jobs/{id}/retry": {"post": {"summary": "Retry a failed download"}},
+    "/api/downloads/clear":           {"post": {"summary": "Clear finished downloads"}},
+
+    "/api/quality-profiles":       {"get": {"summary": "List quality profiles"}, "post": {"summary": "Create quality profile"}},
+    "/api/quality-profiles/{id}":  {"delete": {"summary": "Delete quality profile"}},
+    "/api/quality-profiles/default": {"get": {"summary": "Default profile"}},
+    "/api/release-profiles":       {"get": {"summary": "List release profiles"}, "post": {"summary": "Create"}},
+    "/api/release-profiles/{id}":  {"delete": {"summary": "Delete release profile"}},
+    "/api/blocklist":              {"get": {"summary": "List blocklist entries"}, "post": {"summary": "Add an entry"}},
+    "/api/blocklist/{id}":         {"delete": {"summary": "Remove an entry"}},
+    "/api/tags":                   {"get": {"summary": "List tags"}, "post": {"summary": "Create a tag"}},
+    "/api/tags/{id}":              {"delete": {"summary": "Delete a tag"}},
+
+    "/api/users":                  {"get": {"summary": "List users (admin only)"}},
+    "/api/users/{id}":             {
+      "patch":  {"summary": "Update user role/status (admin only)"},
+      "delete": {"summary": "Delete user (admin only). Refuses to delete the last admin (HTTP 409)."}
+    },
+    "/api/invites":                {"get": {"summary": "List invites (admin)"}, "post": {"summary": "Create invite (admin)"}},
+    "/api/invites/{id}":           {"delete": {"summary": "Revoke invite (admin)"}},
+
+    "/api/totp/setup":   {"post": {"summary": "Generate TOTP secret + QR code"}},
+    "/api/totp/verify":  {"post": {"summary": "Verify TOTP code and enable 2FA"}},
+    "/api/totp/disable": {"post": {"summary": "Disable TOTP"}},
+    "/api/totp/status":  {"get":  {"summary": "Check if TOTP is enabled"}},
+
+    "/api/notifications":              {"get": {"summary": "List notifications"}},
+    "/api/notifications/{id}":         {"delete": {"summary": "Delete notification"}},
+    "/api/notifications/{id}/read":    {"put": {"summary": "Mark as read"}},
+    "/api/notifications/read-all":     {"put": {"summary": "Mark all as read"}},
+    "/api/notifications/unread":       {"get": {"summary": "Unread count"}},
+
+    "/api/webhooks":      {"get": {"summary": "List webhooks"}, "post": {"summary": "Create webhook"}},
+    "/api/webhooks/{id}": {"delete": {"summary": "Delete webhook"}},
+    "/api/webhooks/test": {"post": {"summary": "Send a test payload"}},
+
+    "/api/stats":    {"get": {"summary": "Library statistics"}},
+    "/api/activity": {"get": {"summary": "Recent activity log"}},
+    "/api/history":  {"get": {"summary": "Reading history"}},
+    "/api/history/{id}":   {"delete": {"summary": "Delete history entry"}},
+    "/api/history/stats":  {"get": {"summary": "Reading-history statistics"}},
+
+    "/api/authors":         {"get": {"summary": "List monitored authors"}},
+    "/api/authors/{id}":    {"delete": {"summary": "Unmonitor an author"}},
+    "/api/series":          {"get": {"summary": "List series with completeness"}},
+    "/api/series/{name}/missing": {"get": {"summary": "Missing volumes in a series"}},
+
+    "/api/settings":           {"get": {"summary": "Get configuration"}, "post": {"summary": "Update configuration (admin)"}},
+    "/api/config":             {"get": {"summary": "Public-safe config subset"}},
+    "/api/scheduler/status":   {"get": {"summary": "Wishlist scheduler status"}},
+    "/api/admin/dashboard":    {"get": {"summary": "Admin dashboard data"}},
+    "/api/admin/health":       {"get": {"summary": "Admin health summary"}},
+    "/api/admin/activity":     {"get": {"summary": "Admin-level activity log"}},
+    "/api/admin/bulk/retry":   {"post": {"summary": "Bulk retry failed downloads"}},
+    "/api/admin/bulk/cancel":  {"post": {"summary": "Bulk cancel active downloads"}},
+    "/api/backup":             {"get": {"summary": "Download a database backup"}},
+    "/api/backup/list":        {"get": {"summary": "List existing backups"}},
+    "/api/restore":            {"post": {"summary": "Restore from a backup file (admin)"}},
+
+    "/api/import/csv":         {"post": {"summary": "Import wishlist from a Goodreads/StoryGraph CSV"}},
+    "/api/import/goodreads":   {"post": {"summary": "Import Goodreads shelves"}},
+    "/api/import/storygraph":  {"post": {"summary": "Import StoryGraph reading list"}},
+    "/api/export/library":     {"get": {"summary": "Export library as JSON/CSV"}},
+    "/api/export/wishlist":    {"get": {"summary": "Export wishlist as JSON/CSV"}},
+    "/api/export/requests":    {"get": {"summary": "Export requests as JSON/CSV"}},
+
+    "/torznab/api": {
+      "get": {
+        "summary": "Torznab indexer API",
+        "description": "Lets Prowlarr / Readarr / other *arr apps use Librarr as a Torznab indexer.",
+        "parameters": [
+          {"name": "t",      "in": "query", "schema": {"type": "string", "enum": ["caps", "search", "book", "audio"]}},
+          {"name": "q",      "in": "query", "schema": {"type": "string"}},
+          {"name": "title",  "in": "query", "schema": {"type": "string"}},
+          {"name": "author", "in": "query", "schema": {"type": "string"}},
+          {"name": "apikey", "in": "query", "schema": {"type": "string"}, "description": "Required when TORZNAB_API_KEY is set."}
+        ],
+        "responses": {
+          "200": {"description": "Torznab XML (RSS feed or caps document)", "content": {"application/xml": {}}}
+        }
+      }
+    },
+    "/api": {
+      "get": {
+        "summary": "Torznab alias for Prowlarr indexer discovery",
+        "description": "Prowlarr probes /api during indexer discovery; this is the same handler as /torznab/api."
+      }
+    },
+    "/opds": {
+      "get": {
+        "summary": "OPDS 1.2 catalog root",
+        "description": "Browse your library from e-reader apps (KOReader, Moon+ Reader, Librera).",
+        "security": [],
+        "responses": {"200": {"description": "Atom feed", "content": {"application/atom+xml": {}}}}
+      }
+    },
+    "/metrics": {
+      "get": {"summary": "Prometheus metrics", "security": []}
+    }
+  }
+}

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleOpenAPI confirms the embedded OpenAPI spec is well-formed JSON
+// and that key fields are present. Catches regressions where a bad edit to
+// openapi.json gets shipped.
+func TestHandleOpenAPI(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/openapi.json", nil)
+	rr := httptest.NewRecorder()
+	s := &Server{}
+	s.handleOpenAPI(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("HTTP %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var spec struct {
+		OpenAPI    string                 `json:"openapi"`
+		Info       map[string]interface{} `json:"info"`
+		Paths      map[string]interface{} `json:"paths"`
+		Components struct {
+			Schemas         map[string]interface{} `json:"schemas"`
+			SecuritySchemes map[string]interface{} `json:"securitySchemes"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &spec); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if !strings.HasPrefix(spec.OpenAPI, "3.") {
+		t.Errorf("openapi field = %q, want 3.x", spec.OpenAPI)
+	}
+	if title, _ := spec.Info["title"].(string); !strings.Contains(title, "Librarr") {
+		t.Errorf("info.title = %q, want to contain Librarr", title)
+	}
+	if len(spec.Paths) < 50 {
+		t.Errorf("expected at least 50 documented paths, got %d", len(spec.Paths))
+	}
+	// Spot-check the major endpoints every AI agent will care about exist.
+	for _, p := range []string{"/api/health", "/api/search", "/api/library", "/api/wishlist", "/torznab/api"} {
+		if _, ok := spec.Paths[p]; !ok {
+			t.Errorf("expected path %q in spec", p)
+		}
+	}
+	if _, ok := spec.Components.SecuritySchemes["apiKey"]; !ok {
+		t.Error("expected apiKey securityScheme")
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -183,6 +183,11 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /health", s.handleHealth)
 	s.mux.HandleFunc("GET /api/health", s.handleHealth)
 
+	// OpenAPI 3.1 spec — AI agents / tooling can introspect this to
+	// discover endpoints, request shapes, and response shapes without
+	// prior knowledge of the codebase.
+	s.mux.HandleFunc("GET /api/openapi.json", s.handleOpenAPI)
+
 	// Authentication.
 	s.mux.HandleFunc("POST /api/login", handleLogin(s.cfg, s.db, s.sessions))
 	s.mux.HandleFunc("POST /api/login/totp", handleLoginTOTP(s.db, s.sessions))


### PR DESCRIPTION
## Summary
Backport of the OpenAPI 3.1 endpoint pattern from gamarr v1.2.0. AI agents and external tooling can fetch the embedded spec at `/api/openapi.json` and discover Librarr's HTTP API without prior knowledge of the codebase.

## What changed
- **`internal/api/openapi.json`** — hand-curated OpenAPI 3.1 covering **84 endpoints** across:
  - Auth (session login, TOTP 2FA, OIDC/SSO callbacks)
  - Search (ebook / audiobook / manga)
  - Sources health + driver registry
  - Library (list / pagination / tag-filter, per-media-type deletes, tag attach/detach)
  - Wishlist + requests (full CRUD + search/download triggers)
  - Downloads (per-item + bulk retry/cancel)
  - Quality + release profiles, blocklist, tags
  - User management, invites, TOTP setup/verify/disable
  - Notifications (list/read/unread/delete)
  - Webhooks (CRUD + test)
  - History + reading stats
  - Authors + series (gap detection)
  - Settings + admin (dashboard, health, activity, backup, restore)
  - Import (Goodreads / StoryGraph / CSV) + Export (library / wishlist / requests)
  - Torznab API + `/api` alias for Prowlarr discovery
  - OPDS catalog
  - `/metrics`
- **`internal/api/openapi.go`** — embeds the JSON via `//go:embed`, serves at `/api/openapi.json` with a 10-min `Cache-Control`. No auth required (the spec is public metadata).
- Route mounted right after `/api/health` in `router.go`.
- `TestHandleOpenAPI` covers content-type, JSON validity, presence of major endpoints, both security schemes (apiKey + session).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test -race -count=1 ./...` all clean.
- [x] All existing tests pass.
- [x] `python3 -c "import json; json.load(open('internal/api/openapi.json'))"` validates as well-formed.
- [x] New `TestHandleOpenAPI` passes — exercises the handler end-to-end via `httptest`, deserializes the response, spot-checks `/api/health`, `/api/search`, `/api/library`, `/api/wishlist`, `/torznab/api` are present.

## Backwards compatibility
Strictly additive — one new route at `/api/openapi.json`. No existing route, env var, or response shape changed.