### PR TITLE
Make /api/openapi.json auth-exempt

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -163,14 +163,15 @@ func (s *SessionStore) Delete(token string) {
 
 // exemptPaths are paths that do not require authentication.
 var exemptPaths = map[string]bool{
-	"/":                true, // Web UI (handles its own login)
-	"/health":          true,
-	"/api/health":      true,
-	"/api/login":       true,
-	"/api/login/totp":  true,
-	"/api/register":    true,
-	"/api/auth/status": true,
-	"/readyz":          true,
+	"/":                 true, // Web UI (handles its own login)
+	"/health":           true,
+	"/api/health":       true,
+	"/api/login":        true,
+	"/api/login/totp":   true,
+	"/api/register":     true,
+	"/api/auth/status":  true,
+	"/readyz":           true,
+	"/api/openapi.json": true, // public API schema for AI/tooling discovery
 }
 
 // isExempt returns true if the path does not require auth.

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -194,10 +194,15 @@ func TestIsExempt(t *testing.T) {
 		{"/opds/books", true},
 		{"/metrics", true},
 		{"/auth/oidc/callback", true},
+		// OpenAPI spec is public so AI agents / tooling can introspect the
+		// API without prior auth (same precedent as /metrics and /health).
+		{"/api/openapi.json", true},
 		{"/api/search", false},
 		{"/api/download", false},
 		{"/api/library", false},
 		{"/api/users", false},
+		// Suffix-attack guard — only the exact path should be exempt.
+		{"/api/openapi.jsonx", false},
 		// Prowlarr's indexer-discovery probe hits bare /api — must be exempt
 		// because the Torznab handler does its own apikey check. But the
 		// exemption MUST be exact-path only; any /api/... JSON endpoint


### PR DESCRIPTION
## Summary
Makes the OpenAPI spec auth-exempt so AI agents and tooling can introspect the API without prior credentials — same precedent as `/metrics` and `/health`.

## Why
The spec endpoint exists for discovery. Currently the auth middleware returns 401 before the handler runs, defeating its purpose. A noted follow-up from PR #44.

## Test plan
- [x] Added `/api/openapi.json` to `exemptPaths`.
- [x] `TestIsExempt` extended with positive assertion + a suffix-attack guard (`/api/openapi.jsonx` must still require auth).
- [x] `go test -race -count=1 ./...` clean.