### PR TITLE
fix: oidc config is hidden behind auth

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -631,15 +631,22 @@ func handleRegister(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 	}
 }
 
-// handleAuthStatus returns the current auth state (are there users? is user logged in?)
-func handleAuthStatus(database *db.DB, sessions *SessionStore) http.HandlerFunc {
+// handleAuthStatus returns the current auth state (are there users? is user logged in? is oidc available?)
+func handleAuthStatus(cfg *config.Config, database *db.DB, sessions *SessionStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userCount, _ := database.CountUsers()
 
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"multi_user":    userCount > 0,
 			"has_users":     userCount > 0,
 			"authenticated": false,
+			"oidc_enabled":  false,
+		}
+
+		// OIDC hints
+		if cfg != nil && cfg.HasOIDC() {
+			resp["oidc_enabled"] = true
+			resp["oidc_provider_name"] = cfg.OIDCProviderName
 		}
 
 		// Check session.

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,8 +1,15 @@
 package api
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
 )
 
 func TestSessionStore_CreateAndGet(t *testing.T) {
@@ -215,6 +222,94 @@ func TestIsExempt(t *testing.T) {
 			result := isExempt(tt.path)
 			if result != tt.expected {
 				t.Errorf("isExempt(%q) = %v, want %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHandleAuthStatus_OIDCHints(t *testing.T) {
+	// /api/auth/status is the canonical pre-auth endpoint the login modal
+	// hits to decide whether to render the SSO button. /api/config is gated
+	// behind the multi-user middleware once any user exists, so the modal
+	// MUST be able to read the OIDC hint here or the button silently
+	// disappears after the first user registers.
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	sessions := NewSessionStore()
+
+	tests := []struct {
+		name             string
+		cfg              *config.Config
+		wantEnabled      bool
+		wantProviderName string
+	}{
+		{
+			name:        "nil config",
+			cfg:         nil,
+			wantEnabled: false,
+		},
+		{
+			name:        "OIDC disabled",
+			cfg:         &config.Config{OIDCEnabled: false},
+			wantEnabled: false,
+		},
+		{
+			name: "OIDC partially configured (no client secret)",
+			cfg: &config.Config{
+				OIDCEnabled:      true,
+				OIDCIssuer:       "https://idp.example.com",
+				OIDCClientID:     "client",
+				OIDCProviderName: "Ignored",
+			},
+			wantEnabled: false,
+		},
+		{
+			name: "OIDC fully configured",
+			cfg: &config.Config{
+				OIDCEnabled:      true,
+				OIDCIssuer:       "https://idp.example.com",
+				OIDCClientID:     "client",
+				OIDCClientSecret: "secret",
+				OIDCProviderName: "PocketID",
+			},
+			wantEnabled:      true,
+			wantProviderName: "PocketID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/auth/status", nil)
+			rr := httptest.NewRecorder()
+			handleAuthStatus(tt.cfg, database, sessions)(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+			}
+			var resp map[string]any
+			if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			enabled, _ := resp["oidc_enabled"].(bool)
+			if enabled != tt.wantEnabled {
+				t.Errorf("oidc_enabled = %v, want %v", enabled, tt.wantEnabled)
+			}
+			if tt.wantEnabled {
+				if got, _ := resp["oidc_provider_name"].(string); got != tt.wantProviderName {
+					t.Errorf("oidc_provider_name = %q, want %q", got, tt.wantProviderName)
+				}
+				// MUST NOT leak the client secret on the public endpoint.
+				for k, v := range resp {
+					if s, ok := v.(string); ok && s == "secret" {
+						t.Errorf("response leaks secret-like value at key %q", k)
+					}
+				}
+			} else if _, present := resp["oidc_provider_name"]; present {
+				t.Errorf("oidc_provider_name MUST be absent when OIDC is disabled, got %v", resp["oidc_provider_name"])
 			}
 		})
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -193,7 +193,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /api/login/totp", handleLoginTOTP(s.db, s.sessions))
 	s.mux.HandleFunc("POST /api/register", handleRegister(s.db, s.sessions))
 	s.mux.HandleFunc("POST /api/logout", handleLogout(s.sessions, s.db))
-	s.mux.HandleFunc("GET /api/auth/status", handleAuthStatus(s.db, s.sessions))
+	s.mux.HandleFunc("GET /api/auth/status", handleAuthStatus(s.cfg, s.db, s.sessions))
 
 	// User management (admin only).
 	s.mux.HandleFunc("GET /api/users", requireAdmin(handleListUsers(s.db)))

--- a/web/index.html
+++ b/web/index.html
@@ -1386,7 +1386,7 @@ function showLoginModal() {
   }).catch(() => {});
 
   // Check OIDC config.
-  fetch('/api/config', { credentials: 'include' }).then(r => r.json()).then(data => {
+  fetch('/api/auth/status', { credentials: 'include' }).then(r => r.json()).then(data => {
     if (data.oidc_enabled) {
       document.getElementById('login-oidc-btn').classList.remove('hidden');
       document.getElementById('oidc-login-link').textContent = t('login_with', {provider: data.oidc_provider_name || 'SSO'});


### PR DESCRIPTION
In the existing implementation the oidc config is fetched from the `/auth/config` endpoint which is hidden behind the auth middleware.

This change makes it inaccesible for the unauthenticated user to access OIDC provider.

Moved the oidc config hints to the `/api/auth/status` which is already used.

Opening the `/api/config` would openly leak info about configured torrent, prowlarr, etc