### PR TITLE
Auto-derive SETTINGS_FILE from LIBRARR_DB_PATH; probe writability at startup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/JeremiahM37/librarr/internal/sources"
@@ -187,7 +189,56 @@ type Config struct {
 func Load() *Config {
 	cfg := buildFromEnv()
 	cfg.applySettingsFileOverrides()
+	cfg.probeSettingsFileWritable()
 	return cfg
+}
+
+// deriveSettingsFile resolves the path the binary will read+write for UI-saved
+// settings. If SETTINGS_FILE is explicitly set, that wins. Otherwise we
+// co-locate settings.json next to the SQLite database so deployments that mount
+// their data volume at a non-default path (e.g. /data/librarr/ instead of
+// /data/) don't silently fail on every "Save Settings" click.
+//
+// The historical default of /data/settings.json is preserved when
+// LIBRARR_DB_PATH is also at the default /data/librarr.db — so existing
+// deployments with no env-var changes behave identically.
+func deriveSettingsFile(explicit, dbPath string) string {
+	if explicit != "" {
+		return explicit
+	}
+	dir := filepath.Dir(dbPath)
+	if dir == "" || dir == "." {
+		dir = "/data"
+	}
+	return filepath.Join(dir, "settings.json")
+}
+
+// probeSettingsFileWritable logs a clear error at startup if the binary can't
+// write SettingsFile. The previous behaviour was to discover this on the first
+// /api/settings POST, hours after boot, which silently broke the UI's Save
+// Settings button.
+func (c *Config) probeSettingsFileWritable() {
+	if c.SettingsFile == "" {
+		return
+	}
+	dir := filepath.Dir(c.SettingsFile)
+	if dir == "" {
+		return
+	}
+	probe := filepath.Join(dir, ".librarr-settings-write-probe")
+	f, err := os.OpenFile(probe, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		slog.Error(
+			"settings file location is not writable — UI 'Save Settings' will fail until this is fixed",
+			"path", c.SettingsFile,
+			"parent_dir", dir,
+			"error", err,
+			"hint", "set SETTINGS_FILE to a path inside a writable volume, or mount your data dir at the SettingsFile parent",
+		)
+		return
+	}
+	_ = f.Close()
+	_ = os.Remove(probe)
 }
 
 // buildFromEnv returns a Config populated from environment variables and defaults.
@@ -300,7 +351,7 @@ func buildFromEnv() *Config {
 
 		LNCrawlContainer: getEnv("LNCRAWL_CONTAINER", ""),
 
-		SettingsFile: getEnv("SETTINGS_FILE", "/data/settings.json"),
+		SettingsFile: deriveSettingsFile(os.Getenv("SETTINGS_FILE"), getEnv("LIBRARR_DB_PATH", "/data/librarr.db")),
 
 		OIDCEnabled:         getEnvBool("OIDC_ENABLED", false),
 		OIDCProviderName:    getEnv("OIDC_PROVIDER_NAME", "SSO"),

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -1,0 +1,16 @@
+package config
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+// Silence slog during test runs — the new settings-file write-probe
+// intentionally emits ERROR logs for non-writable paths, which would
+// otherwise spam test output.
+func TestMain(m *testing.M) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	os.Exit(m.Run())
+}

--- a/internal/config/settings_path_test.go
+++ b/internal/config/settings_path_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDeriveSettingsFile covers the path-resolution rules for SETTINGS_FILE.
+//
+// Regression: a v1.1.0 deployment with LIBRARR_DB_PATH=/data/librarr/librarr.db
+// silently failed every UI "Save Settings" click because the binary defaulted
+// SettingsFile to /data/settings.json (a path inside a non-writable parent).
+// Auto-deriving from the DB-path dir prevents that whole class of misconfig.
+func TestDeriveSettingsFile(t *testing.T) {
+	cases := []struct {
+		name     string
+		explicit string
+		dbPath   string
+		want     string
+	}{
+		{"explicit env wins over derived", "/custom/settings.json", "/data/librarr/librarr.db", "/custom/settings.json"},
+		{"default db path -> /data/settings.json (historical)", "", "/data/librarr.db", "/data/settings.json"},
+		{"db in subdir -> derives next to it", "", "/data/librarr/librarr.db", "/data/librarr/settings.json"},
+		{"db at root of mount -> derives next to it", "", "/var/lib/librarr/db.sqlite", "/var/lib/librarr/settings.json"},
+		{"relative db path -> falls back to /data", "", "librarr.db", "/data/settings.json"},
+		{"empty db path -> /data fallback", "", "", "/data/settings.json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveSettingsFile(tc.explicit, tc.dbPath)
+			if got != tc.want {
+				t.Errorf("deriveSettingsFile(%q, %q) = %q, want %q", tc.explicit, tc.dbPath, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProbeSettingsFileWritable confirms the startup write probe does NOT
+// crash on a non-writable path (must be tolerant — just logs a clear error).
+func TestProbeSettingsFileWritable_NonWritable(t *testing.T) {
+	// /proc is read-only on Linux; on darwin, /System. Find a path we know
+	// won't be writable for tests.
+	dir := t.TempDir()
+	roDir := filepath.Join(dir, "read-only")
+	if err := os.Mkdir(roDir, 0o555); err != nil { // r-xr-xr-x, no write
+		t.Fatal(err)
+	}
+	cfg := &Config{SettingsFile: filepath.Join(roDir, "settings.json")}
+
+	// Must not panic. The error is reported via slog (silenced by main_test.go).
+	cfg.probeSettingsFileWritable()
+}
+
+// TestProbeSettingsFileWritable_Writable confirms the probe leaves no
+// litter behind on the happy path.
+func TestProbeSettingsFileWritable_Writable(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{SettingsFile: filepath.Join(dir, "settings.json")}
+	cfg.probeSettingsFileWritable()
+
+	// The probe file must be cleaned up.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "settings.json" {
+			t.Errorf("probe left behind unexpected entry: %s", e.Name())
+		}
+	}
+}
+
+// TestProbeSettingsFileWritable_EmptyPath is a defensive guard — empty
+// SettingsFile should be a no-op, not a crash.
+func TestProbeSettingsFileWritable_EmptyPath(t *testing.T) {
+	cfg := &Config{SettingsFile: ""}
+	cfg.probeSettingsFileWritable() // must not panic
+}


### PR DESCRIPTION
## Summary
Fixes a silent-failure-on-save bug surfaced while auditing the v1.1.0 prod deployment.

## Root cause
The historical default for `SETTINGS_FILE` is `/data/settings.json`, set independently of `LIBRARR_DB_PATH` (default `/data/librarr.db`). Deployments that organize their data volume at a non-default path — e.g. mount at `/data/librarr/` and set `LIBRARR_DB_PATH=/data/librarr/librarr.db` — end up with `SettingsFile` pointing at a directory that isn't a mount. Every UI "Save Settings" click then silently 500s with `permission denied`, only visible if you tail the container logs.

This isn't a config error users should have to discover by hand; it's a class of misconfig the binary can detect at boot.

## What this PR changes
- **`deriveSettingsFile()`** — when `SETTINGS_FILE` is unset, derive it from `filepath.Dir(LIBRARR_DB_PATH) + "/settings.json"`. Default deployment (`LIBRARR_DB_PATH=/data/librarr.db`) still resolves to `/data/settings.json` bit-identically — no behavior change for users who already work.
- **`probeSettingsFileWritable()`** runs at `Load()` and logs a clear `ERROR` with a remediation hint if `SettingsFile`'s parent dir can't be written. Surfaces the misconfig at boot instead of waiting for a UI save attempt.
- **TestMain** added to `internal/config` (matches other packages) so the intentional `ERROR` logs the probe emits during tests don't show as noise.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test -race -count=1 ./...` all clean.
- [x] **6 new path-resolution subtests** (explicit env wins, default db path keeps historical default, db-in-subdir derives next to it, db-at-root-of-mount, relative path fallback, empty path fallback).
- [x] **3 new probe scenarios** — writable directory (no error, no litter left behind), non-writable directory (logs ERROR, doesn't panic), empty path (no-op).
- [x] Existing config tests still pass under the new TestMain.

## Backwards compatibility
Strictly preserved for users who haven't changed `LIBRARR_DB_PATH`. The default `LIBRARR_DB_PATH=/data/librarr.db` still derives `SettingsFile=/data/settings.json`. Users who set both env vars explicitly are unaffected. The new behavior only kicks in for the previously-broken case (custom `LIBRARR_DB_PATH`, unset `SETTINGS_FILE`).