### PR TITLE
Fix Z-Library downloads and harden parser fallbacks

### DIFF
--- a/internal/api/csv.go
+++ b/internal/api/csv.go
@@ -127,7 +127,7 @@ func (s *Server) handleCSVImport(w http.ResponseWriter, r *http.Request) {
 				if dlURL == "" {
 					dlURL = best.EpubURL
 				}
-				s.downloadMgr.StartDirectDownload(dlURL, title, best.Source, best.SourceID)
+				s.downloadMgr.StartDirectDownload(dlURL, title, best.Source, best.SourceID, best.Author)
 			} else if best.MagnetURL != "" || best.InfoHash != "" {
 				url := best.MagnetURL
 				if url == "" {

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -167,7 +167,7 @@ func (s *Server) handleDirectDownloadReq(w http.ResponseWriter, req models.Downl
 			return
 		}
 
-		job, err := s.downloadMgr.StartDirectDownload(dlURL, req.Title, req.Source, sourceID)
+		job, err := s.downloadMgr.StartDirectDownload(dlURL, req.Title, req.Source, sourceID, req.Author)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
 				"success": false,
@@ -283,6 +283,9 @@ func (s *Server) handleCheckDuplicate(w http.ResponseWriter, r *http.Request) {
 }
 
 func extractSourceID(req models.DownloadRequest) string {
+	if req.SourceID != "" {
+		return req.SourceID
+	}
 	if req.MD5 != "" {
 		return req.MD5
 	}

--- a/internal/api/requests.go
+++ b/internal/api/requests.go
@@ -466,6 +466,8 @@ func (s *Server) processApprovedRequest(req *models.Request) {
 	dlReq := models.DownloadRequest{
 		Source:           chosen.Source,
 		Title:            chosen.Title,
+		Author:           chosen.Author,
+		SourceID:         chosen.SourceID,
 		DownloadURL:      chosen.DownloadURL,
 		MagnetURL:        chosen.MagnetURL,
 		InfoHash:         chosen.InfoHash,
@@ -547,7 +549,7 @@ func (s *Server) processApprovedRequest(req *models.Request) {
 			if fileURL == "" {
 				fileURL = dlReq.URL
 			}
-			job, err := s.downloadMgr.StartDirectDownload(fileURL, dlReq.Title, dlReq.Source, "")
+			job, err := s.downloadMgr.StartDirectDownload(fileURL, dlReq.Title, dlReq.Source, dlReq.SourceID, dlReq.Author)
 			if err != nil {
 				s.failRequest(req, fmt.Sprintf("Download failed: %v", err))
 				return

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -95,13 +95,14 @@ func (d *DB) migrate() error {
 		`CREATE TABLE IF NOT EXISTS download_jobs (
 			id TEXT PRIMARY KEY,
 			title TEXT NOT NULL DEFAULT '',
-			source TEXT NOT NULL DEFAULT '',
-			status TEXT NOT NULL DEFAULT 'queued',
-			detail TEXT NOT NULL DEFAULT '',
-			error TEXT NOT NULL DEFAULT '',
-			url TEXT NOT NULL DEFAULT '',
-			md5 TEXT NOT NULL DEFAULT '',
-			media_type TEXT NOT NULL DEFAULT 'ebook',
+				source TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'queued',
+				detail TEXT NOT NULL DEFAULT '',
+				error TEXT NOT NULL DEFAULT '',
+				url TEXT NOT NULL DEFAULT '',
+				md5 TEXT NOT NULL DEFAULT '',
+				source_id TEXT NOT NULL DEFAULT '',
+				media_type TEXT NOT NULL DEFAULT 'ebook',
 			retry_count INTEGER NOT NULL DEFAULT 0,
 			max_retries INTEGER NOT NULL DEFAULT 2,
 			status_history TEXT NOT NULL DEFAULT '[]',
@@ -314,6 +315,7 @@ func (d *DB) migrate() error {
 	// and are ignored.
 	addColumns := []string{
 		`ALTER TABLE download_jobs ADD COLUMN status_history TEXT NOT NULL DEFAULT '[]'`,
+		`ALTER TABLE download_jobs ADD COLUMN source_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE activity_log ADD COLUMN user TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE reading_history ADD COLUMN status TEXT NOT NULL DEFAULT ''`,
 	}
@@ -877,10 +879,10 @@ func (d *DB) SaveJob(job *models.DownloadJob) error {
 	}
 
 	_, err := d.db.Exec(
-		`INSERT OR REPLACE INTO download_jobs (id, title, source, status, detail, error, url, md5, media_type, retry_count, max_retries, status_history, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT OR REPLACE INTO download_jobs (id, title, source, status, detail, error, url, md5, source_id, media_type, retry_count, max_retries, status_history, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		job.ID, job.Title, job.Source, job.Status, job.Detail, job.Error,
-		job.URL, job.MD5, job.MediaType,
+		job.URL, job.MD5, job.SourceID, job.MediaType,
 		job.RetryCount, job.MaxRetries, string(historyJSON),
 		float64(job.CreatedAt.Unix()), float64(job.UpdatedAt.Unix()),
 	)
@@ -901,13 +903,13 @@ func (d *DB) UpdateJobStatus(id, status, detail, errMsg string) error {
 
 // GetJob retrieves a download job by ID.
 func (d *DB) GetJob(id string) (*models.DownloadJob, error) {
-	row := d.db.QueryRow("SELECT id, title, source, status, detail, error, url, md5, media_type, retry_count, max_retries, status_history, created_at, updated_at FROM download_jobs WHERE id = ?", id)
+	row := d.db.QueryRow("SELECT id, title, source, status, detail, error, url, md5, source_id, media_type, retry_count, max_retries, status_history, created_at, updated_at FROM download_jobs WHERE id = ?", id)
 	return scanJob(row)
 }
 
 // GetJobs returns all download jobs.
 func (d *DB) GetJobs() ([]models.DownloadJob, error) {
-	rows, err := d.db.Query("SELECT id, title, source, status, detail, error, url, md5, media_type, retry_count, max_retries, status_history, created_at, updated_at FROM download_jobs ORDER BY created_at DESC")
+	rows, err := d.db.Query("SELECT id, title, source, status, detail, error, url, md5, source_id, media_type, retry_count, max_retries, status_history, created_at, updated_at FROM download_jobs ORDER BY created_at DESC")
 	if err != nil {
 		return nil, err
 	}
@@ -1073,7 +1075,7 @@ func scanJob(row *sql.Row) (*models.DownloadJob, error) {
 	var createdAt, updatedAt float64
 	var historyJSON string
 	err := row.Scan(&j.ID, &j.Title, &j.Source, &j.Status, &j.Detail, &j.Error,
-		&j.URL, &j.MD5, &j.MediaType,
+		&j.URL, &j.MD5, &j.SourceID, &j.MediaType,
 		&j.RetryCount, &j.MaxRetries, &historyJSON, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err
@@ -1091,7 +1093,7 @@ func scanJobFromRows(rows *sql.Rows) (*models.DownloadJob, error) {
 	var createdAt, updatedAt float64
 	var historyJSON string
 	err := rows.Scan(&j.ID, &j.Title, &j.Source, &j.Status, &j.Detail, &j.Error,
-		&j.URL, &j.MD5, &j.MediaType,
+		&j.URL, &j.MD5, &j.SourceID, &j.MediaType,
 		&j.RetryCount, &j.MaxRetries, &historyJSON, &createdAt, &updatedAt)
 	if err != nil {
 		return nil, err

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -165,6 +165,7 @@ func TestDownloadJobs_CRUD(t *testing.T) {
 		Status:     "queued",
 		URL:        "https://example.com",
 		MD5:        "abc123",
+		SourceID:   "zlibrary-42-abc123",
 		MediaType:  "ebook",
 		MaxRetries: 2,
 		CreatedAt:  time.Now(),
@@ -186,6 +187,9 @@ func TestDownloadJobs_CRUD(t *testing.T) {
 		}
 		if got.Source != "annas" {
 			t.Errorf("expected source annas, got %s", got.Source)
+		}
+		if got.SourceID != "zlibrary-42-abc123" {
+			t.Errorf("expected source_id zlibrary-42-abc123, got %s", got.SourceID)
 		}
 	})
 

--- a/internal/download/direct.go
+++ b/internal/download/direct.go
@@ -2,10 +2,14 @@ package download
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/cookiejar"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -13,6 +17,7 @@ import (
 
 	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/organize"
+	"github.com/JeremiahM37/librarr/internal/zlibraryparse"
 )
 
 // DirectDownloader handles direct HTTP file downloads (Anna's Archive, Gutenberg, etc.).
@@ -27,6 +32,8 @@ func NewDirectDownloader(cfg *config.Config, client *http.Client) *DirectDownloa
 }
 
 var getLinkRe = regexp.MustCompile(`href="(get\.php\?md5=[^"]+)"`)
+
+const zlibraryUserAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:151.0) Gecko/20100101 Firefox/151.0"
 
 // mirrors returns the list of libgen-style ads.php/get.php mirrors to try, in
 // order. Sourced from the runtime registry (cfg.Sources.LibgenMirrors).
@@ -113,28 +120,78 @@ func (d *DirectDownloader) fetchLibgenDownloadURL(md5 string, progressFn func(st
 
 // DownloadFromURL downloads a file from any direct URL.
 func (d *DirectDownloader) DownloadFromURL(fileURL, title string, progressFn func(string)) (string, int64, error) {
-	return d.downloadFile(fileURL, title, progressFn)
+	return d.downloadFileWithClient(d.client, fileURL, title, progressFn)
+}
+
+func (d *DirectDownloader) DownloadFromZLibrary(fileURL, title, author, sourceID string, progressFn func(string)) (string, int64, error) {
+	if progressFn != nil {
+		progressFn("Signing in to Z-Library...")
+	}
+
+	client, err := d.zlibraryClient()
+	if err != nil {
+		return "", 0, err
+	}
+	if err := d.zlibraryLogin(client); err != nil {
+		return "", 0, err
+	}
+
+	if progressFn != nil {
+		progressFn("Resolving Z-Library download link...")
+	}
+	resolvedURL, err := d.resolveZLibraryDownloadURL(client, fileURL, title, author, sourceID)
+	if err != nil {
+		return "", 0, err
+	}
+	return d.downloadFileWithClientAndUserAgent(client, resolvedURL, title, progressFn, zlibraryUserAgent)
 }
 
 func (d *DirectDownloader) downloadFile(fileURL, title string, progressFn func(string)) (string, int64, error) {
+	return d.downloadFileWithClient(d.client, fileURL, title, progressFn)
+}
+
+func (d *DirectDownloader) downloadFileWithClient(client *http.Client, fileURL, title string, progressFn func(string)) (string, int64, error) {
+	return d.downloadFileWithClientAndUserAgent(client, fileURL, title, progressFn, d.cfg.UserAgent)
+}
+
+func (d *DirectDownloader) downloadFileWithClientAndUserAgent(client *http.Client, fileURL, title string, progressFn func(string), userAgent string) (string, int64, error) {
+	return d.downloadFileAttempt(client, fileURL, title, progressFn, true, userAgent)
+}
+
+func (d *DirectDownloader) downloadFileAttempt(client *http.Client, fileURL, title string, progressFn func(string), allowChallenge bool, userAgent string) (string, int64, error) {
 	req, err := http.NewRequest("GET", fileURL, nil)
 	if err != nil {
 		return "", 0, err
 	}
-	req.Header.Set("User-Agent", d.cfg.UserAgent)
+	req.Header.Set("User-Agent", userAgent)
 
-	resp, err := d.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", 0, fmt.Errorf("download file: %w", err)
 	}
 	defer resp.Body.Close()
+
+	contentType := resp.Header.Get("Content-Type")
+	if resp.StatusCode == http.StatusServiceUnavailable && strings.Contains(contentType, "text/html") && allowChallenge {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+		if token, ok := solveZLibraryChallenge(body); ok {
+			if progressFn != nil {
+				progressFn("Passing Z-Library browser check...")
+			}
+			if err := addCookie(client, fileURL, "c_token", token); err != nil {
+				return "", 0, err
+			}
+			_ = addCookie(client, fileURL, "c_time", "0.1")
+			return d.downloadFileAttempt(client, fileURL, title, progressFn, false, userAgent)
+		}
+		return "", 0, fmt.Errorf("zlibrary browser challenge changed or could not be solved")
+	}
 
 	if resp.StatusCode != 200 {
 		return "", 0, fmt.Errorf("download HTTP %d", resp.StatusCode)
 	}
 
 	// If we got an HTML response, try to find the actual download link.
-	contentType := resp.Header.Get("Content-Type")
 	if strings.Contains(contentType, "text/html") {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024)) // 2MB max for HTML
 		bodyStr := string(body)
@@ -148,11 +205,14 @@ func (d *DirectDownloader) downloadFile(fileURL, title string, progressFn func(s
 		if len(getLink) < 2 {
 			fileLink := regexp.MustCompile(`href="(https?://[^"]*\.(epub|pdf|mobi)[^"]*)"`).FindStringSubmatch(bodyStr)
 			if len(fileLink) < 2 {
+				if dlLink := zlibraryparse.FindDownloadLinkInHTML(fileURL, body); dlLink != "" {
+					return d.downloadFileWithClientAndUserAgent(client, dlLink, title, progressFn, userAgent)
+				}
 				return "", 0, fmt.Errorf("no download link found in HTML response")
 			}
-			return d.downloadFile(fileLink[1], title, progressFn)
+			return d.downloadFileWithClientAndUserAgent(client, fileLink[1], title, progressFn, userAgent)
 		}
-		return d.downloadFile(getLink[1], title, progressFn)
+		return d.downloadFileWithClientAndUserAgent(client, getLink[1], title, progressFn, userAgent)
 	}
 
 	// Save to incoming directory.
@@ -212,6 +272,251 @@ func (d *DirectDownloader) downloadFile(fileURL, title string, progressFn func(s
 	}
 
 	return filePath, written, nil
+}
+
+func (d *DirectDownloader) zlibraryClient() (*http.Client, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("zlibrary cookie jar: %w", err)
+	}
+	client := &http.Client{
+		Timeout:       d.client.Timeout,
+		CheckRedirect: d.client.CheckRedirect,
+		Jar:           jar,
+	}
+	if d.client.Transport != nil {
+		client.Transport = d.client.Transport
+	}
+	return client, nil
+}
+
+func (d *DirectDownloader) zlibraryBase() string {
+	if d.cfg.ZLibraryURL != "" {
+		return strings.TrimRight(d.cfg.ZLibraryURL, "/")
+	}
+	return strings.TrimRight(d.cfg.Sources.ZLibraryDefault, "/")
+}
+
+func (d *DirectDownloader) zlibraryLogin(client *http.Client) error {
+	baseURL := d.zlibraryBase()
+	form := url.Values{}
+	form.Set("isModal", "true")
+	form.Set("email", d.cfg.ZLibraryEmail)
+	form.Set("password", d.cfg.ZLibraryPassword)
+	form.Set("site_mode", "books")
+	form.Set("action", "login")
+	form.Set("redirectUrl", baseURL+"/")
+	form.Set("gg_json_mode", "1")
+
+	req, err := http.NewRequest("POST", baseURL+"/rpc.php", strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("zlibrary login request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+	req.Header.Set("User-Agent", zlibraryUserAgent)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("zlibrary login: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("zlibrary login HTTP %d", resp.StatusCode)
+	}
+
+	var loginResp struct {
+		Errors   []string `json:"errors"`
+		Response struct {
+			UserID  int    `json:"user_id"`
+			UserKey string `json:"user_key"`
+		} `json:"response"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return fmt.Errorf("zlibrary decode login: %w", err)
+	}
+	if len(loginResp.Errors) > 0 {
+		return fmt.Errorf("zlibrary login failed: %s", strings.Join(loginResp.Errors, "; "))
+	}
+	if loginResp.Response.UserID == 0 || loginResp.Response.UserKey == "" {
+		return fmt.Errorf("zlibrary login failed: missing session credentials")
+	}
+	return nil
+}
+
+func (d *DirectDownloader) resolveZLibraryDownloadURL(client *http.Client, currentURL, title, author, sourceID string) (string, error) {
+	baseURL := d.zlibraryBase()
+	if id, hash, ok := parseZLibrarySourceID(sourceID); ok {
+		return d.resolveZLibraryBookURL(client, baseURL, id, hash)
+	}
+
+	bookURL, err := d.resolveZLibraryBookFromSearch(client, baseURL, title, author)
+	if err == nil {
+		return bookURL, nil
+	}
+
+	if currentURL == "" {
+		return "", err
+	}
+	return currentURL, nil
+}
+
+func (d *DirectDownloader) resolveZLibraryBookURL(client *http.Client, baseURL string, id int, hash string) (string, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/eapi/book/%d/%s", baseURL, id, hash), nil)
+	if err != nil {
+		return "", fmt.Errorf("zlibrary detail request: %w", err)
+	}
+	req.Header.Set("User-Agent", zlibraryUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("zlibrary detail: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("zlibrary detail HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("zlibrary read detail: %w", err)
+	}
+	if dl, err := zlibraryparse.DetailDownloadFromJSON(body); err == nil && dl != "" {
+		return zlibraryparse.AbsoluteURL(baseURL, dl), nil
+	}
+	if dl := zlibraryparse.FindDownloadLinkInHTML(baseURL, body); dl != "" {
+		return dl, nil
+	}
+	return "", fmt.Errorf("zlibrary detail missing download link")
+}
+
+func (d *DirectDownloader) resolveZLibraryBookFromSearch(client *http.Client, baseURL, title, author string) (string, error) {
+	form := url.Values{}
+	query := strings.TrimSpace(title + " " + author)
+	form.Set("message", query)
+	form.Set("limit", "10")
+	form.Set("page", "1")
+
+	req, err := http.NewRequest("POST", baseURL+"/eapi/book/search", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("zlibrary search request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", zlibraryUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("zlibrary search: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("zlibrary search HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("zlibrary read search: %w", err)
+	}
+	if dl := zlibraryparse.FindDownloadLinkInHTML(baseURL, body); dl != "" {
+		return dl, nil
+	}
+	books, err := zlibraryparse.BooksFromJSON(body)
+	if err != nil {
+		return "", fmt.Errorf("zlibrary decode search: %w", err)
+	}
+
+	titleNorm := strings.ToLower(strings.TrimSpace(title))
+	authorNorm := strings.ToLower(strings.TrimSpace(author))
+	for _, book := range books {
+		if strings.ToLower(strings.TrimSpace(book.Title)) != titleNorm {
+			continue
+		}
+		if authorNorm != "" && !strings.Contains(strings.ToLower(book.Author), authorNorm) {
+			continue
+		}
+		if book.Hash != "" {
+			return d.resolveZLibraryBookURL(client, baseURL, book.ID, book.Hash)
+		}
+		if book.DL != "" {
+			return zlibraryparse.AbsoluteURL(baseURL, book.DL), nil
+		}
+	}
+	return "", fmt.Errorf("zlibrary search did not find an exact downloadable match")
+}
+
+func parseZLibrarySourceID(sourceID string) (int, string, bool) {
+	if !strings.HasPrefix(sourceID, "zlibrary-") {
+		return 0, "", false
+	}
+	rest := strings.TrimPrefix(sourceID, "zlibrary-")
+	parts := strings.SplitN(rest, "-", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return 0, "", false
+	}
+	var id int
+	if _, err := fmt.Sscanf(parts[0], "%d", &id); err != nil || id == 0 {
+		return 0, "", false
+	}
+	return id, parts[1], true
+}
+
+func solveZLibraryChallenge(body []byte) (string, bool) {
+	if !bytesContains(body, []byte("Checking your browser")) || !bytesContains(body, []byte("c_token=")) {
+		return "", false
+	}
+	seedMatch := regexp.MustCompile(`\['([A-F0-9]{40})','c_token=','array'\]`).FindSubmatch(body)
+	if len(seedMatch) < 2 {
+		return "", false
+	}
+	seed := string(seedMatch[1])
+	startIndex, ok := firstHexNibble(seed)
+	if !ok || startIndex >= sha1.Size-1 {
+		return "", false
+	}
+	for i := 0; i < 5_000_000; i++ {
+		value := fmt.Sprintf("%s%d", seed, i)
+		sum := sha1.Sum([]byte(value))
+		if sum[startIndex] == 0xb0 && sum[startIndex+1] == 0x0b {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func firstHexNibble(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	switch {
+	case s[0] >= '0' && s[0] <= '9':
+		return int(s[0] - '0'), true
+	case s[0] >= 'a' && s[0] <= 'f':
+		return int(s[0]-'a') + 10, true
+	case s[0] >= 'A' && s[0] <= 'F':
+		return int(s[0]-'A') + 10, true
+	default:
+		return 0, false
+	}
+}
+
+func addCookie(client *http.Client, rawURL, name, value string) error {
+	if client.Jar == nil {
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			return fmt.Errorf("create cookie jar: %w", err)
+		}
+		client.Jar = jar
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse cookie URL: %w", err)
+	}
+	client.Jar.SetCookies(parsed, []*http.Cookie{{Name: name, Value: value, Path: "/"}})
+	return nil
+}
+
+func bytesContains(haystack, needle []byte) bool {
+	return strings.Contains(string(haystack), string(needle))
 }
 
 // detectFileExtension inspects the first bytes of a file and returns the

--- a/internal/download/direct_test.go
+++ b/internal/download/direct_test.go
@@ -3,6 +3,7 @@ package download
 import (
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -189,6 +190,47 @@ func TestDownloadFile_UnknownFormatKeepsOriginalExt(t *testing.T) {
 	// should keep .pdf (the content-type-derived extension).
 	if !strings.HasSuffix(filePath, ".pdf") {
 		t.Errorf("unknown content should keep content-type extension .pdf, got: %s", filePath)
+	}
+}
+
+func TestResolveZLibraryBookFromSearchAcceptsResultShape(t *testing.T) {
+	var searchCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/eapi/book/search":
+			searchCalled = true
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if got := r.Form.Get("message"); got != "Seascraper Benjamin Wood" {
+				t.Fatalf("message = %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"success":1,"result":[{"id":118708376,"title":"Seascraper","author":"Benjamin Wood","dl":"/dl/from-result"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar: %v", err)
+	}
+	cfg := &config.Config{IncomingDir: t.TempDir(), UserAgent: "test"}
+	d := NewDirectDownloader(cfg, server.Client())
+	client := server.Client()
+	client.Jar = jar
+
+	resolved, err := d.resolveZLibraryBookFromSearch(client, server.URL, "Seascraper", "Benjamin Wood")
+	if err != nil {
+		t.Fatalf("resolveZLibraryBookFromSearch: %v", err)
+	}
+	if !searchCalled {
+		t.Fatal("search endpoint was not called")
+	}
+	if resolved != server.URL+"/dl/from-result" {
+		t.Fatalf("resolved = %q", resolved)
 	}
 }
 

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -93,20 +93,21 @@ func (m *Manager) StartNZBDownload(nzbURL, title string) (string, error) {
 }
 
 // StartDirectDownload starts a background download from a direct URL.
-func (m *Manager) StartDirectDownload(fileURL, title, source, sourceID string) (*models.DownloadJob, error) {
+func (m *Manager) StartDirectDownload(fileURL, title, source, sourceID, author string) (*models.DownloadJob, error) {
 	job := m.createJob(title, source, fileURL)
 	job.MediaType = "ebook"
+	job.SourceID = sourceID
 
 	if err := m.db.SaveJob(job); err != nil {
 		return nil, err
 	}
 
-	go m.runDirectDownload(job, fileURL, sourceID)
+	go m.runDirectDownload(job, fileURL, sourceID, author)
 	return job, nil
 }
 
 func (m *Manager) createJob(title, source, url string) *models.DownloadJob {
-	id := fmt.Sprintf("%x", time.Now().UnixNano()%0xFFFFFFFF)[:8]
+	id := fmt.Sprintf("%08x", time.Now().UnixNano()%0xFFFFFFFF)
 
 	job := &models.DownloadJob{
 		ID:         id,
@@ -200,7 +201,7 @@ func (m *Manager) RetryDeadLetterJob(jobID string) error {
 	if job.MD5 != "" {
 		go m.runAnnasDownload(job)
 	} else if job.URL != "" {
-		go m.runDirectDownload(job, job.URL, "")
+		go m.runDirectDownload(job, job.URL, job.SourceID, "")
 	}
 
 	return nil
@@ -290,10 +291,17 @@ func (m *Manager) runAnnasDownload(job *models.DownloadJob) {
 	}
 }
 
-func (m *Manager) runDirectDownload(job *models.DownloadJob, fileURL, sourceID string) {
+func (m *Manager) runDirectDownload(job *models.DownloadJob, fileURL, sourceID, authorHint string) {
 	m.updateJob(job, "downloading", "Downloading...", "")
 
-	filePath, fileSize, err := m.direct.DownloadFromURL(fileURL, job.Title, func(detail string) {
+	download := m.direct.DownloadFromURL
+	if job.Source == "zlibrary" {
+		download = func(url, title string, progressFn func(string)) (string, int64, error) {
+			return m.direct.DownloadFromZLibrary(url, title, authorHint, sourceID, progressFn)
+		}
+	}
+
+	filePath, fileSize, err := download(fileURL, job.Title, func(detail string) {
 		job.Detail = detail
 		job.UpdatedAt = time.Now()
 	})
@@ -328,7 +336,7 @@ func (m *Manager) runDirectDownload(job *models.DownloadJob, fileURL, sourceID s
 		FileFormat:   "epub",
 		MediaType:    "ebook",
 		Source:       job.Source,
-		SourceID:     sourceID,
+		SourceID:     job.SourceID,
 	})
 
 	// Trigger library imports.

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -71,6 +71,7 @@ type DownloadJob struct {
 	Error         string             `json:"error,omitempty"`
 	URL           string             `json:"url,omitempty"`
 	MD5           string             `json:"md5,omitempty"`
+	SourceID      string             `json:"source_id,omitempty"`
 	MediaType     string             `json:"media_type,omitempty"`
 	RetryCount    int                `json:"retry_count"`
 	MaxRetries    int                `json:"max_retries"`
@@ -155,6 +156,8 @@ type User struct {
 type DownloadRequest struct {
 	Source           string `json:"source"`
 	Title            string `json:"title"`
+	Author           string `json:"author,omitempty"`
+	SourceID         string `json:"source_id,omitempty"`
 	DownloadURL      string `json:"download_url,omitempty"`
 	MagnetURL        string `json:"magnet_url,omitempty"`
 	InfoHash         string `json:"info_hash,omitempty"`

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -195,7 +195,7 @@ func (s *Scheduler) startDownload(result models.SearchResult, title string) {
 		if dlURL == "" {
 			dlURL = result.EpubURL
 		}
-		_, err := s.downloadMgr.StartDirectDownload(dlURL, title, result.Source, result.SourceID)
+		_, err := s.downloadMgr.StartDirectDownload(dlURL, title, result.Source, result.SourceID, result.Author)
 		if err != nil {
 			slog.Error("scheduler: auto-download failed", "title", title, "error", err)
 		}

--- a/internal/search/zlibrary.go
+++ b/internal/search/zlibrary.go
@@ -9,12 +9,14 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/models"
+	"github.com/JeremiahM37/librarr/internal/zlibraryparse"
 )
 
 // ZLibrary searches the Z-Library external API for ebooks.
@@ -68,37 +70,12 @@ func (z *ZLibrary) apiBase() string {
 
 // --- Z-Library API response types ---
 
-type zlLoginResponse struct {
-	Success bool `json:"success"`
-	User    struct {
-		ID    int    `json:"id"`
-		Email string `json:"email"`
-	} `json:"user"`
-	Message string `json:"message,omitempty"`
-}
-
-type zlSearchResponse struct {
-	Success    bool     `json:"success"`
-	Result     []zlBook `json:"result"`
-	Pagination struct {
-		Page  int `json:"page"`
-		Total int `json:"total"`
-	} `json:"pagination"`
-	Error string `json:"error,omitempty"`
-}
-
-type zlBook struct {
-	ID          int    `json:"id"`
-	Hash        string `json:"hash"`
-	Title       string `json:"title"`
-	Author      string `json:"author"`
-	Extension   string `json:"extension"`
-	Filesize    int64  `json:"filesize"`
-	Language    string `json:"language"`
-	Year        string `json:"year"`
-	Pages       int    `json:"pages"`
-	Cover       string `json:"cover"`
-	Description string `json:"description,omitempty"`
+type zlRPCLoginResponse struct {
+	Errors   []string `json:"errors"`
+	Response struct {
+		UserID  int    `json:"user_id"`
+		UserKey string `json:"user_key"`
+	} `json:"response"`
 }
 
 type zlDomainsResponse struct {
@@ -117,23 +94,24 @@ func (z *ZLibrary) login(ctx context.Context) error {
 	}
 
 	baseURL := z.apiBase()
-	loginURL := fmt.Sprintf("%s/eapi/user/login", baseURL)
+	loginURL := fmt.Sprintf("%s/rpc.php", baseURL)
 
-	payload := map[string]string{
-		"email":    z.cfg.ZLibraryEmail,
-		"password": z.cfg.ZLibraryPassword,
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("zlibrary marshal login: %w", err)
-	}
+	form := url.Values{}
+	form.Set("isModal", "true")
+	form.Set("email", z.cfg.ZLibraryEmail)
+	form.Set("password", z.cfg.ZLibraryPassword)
+	form.Set("site_mode", "books")
+	form.Set("action", "login")
+	form.Set("redirectUrl", baseURL+"/")
+	form.Set("gg_json_mode", "1")
 
-	req, err := http.NewRequestWithContext(ctx, "POST", loginURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", loginURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return fmt.Errorf("zlibrary login request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
 	req.Header.Set("User-Agent", z.cfg.UserAgent)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 
 	resp, err := z.client.Do(req)
 	if err != nil {
@@ -145,13 +123,16 @@ func (z *ZLibrary) login(ctx context.Context) error {
 		return fmt.Errorf("zlibrary login HTTP %d", resp.StatusCode)
 	}
 
-	var loginResp zlLoginResponse
+	var loginResp zlRPCLoginResponse
 	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
 		return fmt.Errorf("zlibrary decode login: %w", err)
 	}
 
-	if !loginResp.Success {
-		return fmt.Errorf("zlibrary login failed: %s", loginResp.Message)
+	if len(loginResp.Errors) > 0 {
+		return fmt.Errorf("zlibrary login failed: %s", strings.Join(loginResp.Errors, "; "))
+	}
+	if loginResp.Response.UserID == 0 || loginResp.Response.UserKey == "" {
+		return fmt.Errorf("zlibrary login failed: missing session credentials")
 	}
 
 	z.loggedIn = true
@@ -207,21 +188,17 @@ func (z *ZLibrary) Search(ctx context.Context, query string) ([]models.SearchRes
 	baseURL := z.apiBase()
 	searchURL := fmt.Sprintf("%s/eapi/book/search", baseURL)
 
-	payload := map[string]interface{}{
-		"message": query,
-		"limit":   15,
-		"page":    1,
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("zlibrary marshal search: %w", err)
-	}
+	form := url.Values{}
+	form.Set("message", query)
+	form.Set("limit", "15")
+	form.Set("page", "1")
+	body := []byte(form.Encode())
 
 	req, err := http.NewRequestWithContext(ctx, "POST", searchURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("zlibrary search request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", z.cfg.UserAgent)
 
 	resp, err := z.client.Do(req)
@@ -251,7 +228,7 @@ func (z *ZLibrary) Search(ctx context.Context, query string) ([]models.SearchRes
 		if err != nil {
 			return nil, err
 		}
-		req2.Header.Set("Content-Type", "application/json")
+		req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req2.Header.Set("User-Agent", z.cfg.UserAgent)
 
 		resp2, err := z.client.Do(req2)
@@ -274,23 +251,25 @@ func (z *ZLibrary) Search(ctx context.Context, query string) ([]models.SearchRes
 		return nil, fmt.Errorf("zlibrary search HTTP %d: %s", resp.StatusCode, snippet)
 	}
 
-	var searchResp zlSearchResponse
-	if err := json.Unmarshal(respBody, &searchResp); err != nil {
+	books, err := zlibraryparse.BooksFromJSON(respBody)
+	if err != nil {
 		return nil, fmt.Errorf("zlibrary decode search: %w", err)
 	}
 
-	if !searchResp.Success {
-		return nil, fmt.Errorf("zlibrary search failed: %s", searchResp.Error)
-	}
-
 	var results []models.SearchResult
-	for _, book := range searchResp.Result {
+	for _, book := range books {
 		sizeHuman := formatZLSize(book.Filesize)
 		format := strings.ToUpper(book.Extension)
+		sourceID := fmt.Sprintf("zlibrary-%d", book.ID)
+		if book.Hash != "" {
+			sourceID = fmt.Sprintf("%s-%s", sourceID, book.Hash)
+		}
 
 		// Construct download URL using personal domain.
 		downloadURL := ""
-		if z.personalURL != "" && book.Hash != "" {
+		if book.DL != "" {
+			downloadURL = zlibraryparse.AbsoluteURL(baseURL, book.DL)
+		} else if z.personalURL != "" && book.Hash != "" {
 			downloadURL = fmt.Sprintf("%s/dl/%d/%s", z.personalURL, book.ID, book.Hash)
 		} else if z.personalURL != "" {
 			downloadURL = fmt.Sprintf("%s/dl/%d", z.personalURL, book.ID)
@@ -305,7 +284,7 @@ func (z *ZLibrary) Search(ctx context.Context, query string) ([]models.SearchRes
 			Source:      "zlibrary",
 			Title:       book.Title,
 			Author:      book.Author,
-			SourceID:    fmt.Sprintf("zlibrary-%d", book.ID),
+			SourceID:    sourceID,
 			CoverURL:    coverURL,
 			URL:         downloadURL,
 			DownloadURL: downloadURL,

--- a/internal/search/zlibrary_test.go
+++ b/internal/search/zlibrary_test.go
@@ -21,12 +21,24 @@ func newZLibraryTestServer(t *testing.T, unauthorizedFirst bool) *httptest.Serve
 		searchCount int
 	)
 	mux := http.NewServeMux()
-	mux.HandleFunc("/eapi/user/login", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/rpc.php", func(w http.ResponseWriter, r *http.Request) {
 		loginCount++
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if r.Form.Get("action") != "login" {
+			t.Fatalf("action = %q, want login", r.Form.Get("action"))
+		}
+		if r.Form.Get("email") == "" || r.Form.Get("password") == "" {
+			t.Fatalf("login form missing credentials")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"success": true,
-			"user":    map[string]any{"id": 1, "email": "u@example.com"},
+			"errors": []string{},
+			"response": map[string]any{
+				"user_id":  1,
+				"user_key": "session-key",
+			},
 		})
 	})
 	mux.HandleFunc("/eapi/info/domains", func(w http.ResponseWriter, r *http.Request) {
@@ -43,10 +55,19 @@ func newZLibraryTestServer(t *testing.T, unauthorizedFirst bool) *httptest.Serve
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
+		if ct := r.Header.Get("Content-Type"); !strings.Contains(ct, "application/x-www-form-urlencoded") {
+			t.Fatalf("Content-Type = %q, want form encoded", ct)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if r.Form.Get("message") == "" {
+			t.Fatalf("search form missing message")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"success": true,
-			"result": []map[string]any{
+			"success": 1,
+			"books": []map[string]any{
 				{
 					"id":        42,
 					"hash":      "abc123",
@@ -55,6 +76,7 @@ func newZLibraryTestServer(t *testing.T, unauthorizedFirst bool) *httptest.Serve
 					"extension": "epub",
 					"filesize":  2_500_000,
 					"language":  "english",
+					"dl":        "/dl/custom-token",
 				},
 			},
 			"pagination": map[string]any{"page": 1, "total": 1},
@@ -97,11 +119,11 @@ func TestZLibrarySearch(t *testing.T) {
 	if r.Format != "EPUB" {
 		t.Errorf("Format = %q, want EPUB (extension upper-cased)", r.Format)
 	}
-	if r.SourceID != "zlibrary-42" {
+	if r.SourceID != "zlibrary-42-abc123" {
 		t.Errorf("SourceID = %q", r.SourceID)
 	}
-	if !strings.Contains(r.DownloadURL, "dl.example.org") || !strings.Contains(r.DownloadURL, "/dl/42/abc123") {
-		t.Errorf("DownloadURL = %q, want it to use personal domain and hash", r.DownloadURL)
+	if !strings.Contains(r.DownloadURL, srv.URL) || !strings.Contains(r.DownloadURL, "/dl/custom-token") {
+		t.Errorf("DownloadURL = %q, want it to use dl path from response", r.DownloadURL)
 	}
 	if r.SizeHuman == "" {
 		t.Errorf("SizeHuman should be non-empty")
@@ -127,6 +149,71 @@ func TestZLibrarySessionRenewOn401(t *testing.T) {
 	}
 	if len(results) != 1 {
 		t.Fatalf("got %d results after retry, want 1", len(results))
+	}
+}
+
+func TestZLibrarySearchHashlessResultUsesStableSourceID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/rpc.php", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []string{},
+			"response": map[string]any{
+				"user_id":  1,
+				"user_key": "session-key",
+			},
+		})
+	})
+	mux.HandleFunc("/eapi/info/domains", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"domains": []string{"dl.example.org"},
+		})
+	})
+	mux.HandleFunc("/eapi/book/search", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"books": []map[string]any{
+				{
+					"id":        118708376,
+					"title":     "Seascraper",
+					"author":    "Benjamin Wood",
+					"extension": "epub",
+					"filesize":  799783,
+					"dl":        "/dl/fresh-token",
+				},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := &config.Config{
+		ZLibraryURL:      srv.URL,
+		ZLibraryEmail:    "u@example.com",
+		ZLibraryPassword: "pw",
+		ZLibraryEnabled:  true,
+		UserAgent:        "test-agent",
+	}
+	z := NewZLibrary(cfg, &http.Client{Timeout: 5 * time.Second})
+
+	results, err := z.Search(context.Background(), "Seascraper Benjamin Wood")
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].SourceID != "zlibrary-118708376" {
+		t.Fatalf("SourceID = %q", results[0].SourceID)
+	}
+	if strings.HasSuffix(results[0].SourceID, "-") {
+		t.Fatalf("SourceID has trailing hyphen: %q", results[0].SourceID)
+	}
+	if results[0].DownloadURL != srv.URL+"/dl/fresh-token" {
+		t.Fatalf("DownloadURL = %q", results[0].DownloadURL)
 	}
 }
 

--- a/internal/zlibraryparse/parser.go
+++ b/internal/zlibraryparse/parser.go
@@ -1,0 +1,257 @@
+package zlibraryparse
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+type Book struct {
+	ID          int
+	Hash        string
+	Title       string
+	Author      string
+	Extension   string
+	Filesize    int64
+	Language    string
+	Year        any
+	Pages       int
+	Cover       string
+	Description string
+	DL          string
+}
+
+func BooksFromJSON(body []byte) ([]Book, error) {
+	var root any
+	if err := json.Unmarshal(body, &root); err != nil {
+		return nil, err
+	}
+	obj, ok := root.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("zlibrary response is not an object")
+	}
+	if !JSONTruthy(obj["success"], true) {
+		return nil, fmt.Errorf("zlibrary request failed: %s", ErrorMessage(obj))
+	}
+
+	for _, candidate := range arrayCandidates(obj, []string{"books", "result", "results", "data", "items"}) {
+		books := normalizeBooks(candidate)
+		if len(books) > 0 {
+			return books, nil
+		}
+	}
+	return nil, nil
+}
+
+func DetailDownloadFromJSON(body []byte) (string, error) {
+	var root any
+	if err := json.Unmarshal(body, &root); err != nil {
+		return "", err
+	}
+	obj, ok := root.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("zlibrary detail response is not an object")
+	}
+	if !JSONTruthy(obj["success"], true) {
+		return "", fmt.Errorf("zlibrary detail failed: %s", ErrorMessage(obj))
+	}
+
+	for _, candidate := range objectCandidates(obj, []string{"book", "data", "response", "result", "item"}) {
+		if dl := firstString(candidate, "dl", "downloadUrl", "download_url", "href", "url"); dl != "" {
+			return dl, nil
+		}
+	}
+	if dl := firstString(obj, "dl", "downloadUrl", "download_url", "href", "url"); dl != "" {
+		return dl, nil
+	}
+	return "", nil
+}
+
+func FindDownloadLinkInHTML(baseURL string, body []byte) string {
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)href=["']([^"']*/dl/[^"']+)["']`),
+		regexp.MustCompile(`(?i)["']((?:https?://[^"']+)?/dl/[^"']+)["']`),
+	}
+	for _, pattern := range patterns {
+		if match := pattern.FindSubmatch(body); len(match) > 1 {
+			return AbsoluteURL(baseURL, htmlUnescape(string(match[1])))
+		}
+	}
+	return ""
+}
+
+func JSONTruthy(v any, defaultValue bool) bool {
+	if v == nil {
+		return defaultValue
+	}
+	switch value := v.(type) {
+	case bool:
+		return value
+	case float64:
+		return value != 0
+	case int:
+		return value != 0
+	case string:
+		return value == "1" || strings.EqualFold(value, "true") || strings.EqualFold(value, "ok") || strings.EqualFold(value, "success")
+	default:
+		return defaultValue
+	}
+}
+
+func ErrorMessage(obj map[string]any) string {
+	for _, key := range []string{"error", "message", "msg", "reason"} {
+		if value := stringValue(obj[key]); value != "" {
+			return value
+		}
+	}
+	if errorsValue, ok := obj["errors"].([]any); ok {
+		var parts []string
+		for _, item := range errorsValue {
+			if value := stringValue(item); value != "" {
+				parts = append(parts, value)
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, "; ")
+		}
+	}
+	return "unknown error"
+}
+
+func AbsoluteURL(baseURL, path string) string {
+	if path == "" || strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+	base, err := url.Parse(strings.TrimRight(baseURL, "/") + "/")
+	if err != nil {
+		return path
+	}
+	ref, err := url.Parse(path)
+	if err != nil {
+		return path
+	}
+	return base.ResolveReference(ref).String()
+}
+
+func arrayCandidates(obj map[string]any, keys []string) [][]any {
+	var candidates [][]any
+	for _, key := range keys {
+		if items, ok := obj[key].([]any); ok {
+			candidates = append(candidates, items)
+		}
+		if nested, ok := obj[key].(map[string]any); ok {
+			candidates = append(candidates, arrayCandidates(nested, keys)...)
+		}
+	}
+	return candidates
+}
+
+func objectCandidates(obj map[string]any, keys []string) []map[string]any {
+	var candidates []map[string]any
+	for _, key := range keys {
+		if nested, ok := obj[key].(map[string]any); ok {
+			candidates = append(candidates, nested)
+		}
+	}
+	return candidates
+}
+
+func normalizeBooks(items []any) []Book {
+	books := make([]Book, 0, len(items))
+	for _, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		books = append(books, Book{
+			ID:          intValue(obj["id"]),
+			Hash:        firstString(obj, "hash", "bookHash", "book_hash", "md5"),
+			Title:       firstString(obj, "title", "name", "bookTitle", "book_title"),
+			Author:      firstString(obj, "author", "authors", "authorName", "author_name"),
+			Extension:   firstString(obj, "extension", "ext", "format", "fileType", "file_type"),
+			Filesize:    int64Value(firstPresent(obj, "filesize", "fileSize", "file_size", "size", "sizeBytes", "size_bytes")),
+			Language:    firstString(obj, "language", "lang"),
+			Year:        firstPresent(obj, "year", "published", "publishYear", "publish_year"),
+			Pages:       intValue(firstPresent(obj, "pages", "pageCount", "page_count")),
+			Cover:       firstString(obj, "cover", "coverUrl", "cover_url", "image", "thumbnail"),
+			Description: firstString(obj, "description", "desc", "summary"),
+			DL:          firstString(obj, "dl", "downloadUrl", "download_url", "href", "url"),
+		})
+	}
+	return books
+}
+
+func firstPresent(obj map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := obj[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func firstString(obj map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := stringValue(obj[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stringValue(v any) string {
+	switch value := v.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []any:
+		var parts []string
+		for _, item := range value {
+			if part := stringValue(item); part != "" {
+				parts = append(parts, part)
+			}
+		}
+		return strings.Join(parts, ", ")
+	case map[string]any:
+		return firstString(value, "name", "title", "value")
+	default:
+		return ""
+	}
+}
+
+func intValue(v any) int {
+	n := int64Value(v)
+	if n > int64(math.MaxInt) {
+		return 0
+	}
+	return int(n)
+}
+
+func int64Value(v any) int64 {
+	switch value := v.(type) {
+	case int:
+		return int64(value)
+	case int64:
+		return value
+	case float64:
+		return int64(value)
+	case json.Number:
+		n, _ := value.Int64()
+		return n
+	case string:
+		value = strings.TrimSpace(value)
+		value = strings.ReplaceAll(value, ",", "")
+		var n int64
+		if _, err := fmt.Sscanf(value, "%d", &n); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func htmlUnescape(s string) string {
+	replacer := strings.NewReplacer("&amp;", "&", "&#38;", "&")
+	return replacer.Replace(s)
+}

--- a/web/index.html
+++ b/web/index.html
@@ -870,9 +870,12 @@ const I18N = {
     status_queued: 'Queued',
     status_searching: 'Searching',
     status_importing: 'Importing',
+    status_retry_wait: 'Retry Wait',
     // Download actions
     download_started: 'Download started: {title}',
+    download_complete: 'Download completed: {title}',
     download_failed: 'Download failed: {msg}',
+    unknown_title: 'Unknown title',
     unknown_error: 'Unknown error',
     retrying_download: 'Retrying download',
     retry_failed: 'Retry failed',
@@ -1064,9 +1067,12 @@ const I18N = {
     status_queued: 'В очереди',
     status_searching: 'Поиск',
     status_importing: 'Импорт',
+    status_retry_wait: 'Ожидание повтора',
     // Download actions
     download_started: 'Загрузка начата: {title}',
+    download_complete: 'Загрузка завершена: {title}',
     download_failed: 'Ошибка загрузки: {msg}',
+    unknown_title: 'Неизвестное название',
     unknown_error: 'Неизвестная ошибка',
     retrying_download: 'Повтор загрузки',
     retry_failed: 'Ошибка повтора',
@@ -1232,6 +1238,7 @@ const state = {
   pendingDownloads: new Set(),
   downloadOutcomes: new Map(),
   downloadOutcomeTimers: new Map(),
+  trackedDownloadJobs: new Map(),
   downloadJobs: [],
   pendingRetryDownloads: new Set(),
   sortMode: 'relevance',
@@ -1785,7 +1792,7 @@ function renderSearchResults() {
 function renderBookCard(result, index) {
   const src = SOURCE_COLORS[result.source] || { bg: '#475569', text: 'white', label: result.source || 'Unknown' };
   const downloadKey = getDownloadKey(result);
-  const isDownloading = state.pendingDownloads.has(downloadKey);
+  const isDownloading = state.pendingDownloads.has(downloadKey) || state.trackedDownloadJobs.has(downloadKey);
   const downloadOutcome = state.downloadOutcomes.get(downloadKey);
   const coverHtml = result.cover_url
     ? `<img src="${escapeHtml(result.cover_url)}" alt="" class="w-full h-48 object-cover" loading="lazy" onerror="this.outerHTML=makePlaceholder('${escapeHtml(result.title || '')}', ${index})">`
@@ -1876,6 +1883,7 @@ function getDownloadKey(result) {
     result.info_hash || '',
     result.magnet || '',
     result.md5 || '',
+    result.source_id || '',
     result.title || '',
     result.author || '',
   ].join('|');
@@ -1896,6 +1904,46 @@ function setDownloadOutcome(downloadKey, status) {
   state.downloadOutcomeTimers.set(downloadKey, timer);
 }
 
+function isTerminalDownloadStatus(status) {
+  return status === 'completed' || status === 'error' || status === 'dead_letter';
+}
+
+function isActiveDownloadStatus(status) {
+  return status === 'queued' || status === 'searching' || status === 'downloading' || status === 'organizing' || status === 'importing' || status === 'retry_wait';
+}
+
+function trackDownloadJob(downloadKey, jobId, title) {
+  if (!jobId) return;
+  state.trackedDownloadJobs.set(downloadKey, { jobId: String(jobId), title });
+  startDownloadPolling();
+  renderSearchResults();
+}
+
+function syncTrackedDownloadJobs(jobs) {
+  if (!state.trackedDownloadJobs.size) return;
+
+  let changed = false;
+  for (const [downloadKey, tracked] of state.trackedDownloadJobs.entries()) {
+    const job = jobs.find(j => String(j.job_id) === tracked.jobId);
+    if (!job || !isTerminalDownloadStatus(job.status)) continue;
+
+    state.trackedDownloadJobs.delete(downloadKey);
+    changed = true;
+    if (job.status === 'completed') {
+      setDownloadOutcome(downloadKey, 'success');
+      showToast(t('download_complete', {title: tracked.title || job.title || t('unknown_title')}), 'success');
+    } else {
+      setDownloadOutcome(downloadKey, 'error');
+      showToast(t('download_failed', {msg: job.error || t('unknown_error')}), 'error');
+    }
+  }
+
+  if (changed) renderSearchResults();
+  if (!state.trackedDownloadJobs.size && !jobs.some(j => isActiveDownloadStatus(j.status))) {
+    stopDownloadPolling();
+  }
+}
+
 // ============================================================
 // DOWNLOAD
 // ============================================================
@@ -1912,6 +1960,7 @@ async function startDownload(result) {
       download_url: result.download_url || result.url || '',
       abb_url: result.abb_url || '',
       source: result.source,
+      source_id: result.source_id || '',
       md5: result.md5 || '',
       author: result.author || '',
       info_hash: result.info_hash || '',
@@ -1924,8 +1973,13 @@ async function startDownload(result) {
     });
 
     if (data.success || data.job_id) {
-      setDownloadOutcome(downloadKey, 'success');
-      showToast(t('download_started', {title: result.title}), 'success');
+      if (data.job_id) {
+        trackDownloadJob(downloadKey, data.job_id, result.title);
+        showToast(t('download_started', {title: result.title}), 'info');
+      } else {
+        setDownloadOutcome(downloadKey, 'success');
+        showToast(t('download_started', {title: result.title}), 'success');
+      }
     } else {
       setDownloadOutcome(downloadKey, 'error');
       showToast(t('download_failed', {msg: data.error || t('unknown_error')}), 'error');
@@ -1961,7 +2015,8 @@ async function refreshDownloads(manual = false) {
 
   try {
     const data = await apiJson('/api/downloads');
-    state.downloadJobs = data.jobs || [];
+    state.downloadJobs = data.downloads || data.jobs || [];
+    syncTrackedDownloadJobs(state.downloadJobs);
     renderDownloadList();
   } catch (err) {
     if (err.message !== 'Unauthorized') {
@@ -1978,7 +2033,7 @@ function renderDownloadList() {
   const emptyEl = document.getElementById('downloads-empty');
 
   // Update badge
-  const activeCount = jobs.filter(j => j.status === 'downloading' || j.status === 'queued' || j.status === 'searching' || j.status === 'organizing' || j.status === 'importing').length;
+  const activeCount = jobs.filter(j => isActiveDownloadStatus(j.status)).length;
   const badge = document.getElementById('dl-badge');
   if (activeCount > 0) {
     badge.textContent = activeCount;


### PR DESCRIPTION
## What broke

- The previous Z-Library path treated the provided download URL as the final file URL. For results like `https://1lib.sk/exactEnd`, that URL only led to a browser-check/anti-bot response, so the worker reported success on queueing while no file reached disk.
- The old code also assumed narrow response shapes from Z-Library search/detail APIs, which made the integration brittle when the upstream payload changed.

## New flow

1. The UI submits `source`, `title`, `author`, and `source_id` with the download request.
2. The backend logs in to Z-Library through the browser-style `/rpc.php` flow and keeps an isolated cookie jar for the job.
3. It resolves a fresh download target from the book detail/search response instead of trusting the original link.
4. It follows the browser-check challenge when present, then downloads, organizes, and imports the file.
5. The UI now stays in a loading state until the background job reaches a terminal status instead of marking the click successful immediately.

## Resiliency work

- Added a shared Z-Library parser that accepts common aliases for list/detail payloads (`books`, `result`, `items`, `data`, and multiple download-link field names).
- Added HTML `/dl/...` fallback for cases where the JSON payload no longer carries the download link directly.
- Persisted `source_id` on download jobs so retries and request workflows retain the exact resolver context.
- Added focused regression tests for search shapes, hashless results, and the direct-download fallback path.

## Limitations

- This is still a best-effort integration against a private, changing upstream surface. If Z-Library changes the login contract, browser-check script, or download-link semantics, the downloader may need another update.
- The browser-check solver is intentionally narrow and will fail cleanly if the challenge format changes instead of guessing blindly.
- There is still no guarantee that every future payload shape can be inferred without adding another normalization rule or fallback.

## Validation

- `docker run --rm -v "$PWD":/app -w /app golang:1.25 go test ./internal/zlibraryparse ./internal/download ./internal/search ./internal/db ./internal/scheduler`
- `docker run --rm -v "$PWD":/app -w /app golang:1.25 go test ./internal/api -run "^$"`
- Rebuilt and restarted the running `librarr` container, then replayed the Seascraper Z-Library payload successfully.
