### PR TITLE
fix: route imported audiobooks/manga to correct tabs (#49)

### DIFF
--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -21,7 +21,15 @@ func (s *Server) handleLibrary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// /api/library is the ebooks tab; default to media_type="ebook" so
+	// audiobooks/manga imported into the local DB don't bleed into this
+	// view. Callers that genuinely want every row can pass ?type=all.
 	mediaType := r.URL.Query().Get("type")
+	if mediaType == "" {
+		mediaType = "ebook"
+	} else if mediaType == "all" {
+		mediaType = ""
+	}
 	limit := queryBoundedInt(r, "limit", 50, 1, 500)
 	offset := queryBoundedInt(r, "offset", 0, 0, 1_000_000)
 	tagFilter := r.URL.Query().Get("tag")
@@ -85,6 +93,44 @@ func (s *Server) handleLibrary(w http.ResponseWriter, r *http.Request) {
 		"total":  total,
 		"limit":  limit,
 		"offset": offset,
+	})
+}
+
+// serveLocalLibraryByMediaType is the fallback used by /api/library/audiobooks
+// and /api/library/manga when ABS / Kavita aren't configured. Response shape
+// matches the ABS handler (items/total/page/pages) so the UI's existing
+// pagination code works against both code paths.
+func (s *Server) serveLocalLibraryByMediaType(w http.ResponseWriter, r *http.Request, mediaType string) {
+	const pageSize = 100
+	page := queryInt(r, "page", 1)
+	if page < 1 {
+		page = 1
+	}
+	offset := (page - 1) * pageSize
+
+	items, err := s.db.GetItems(mediaType, pageSize, offset)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"error": err.Error(),
+		})
+		return
+	}
+	total, _ := s.db.CountItems(mediaType)
+
+	jsonItems := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		jsonItems = append(jsonItems, db.ItemToJSON(item))
+	}
+	pages := 0
+	if total > 0 {
+		pages = int(math.Ceil(float64(total) / float64(pageSize)))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"items": jsonItems,
+		"total": total,
+		"page":  page,
+		"pages": pages,
 	})
 }
 

--- a/internal/api/library_external.go
+++ b/internal/api/library_external.go
@@ -55,13 +55,12 @@ type absSeries struct {
 
 func (s *Server) handleLibraryAudiobooks(w http.ResponseWriter, r *http.Request) {
 	if !s.cfg.HasAudiobookshelf() {
-		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"items": []interface{}{},
-			"total": 0,
-			"page":  1,
-			"pages": 0,
-			"error": "Audiobookshelf not configured",
-		})
+		// Issue #49: when ABS isn't configured, surface audiobooks that
+		// were imported into the local DB (e.g. via /api/import/files
+		// or the curl-based bulk import flow) rather than returning an
+		// empty list. Without this fallback those items only appear
+		// under /api/library and get mislabeled as ebooks in the UI.
+		s.serveLocalLibraryByMediaType(w, r, "audiobook")
 		return
 	}
 
@@ -185,11 +184,10 @@ func (s *Server) handleLibraryAudiobooks(w http.ResponseWriter, r *http.Request)
 
 func (s *Server) handleLibraryManga(w http.ResponseWriter, r *http.Request) {
 	if !s.cfg.HasKavita() {
-		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"items": []interface{}{},
-			"total": 0,
-			"error": "Kavita not configured",
-		})
+		// Issue #49: same as audiobooks — fall back to local DB so manga
+		// imported via /api/import/files is visible in its own tab
+		// instead of leaking into /api/library.
+		s.serveLocalLibraryByMediaType(w, r, "manga")
 		return
 	}
 

--- a/internal/api/library_media_type_test.go
+++ b/internal/api/library_media_type_test.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+// libraryMediaTypeTestSetup creates a server with three library items
+// (one ebook, one audiobook, one manga) imported into the local DB.
+// ABS and Kavita are deliberately left unconfigured so the local-DB
+// fallback paths are exercised — this is the exact configuration in
+// which the issue #49 reproducer ran.
+func libraryMediaTypeTestSetup(t *testing.T) *Server {
+	t.Helper()
+	database, err := db.New(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	items := []models.LibraryItem{
+		{Title: "An Ebook", Author: "E. Bookworm", FilePath: "/x/ebook.epub", FileFormat: "epub", MediaType: "ebook", Source: "manual_import"},
+		{Title: "An Audiobook", Author: "A. Reader", FilePath: "/x/audio.m4b", FileFormat: "m4b", MediaType: "audiobook", Source: "manual_import"},
+		{Title: "Some Manga", Author: "M. Artist", FilePath: "/x/manga.cbz", FileFormat: "cbz", MediaType: "manga", Source: "manual_import"},
+	}
+	for i := range items {
+		if _, err := database.AddItem(&items[i]); err != nil {
+			t.Fatalf("AddItem(%s): %v", items[i].Title, err)
+		}
+	}
+
+	return &Server{
+		cfg: &config.Config{}, // ABSURL, ABSToken, KavitaURL, etc. all empty
+		db:  database,
+	}
+}
+
+// decodeLibraryListBody pulls the items array out of a /api/library* response
+// and returns the (title, media_type) pairs for assertion.
+func decodeLibraryListBody(t *testing.T, body []byte) []struct{ Title, MediaType string } {
+	t.Helper()
+	var resp struct {
+		Items []map[string]interface{} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, body)
+	}
+	out := make([]struct{ Title, MediaType string }, 0, len(resp.Items))
+	for _, it := range resp.Items {
+		title, _ := it["title"].(string)
+		mt, _ := it["media_type"].(string)
+		out = append(out, struct{ Title, MediaType string }{title, mt})
+	}
+	return out
+}
+
+// TestLibraryEbooks_ExcludesAudiobooksAndManga is the regression test for
+// issue #49: a curl-imported library where everything ended up showing
+// under the "Ebooks" tab. The UI's ebooks tab calls GET /api/library
+// with no `type` filter; before the fix the handler returned every row
+// in library_items regardless of media_type.
+func TestLibraryEbooks_ExcludesAudiobooksAndManga(t *testing.T) {
+	s := libraryMediaTypeTestSetup(t)
+
+	req := httptest.NewRequest("GET", "/api/library", nil)
+	rr := httptest.NewRecorder()
+	s.handleLibrary(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("HTTP %d: %s", rr.Code, rr.Body.String())
+	}
+	items := decodeLibraryListBody(t, rr.Body.Bytes())
+	if len(items) != 1 {
+		t.Fatalf("expected exactly 1 item under default /api/library (ebooks only), got %d: %+v", len(items), items)
+	}
+	if items[0].MediaType != "ebook" {
+		t.Errorf("expected ebook, got media_type=%q (title=%q)", items[0].MediaType, items[0].Title)
+	}
+}
+
+// TestLibraryAudiobooks_FallsBackToLocalDB covers the second half of issue #49:
+// audiobooks imported into the local DB were invisible because the audiobooks
+// endpoint short-circuited to ABS and returned an empty list when ABS was
+// unconfigured. With the fix it falls back to library_items filtered by
+// media_type="audiobook".
+func TestLibraryAudiobooks_FallsBackToLocalDB(t *testing.T) {
+	s := libraryMediaTypeTestSetup(t)
+
+	req := httptest.NewRequest("GET", "/api/library/audiobooks", nil)
+	rr := httptest.NewRecorder()
+	s.handleLibraryAudiobooks(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("HTTP %d: %s", rr.Code, rr.Body.String())
+	}
+	items := decodeLibraryListBody(t, rr.Body.Bytes())
+	if len(items) != 1 {
+		t.Fatalf("expected 1 audiobook from local DB, got %d: %+v", len(items), items)
+	}
+	if items[0].MediaType != "audiobook" {
+		t.Errorf("expected audiobook, got media_type=%q (title=%q)", items[0].MediaType, items[0].Title)
+	}
+}
+
+// TestLibraryManga_FallsBackToLocalDB — mirror of the audiobooks case for
+// the manga endpoint, which short-circuited to Kavita.
+func TestLibraryManga_FallsBackToLocalDB(t *testing.T) {
+	s := libraryMediaTypeTestSetup(t)
+
+	req := httptest.NewRequest("GET", "/api/library/manga", nil)
+	rr := httptest.NewRecorder()
+	s.handleLibraryManga(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("HTTP %d: %s", rr.Code, rr.Body.String())
+	}
+	items := decodeLibraryListBody(t, rr.Body.Bytes())
+	if len(items) != 1 {
+		t.Fatalf("expected 1 manga from local DB, got %d: %+v", len(items), items)
+	}
+	if items[0].MediaType != "manga" {
+		t.Errorf("expected manga, got media_type=%q (title=%q)", items[0].MediaType, items[0].Title)
+	}
+}
+
+// TestLibraryEbooks_ExplicitTypeOverrideStillWorks confirms the existing
+// `?type=` query param keeps working — important because the OPDS feed and
+// the wishlist/scheduler use it explicitly to ask for a specific media type.
+func TestLibraryEbooks_ExplicitTypeOverrideStillWorks(t *testing.T) {
+	s := libraryMediaTypeTestSetup(t)
+
+	req := httptest.NewRequest("GET", "/api/library?type=audiobook", nil)
+	rr := httptest.NewRecorder()
+	s.handleLibrary(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("HTTP %d: %s", rr.Code, rr.Body.String())
+	}
+	items := decodeLibraryListBody(t, rr.Body.Bytes())
+	if len(items) != 1 || items[0].MediaType != "audiobook" {
+		t.Errorf("expected single audiobook for ?type=audiobook, got: %+v", items)
+	}
+}


### PR DESCRIPTION
Closes #49.

## Bug
Curl-imported audiobooks and manga all showed up under the Ebooks tab.

## Cause
- `/api/library` had no default `media_type` filter → returned every row.
- `/api/library/audiobooks` and `/api/library/manga` returned an empty list when ABS/Kavita weren't configured → local-DB items invisible.

## Fix
- Default `/api/library` to `media_type=ebook` (`?type=all` is the escape hatch).
- Audiobooks/manga endpoints fall back to local DB when their external service is absent, via a shared `serveLocalLibraryByMediaType` helper.

## Tests (`internal/api/library_media_type_test.go`)
Four regression tests — three fail on `main`, all pass with the fix:
- `TestLibraryEbooks_ExcludesAudiobooksAndManga`
- `TestLibraryAudiobooks_FallsBackToLocalDB`
- `TestLibraryManga_FallsBackToLocalDB`
- `TestLibraryEbooks_ExplicitTypeOverrideStillWorks` (control — `?type=audiobook` still works for OPDS/scheduler)

