### PR TITLE
separate Prowlarr audiobook results from ABB

### DIFF
--- a/internal/search/prowlarr.go
+++ b/internal/search/prowlarr.go
@@ -167,7 +167,7 @@ func (p *Prowlarr) doSearch(ctx context.Context, params prowlarrSearchParams) ([
 	for _, item := range items {
 		source := "torrent"
 		if p.tab == "audiobook" {
-			source = "audiobook"
+			source = "prowlarr_audiobooks"
 		} else if p.tab == "manga" {
 			source = "prowlarr_manga"
 		}

--- a/internal/search/prowlarr_test.go
+++ b/internal/search/prowlarr_test.go
@@ -149,8 +149,8 @@ func TestProwlarr_SearchAudiobook(t *testing.T) {
 	}
 
 	for _, r := range results {
-		if r.Source != "audiobook" {
-			t.Errorf("expected source audiobook, got %s", r.Source)
+		if r.Source != "prowlarr_audiobooks" {
+			t.Errorf("expected source prowlarr_audiobooks, got %s", r.Source)
 		}
 	}
 }

--- a/internal/search/scorer.go
+++ b/internal/search/scorer.go
@@ -263,7 +263,7 @@ func extractFormatFromTitle(title string) string {
 // guessMediaType guesses the media type from the result source.
 func guessMediaType(result models.SearchResult) string {
 	switch result.Source {
-	case "audiobook":
+	case "audiobook", "prowlarr_audiobooks":
 		return "audiobook"
 	case "prowlarr_manga", "nyaa_manga", "mangadex", "annas_manga":
 		return "manga"

--- a/internal/search/scorer_test.go
+++ b/internal/search/scorer_test.go
@@ -128,6 +128,18 @@ func TestScoreResult_SizeAudiobook(t *testing.T) {
 	}
 }
 
+func TestScoreResult_SizeProwlarrAudiobookWithoutMediaType(t *testing.T) {
+	result := models.SearchResult{
+		Title:  "Test Audiobook",
+		Source: "prowlarr_audiobooks",
+		Size:   500e6, // 500MB
+	}
+	sb := ScoreResult(result, "test audiobook", "")
+	if sb.SizeScore != 10 {
+		t.Errorf("500MB prowlarr audiobook should score 10, got %f", sb.SizeScore)
+	}
+}
+
 func TestScoreResult_ConfidenceLevels(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## What changed
- Prowlarr audiobook search results now use the distinct source label `prowlarr_audiobooks` instead of `audiobook`.
- Updated the corresponding unit test to assert the new label.

## Why
Librarr already treats `audiobook` as the ABB source. That causes Prowlarr audiobook NZB results to be filtered as if they were ABB rows, which drops them when they do not have ABB-specific metadata or seeders.

## Impact
- Prowlarr audiobook results from indexers such as `nzb.life` now survive librarr's filter path.
- ABB search behavior is unchanged.
- The change is scoped to librarr result labeling only; no Prowlarr configuration changes are required.

## Validation
- `go test ./internal/search -run 'TestProwlarr|TestIsNZBURL'`
- Built a temporary image from the patched source and ran a smoke test against `GET /api/search/audiobooks?q=The Martian`.
- Confirmed the returned results include `source: "prowlarr_audiobooks"` and `indexer: "Nzb.life"`.