### PR TITLE
docs: document REMOVE_TORRENT_AFTER_IMPORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ All configuration is via environment variables. Every variable has a sensible de
 | `QB_MANGA_SAVE_PATH` | `/manga-incoming` | Manga download path |
 | `QB_MANGA_CATEGORY` | `manga` | Torrent category for manga |
 | `QB_PRIORITY` | `1` | Download client priority (lower = preferred) |
+| `REMOVE_TORRENT_AFTER_IMPORT` | `true` | Remove torrent from qBittorrent after a successful import. Set to `false` to keep seeding (required for private trackers with seed-time minimums). |
 | `SABNZBD_URL` | | SABnzbd URL |
 | `SABNZBD_API_KEY` | | SABnzbd API key |
 | `SABNZBD_CATEGORY` | `librarr` | NZB download category |

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -123,8 +123,8 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 		return
 	}
 
-	// Optionally remove torrent from qBit after import. Default is to leave
-	// it seeding — users who want auto-removal set REMOVE_TORRENT_AFTER_IMPORT=true.
+	// Optionally remove torrent from qBit after import. Default is to remove;
+	// set REMOVE_TORRENT_AFTER_IMPORT=false to keep seeding (e.g. private trackers).
 	if w.cfg.RemoveTorrentAfterImport {
 		if err := w.qb.DeleteTorrent(t.Hash, false); err != nil {
 			slog.Warn("failed to remove torrent after import", "hash", t.Hash, "error", err)


### PR DESCRIPTION
The flag and UI toggle already exist; users hitting #59 just couldn't find it. Add it to the README env table and fix a watcher comment that claimed the default was to keep seeding (it isn't — default is `true`/remove).

Closes #59

## Test plan
- [x] `go test ./internal/config/... ./internal/download/... ./internal/api/...`
- [x] Default startup → `GET /api/settings` returns `remove_torrent_after_import: true`
- [x] `REMOVE_TORRENT_AFTER_IMPORT=false` startup → returns `false`
- [x] `POST /api/settings` toggle round-trips both ways