### PR TITLE
Add opt-in Authentik proxy header login

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ All configuration is via environment variables. Every variable has a sensible de
 | `OIDC_REDIRECT_URI` | | Callback URL (`https://librarr.example.com/auth/oidc/callback`) |
 | `OIDC_AUTO_CREATE_USERS` | `true` | Auto-create users on first OIDC login |
 | `OIDC_DEFAULT_ROLE` | `user` | Default role for OIDC-created users |
+| `OIDC_PROXY_HEADERS_ENABLED` | `false` | Trust Authentik identity headers from a reverse proxy |
+
+When `OIDC_PROXY_HEADERS_ENABLED=true` and Librarr sits behind a trusted reverse
+proxy that injects Authentik headers like `X-Authentik-Username`, it will treat
+those requests as an authenticated SSO session, auto-provision the local user if
+needed, and skip the manual "Login with SSO" click. Enable this only for
+proxy-gated deployments.
+Local logout only clears Librarr's session cookie; if the proxy keeps sending
+the identity header, the next request will sign the browser back in.
 
 ### Download Clients
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     environment:
       - LIBRARR_PORT=5050
       - LIBRARR_DB_PATH=/data/librarr.db
+      # Set to true only when a trusted reverse proxy injects Authentik headers.
+      - OIDC_PROXY_HEADERS_ENABLED=false
 
 volumes:
   librarr-data:

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -381,14 +381,7 @@ func handleLogin(cfg *config.Config, database *db.DB, sessions *SessionStore) ht
 			// No TOTP — create full session.
 			database.UpdateLastLogin(user.ID)
 			token := sessions.Create(user.ID, user.Username, user.Role)
-			http.SetCookie(w, &http.Cookie{
-				Name:     "librarr_session",
-				Value:    token,
-				Path:     "/",
-				MaxAge:   86400,
-				HttpOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			})
+			setSessionCookie(w, r, token, 86400)
 
 			database.LogActivity(user.Username, "login", user.Username, "User logged in")
 
@@ -419,14 +412,7 @@ func handleLogin(cfg *config.Config, database *db.DB, sessions *SessionStore) ht
 		}
 
 		token := sessions.Create(0, cfg.AuthUsername, "admin")
-		http.SetCookie(w, &http.Cookie{
-			Name:     "librarr_session",
-			Value:    token,
-			Path:     "/",
-			MaxAge:   86400,
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-		})
+		setSessionCookie(w, r, token, 86400)
 
 		database.LogActivity(cfg.AuthUsername, "login", cfg.AuthUsername, "User logged in (legacy)")
 
@@ -476,14 +462,7 @@ func handleLoginTOTP(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 		if validateTOTPCode(user.TOTPSecret, req.Code) {
 			database.UpdateLastLogin(user.ID)
 			token := sessions.Create(user.ID, user.Username, user.Role)
-			http.SetCookie(w, &http.Cookie{
-				Name:     "librarr_session",
-				Value:    token,
-				Path:     "/",
-				MaxAge:   86400,
-				HttpOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			})
+			setSessionCookie(w, r, token, 86400)
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"success":  true,
 				"token":    token,
@@ -499,14 +478,7 @@ func handleLoginTOTP(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 		if used {
 			database.UpdateLastLogin(user.ID)
 			token := sessions.Create(user.ID, user.Username, user.Role)
-			http.SetCookie(w, &http.Cookie{
-				Name:     "librarr_session",
-				Value:    token,
-				Path:     "/",
-				MaxAge:   86400,
-				HttpOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			})
+			setSessionCookie(w, r, token, 86400)
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"success":          true,
 				"token":            token,
@@ -627,14 +599,7 @@ func handleRegister(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 		if isFirstUser {
 			database.UpdateLastLogin(id)
 			token := sessions.Create(id, req.Username, role)
-			http.SetCookie(w, &http.Cookie{
-				Name:     "librarr_session",
-				Value:    token,
-				Path:     "/",
-				MaxAge:   86400,
-				HttpOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			})
+			setSessionCookie(w, r, token, 86400)
 			writeJSON(w, http.StatusCreated, map[string]interface{}{
 				"success":  true,
 				"id":       id,
@@ -958,14 +923,7 @@ func handleLogout(sessions *SessionStore, database *db.DB) http.HandlerFunc {
 			sessions.Delete(cookie.Value)
 		}
 		database.LogActivity(username, "logout", username, "User logged out")
-		http.SetCookie(w, &http.Cookie{
-			Name:     "librarr_session",
-			Value:    "",
-			Path:     "/",
-			MaxAge:   -1,
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-		})
+		setSessionCookie(w, r, "", -1)
 		writeJSON(w, http.StatusOK, map[string]interface{}{"success": true})
 	}
 }

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -212,6 +212,30 @@ func authMiddleware(cfg *config.Config, database *db.DB, sessions *SessionStore,
 		userCount, _ := database.CountUsers()
 		multiUser := userCount > 0
 
+		// Trusted reverse-proxy SSO headers should short-circuit the normal
+		// login flow when OIDC is configured. This lets Authentik-backed
+		// deployments log users in transparently instead of requiring a second
+		// click on the Librarr login button.
+		if cfg != nil && cfg.HasOIDCProxyHeaders() {
+			username := proxyIdentityFromRequest(r)
+			if username != "" {
+				if user, err := resolveOIDCUser(cfg, database, username); err == nil && user != nil {
+					if sessions != nil {
+						if ensureSessionForUser(w, r, sessions, user) {
+							_ = database.UpdateLastLogin(user.ID)
+						}
+					}
+					ctx := context.WithValue(r.Context(), ctxUserID, user.ID)
+					ctx = context.WithValue(ctx, ctxUserRole, user.Role)
+					ctx = context.WithValue(ctx, ctxUsername, user.Username)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				} else if err != nil && cfg != nil && cfg.HasOIDC() {
+					slog.Warn("proxy SSO login rejected", "username", username, "error", err)
+				}
+			}
+		}
+
 		// If no multi-user and no legacy auth, pass through.
 		if !multiUser && !cfg.HasAuth() && !cfg.HasAPIKey() {
 			next.ServeHTTP(w, r)
@@ -649,8 +673,19 @@ func handleAuthStatus(cfg *config.Config, database *db.DB, sessions *SessionStor
 			resp["oidc_provider_name"] = cfg.OIDCProviderName
 		}
 
+		if username, _ := r.Context().Value(ctxUsername).(string); username != "" {
+			resp["authenticated"] = true
+			resp["username"] = username
+		}
+		if role, _ := r.Context().Value(ctxUserRole).(string); role != "" {
+			resp["role"] = role
+		}
+		if userID, _ := r.Context().Value(ctxUserID).(int64); userID != 0 {
+			resp["user_id"] = userID
+		}
+
 		// Check session.
-		cookie, err := r.Cookie("librarr_session")
+		cookie, err := r.Cookie(sessionCookieName)
 		if err == nil {
 			if data, ok := sessions.Get(cookie.Value); ok {
 				resp["authenticated"] = true

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -179,6 +180,58 @@ func TestHashBackupCode(t *testing.T) {
 
 	if len(hash1) != 64 {
 		t.Errorf("expected SHA-256 hex length 64, got %d", len(hash1))
+	}
+}
+
+func TestSetSessionCookieSecureFlag(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(*http.Request)
+		wantSecure bool
+	}{
+		{
+			name: "plain HTTP dev request",
+		},
+		{
+			name: "direct TLS request",
+			configure: func(r *http.Request) {
+				r.TLS = &tls.ConnectionState{}
+			},
+			wantSecure: true,
+		},
+		{
+			name: "reverse proxy HTTPS request",
+			configure: func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Proto", "https")
+			},
+			wantSecure: true,
+		},
+		{
+			name: "standard forwarded HTTPS request",
+			configure: func(r *http.Request) {
+				r.Header.Set("Forwarded", "for=192.0.2.60;proto=https;host=books.example.com")
+			},
+			wantSecure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+			if tt.configure != nil {
+				tt.configure(req)
+			}
+			rr := httptest.NewRecorder()
+			setSessionCookie(rr, req, "token", 86400)
+
+			cookies := rr.Result().Cookies()
+			if len(cookies) != 1 {
+				t.Fatalf("cookie count = %d, want 1", len(cookies))
+			}
+			if cookies[0].Secure != tt.wantSecure {
+				t.Fatalf("Secure = %v, want %v", cookies[0].Secure, tt.wantSecure)
+			}
+		})
 	}
 }
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -312,5 +313,212 @@ func TestHandleAuthStatus_OIDCHints(t *testing.T) {
 				t.Errorf("oidc_provider_name MUST be absent when OIDC is disabled, got %v", resp["oidc_provider_name"])
 			}
 		})
+	}
+}
+
+func newOIDCTestConfig() *config.Config {
+	return &config.Config{
+		OIDCEnabled:         true,
+		OIDCIssuer:          "https://idp.example.com",
+		OIDCClientID:        "client",
+		OIDCClientSecret:    "secret",
+		OIDCAutoCreateUsers: true,
+		OIDCDefaultRole:     "user",
+		OIDCProxyHeaders:    true,
+	}
+}
+
+func TestAuthMiddleware_AcceptsAuthentikProxyHeaders(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	sessions := NewSessionStore()
+
+	var gotUsername, gotRole string
+	var gotUserID int64
+	handler := authMiddleware(newOIDCTestConfig(), database, sessions, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserID = getUserIDFromContext(r)
+		gotUsername, _ = r.Context().Value(ctxUsername).(string)
+		gotRole, _ = r.Context().Value(ctxUserRole).(string)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req.Header.Set("X-Authentik-Username", "alice")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", rr.Code, rr.Body.String())
+	}
+	if gotUsername != "alice" {
+		t.Fatalf("username = %q, want alice", gotUsername)
+	}
+	if gotRole != "admin" {
+		t.Fatalf("role = %q, want admin for first SSO user", gotRole)
+	}
+	if gotUserID == 0 {
+		t.Fatal("expected a resolved user ID")
+	}
+	if _, err := database.GetUserByUsername("alice"); err != nil {
+		t.Fatalf("expected alice user to be created: %v", err)
+	}
+
+	var sessionCookie bool
+	for _, cookie := range rr.Result().Cookies() {
+		if cookie.Name == sessionCookieName {
+			sessionCookie = true
+			break
+		}
+	}
+	if !sessionCookie {
+		t.Fatal("expected proxy-auth login to set a session cookie")
+	}
+}
+
+func TestAuthMiddleware_IgnoresAuthentikHeadersWhenOIDCDisabled(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	sessions := NewSessionStore()
+
+	hash, err := hashPassword("password")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	if _, err := database.CreateUser("existing", hash, "admin"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	called := false
+	handler := authMiddleware(&config.Config{}, database, sessions, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req.Header.Set("X-Authentik-Username", "alice")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Fatal("expected proxy header to be ignored when OIDC is disabled")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestAuthMiddleware_IgnoresAuthentikHeadersWhenProxyHeadersDisabled(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	sessions := NewSessionStore()
+
+	hash, err := hashPassword("password")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	if _, err := database.CreateUser("existing", hash, "admin"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	cfg := newOIDCTestConfig()
+	cfg.OIDCProxyHeaders = false
+
+	called := false
+	handler := authMiddleware(cfg, database, sessions, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req.Header.Set("X-Authentik-Username", "alice")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Fatal("expected proxy header to be ignored when proxy header auth is disabled")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestHandleAuthStatus_AuthentikProxyHeaders(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	sessions := NewSessionStore()
+
+	user, err := resolveOIDCUser(newOIDCTestConfig(), database, "alice")
+	if err != nil {
+		t.Fatalf("seed SSO user: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/status", nil)
+	req.Header.Set("X-Authentik-Username", "alice")
+	req = req.WithContext(context.WithValue(req.Context(), ctxUserID, user.ID))
+	req = req.WithContext(context.WithValue(req.Context(), ctxUsername, user.Username))
+	req = req.WithContext(context.WithValue(req.Context(), ctxUserRole, user.Role))
+	rr := httptest.NewRecorder()
+	handleAuthStatus(newOIDCTestConfig(), database, sessions)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got, _ := resp["authenticated"].(bool); !got {
+		t.Fatalf("authenticated = %v, want true", got)
+	}
+	if got, _ := resp["username"].(string); got != "alice" {
+		t.Fatalf("username = %q, want alice", got)
+	}
+	if got, _ := resp["role"].(string); got != "admin" {
+		t.Fatalf("role = %q, want admin", got)
+	}
+	if got, _ := resp["user_id"].(float64); got == 0 {
+		t.Fatal("expected a resolved user_id")
+	}
+}
+
+func TestHandleAuthStatus_ProxyHeaderDoesNotCreateUser(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	sessions := NewSessionStore()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/status", nil)
+	req.Header.Set("X-Authentik-Username", "alice")
+	rr := httptest.NewRecorder()
+	handleAuthStatus(newOIDCTestConfig(), database, sessions)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	count, err := database.CountUsers()
+	if err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("user count = %d, want 0", count)
 	}
 }

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -244,40 +244,15 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	slog.Info("OIDC login", "username", username, "email", claims.Email, "sub", claims.Sub)
 
 	// Find or create user.
-	user, err := h.db.GetUserByUsername(username)
+	user, err := resolveOIDCUser(h.cfg, h.db, username)
 	if err != nil {
-		// User doesn't exist.
-		if !h.cfg.OIDCAutoCreateUsers {
-			http.Error(w, "User not found and auto-creation is disabled", http.StatusForbidden)
-			return
-		}
-
-		// Determine role: first user is admin, otherwise use default.
-		userCount, _ := h.db.CountUsers()
-		role := h.cfg.OIDCDefaultRole
-		if userCount == 0 {
-			role = "admin"
-		}
-
-		// Create user with a random password (OIDC users don't use password login).
-		randomPass := make([]byte, 32)
-		rand.Read(randomPass)
-		passHash, _ := hashPassword(hex.EncodeToString(randomPass))
-
-		id, err := h.db.CreateUser(username, passHash, role)
-		if err != nil {
-			slog.Error("failed to create OIDC user", "username", username, "error", err)
-			http.Error(w, "Failed to create user account", http.StatusInternalServerError)
-			return
-		}
-
-		user, err = h.db.GetUser(id)
-		if err != nil {
-			http.Error(w, "Failed to retrieve created user", http.StatusInternalServerError)
-			return
-		}
-
-		slog.Info("OIDC user created", "id", id, "username", username, "role", role)
+		slog.Error("failed to resolve OIDC user", "username", username, "error", err)
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+	if user == nil {
+		http.Error(w, "Failed to resolve OIDC user", http.StatusInternalServerError)
+		return
 	}
 
 	// Create session.

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -259,14 +259,7 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	h.db.UpdateLastLogin(user.ID)
 	sessionToken := h.sessions.Create(user.ID, user.Username, user.Role)
 
-	http.SetCookie(w, &http.Cookie{
-		Name:     "librarr_session",
-		Value:    sessionToken,
-		Path:     "/",
-		MaxAge:   86400,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	setSessionCookie(w, r, sessionToken, 86400)
 
 	// Redirect to app root.
 	http.Redirect(w, r, "/", http.StatusFound)

--- a/internal/api/sso_proxy.go
+++ b/internal/api/sso_proxy.go
@@ -35,6 +35,29 @@ func proxyIdentityFromRequest(r *http.Request) string {
 	return ""
 }
 
+func isSecureRequest(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	proto := strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0])
+	if strings.EqualFold(proto, "https") {
+		return true
+	}
+	return strings.Contains(strings.ToLower(r.Header.Get("Forwarded")), "proto=https")
+}
+
+func setSessionCookie(w http.ResponseWriter, r *http.Request, token string, maxAge int) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   isSecureRequest(r),
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
 // resolveOIDCUser returns an existing Librarr user for the supplied SSO
 // identity, or auto-creates one when OIDC user provisioning is enabled.
 func resolveOIDCUser(cfg *config.Config, database *db.DB, username string) (*models.User, error) {
@@ -100,13 +123,6 @@ func ensureSessionForUser(w http.ResponseWriter, r *http.Request, sessions *Sess
 	}
 
 	token := sessions.Create(user.ID, user.Username, user.Role)
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    token,
-		Path:     "/",
-		MaxAge:   86400,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	setSessionCookie(w, r, token, 86400)
 	return true
 }

--- a/internal/api/sso_proxy.go
+++ b/internal/api/sso_proxy.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+const (
+	sessionCookieName = "librarr_session"
+)
+
+var authentikIdentityHeaders = []string{
+	"X-Authentik-Username",
+	"X-Authentik-Email",
+	"X-Authentik-Name",
+	"X-Authentik-Uid",
+	"Remote-User",
+	"X-Forwarded-User",
+}
+
+func proxyIdentityFromRequest(r *http.Request) string {
+	for _, header := range authentikIdentityHeaders {
+		if value := strings.TrimSpace(r.Header.Get(header)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// resolveOIDCUser returns an existing Librarr user for the supplied SSO
+// identity, or auto-creates one when OIDC user provisioning is enabled.
+func resolveOIDCUser(cfg *config.Config, database *db.DB, username string) (*models.User, error) {
+	if cfg == nil || !cfg.HasOIDC() {
+		return nil, nil
+	}
+
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return nil, fmt.Errorf("empty SSO username")
+	}
+
+	user, err := database.GetUserByUsername(username)
+	if err == nil {
+		return user, nil
+	}
+
+	if !cfg.OIDCAutoCreateUsers {
+		return nil, fmt.Errorf("user %q not found and auto-creation is disabled", username)
+	}
+
+	userCount, _ := database.CountUsers()
+	role := cfg.OIDCDefaultRole
+	if userCount == 0 {
+		role = "admin"
+	}
+
+	randomPass := make([]byte, 32)
+	if _, err := rand.Read(randomPass); err != nil {
+		return nil, fmt.Errorf("generate random password seed: %w", err)
+	}
+	passHash, err := hashPassword(hex.EncodeToString(randomPass))
+	if err != nil {
+		return nil, fmt.Errorf("hash random password: %w", err)
+	}
+
+	id, err := database.CreateUser(username, passHash, role)
+	if err != nil {
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+
+	user, err = database.GetUser(id)
+	if err != nil {
+		return nil, fmt.Errorf("load created user: %w", err)
+	}
+
+	slog.Info("OIDC user created", "id", id, "username", username, "role", role)
+
+	return user, nil
+}
+
+// ensureSessionForUser creates a Librarr session cookie for the given user if
+// the request does not already carry a matching valid session.
+func ensureSessionForUser(w http.ResponseWriter, r *http.Request, sessions *SessionStore, user *models.User) bool {
+	if sessions == nil || user == nil {
+		return false
+	}
+
+	if cookie, err := r.Cookie(sessionCookieName); err == nil {
+		if data, ok := sessions.Get(cookie.Value); ok && data.UserID == user.ID && data.Username == user.Username && data.Role == user.Role {
+			return false
+		}
+	}
+
+	token := sessions.Create(user.ID, user.Username, user.Role)
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   86400,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	return true
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,7 @@ type Config struct {
 	OIDCRedirectURI     string
 	OIDCAutoCreateUsers bool
 	OIDCDefaultRole     string
+	OIDCProxyHeaders    bool
 
 	// Deluge
 	DelugeURL      string
@@ -364,6 +365,7 @@ func buildFromEnv() *Config {
 		OIDCRedirectURI:     getEnv("OIDC_REDIRECT_URI", ""),
 		OIDCAutoCreateUsers: getEnvBool("OIDC_AUTO_CREATE_USERS", true),
 		OIDCDefaultRole:     getEnv("OIDC_DEFAULT_ROLE", "user"),
+		OIDCProxyHeaders:    getEnvBool("OIDC_PROXY_HEADERS_ENABLED", false),
 
 		DelugeURL:      getEnv("DELUGE_URL", ""),
 		DelugePassword: getEnv("DELUGE_PASSWORD", ""),
@@ -395,6 +397,11 @@ func buildFromEnv() *Config {
 // HasOIDC returns true if OIDC/SSO is configured.
 func (c *Config) HasOIDC() bool {
 	return c.OIDCEnabled && c.OIDCIssuer != "" && c.OIDCClientID != "" && c.OIDCClientSecret != ""
+}
+
+// HasOIDCProxyHeaders returns true when reverse-proxy SSO headers should be trusted.
+func (c *Config) HasOIDCProxyHeaders() bool {
+	return c.HasOIDC() && c.OIDCProxyHeaders
 }
 
 // HasQBittorrent returns true if qBittorrent is configured.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,7 @@ func TestLoad_Defaults(t *testing.T) {
 		"MIN_TORRENT_SIZE_BYTES", "MAX_TORRENT_SIZE_BYTES",
 		"AUTH_USERNAME", "AUTH_PASSWORD", "API_KEY",
 		"OIDC_ENABLED", "OIDC_ISSUER", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET",
+		"OIDC_PROXY_HEADERS_ENABLED",
 	} {
 		os.Unsetenv(key)
 	}
@@ -65,6 +66,12 @@ func TestLoad_Defaults(t *testing.T) {
 		}
 	})
 
+	t.Run("OIDC proxy headers disabled by default", func(t *testing.T) {
+		if cfg.OIDCProxyHeaders {
+			t.Error("expected OIDCProxyHeaders=false by default")
+		}
+	})
+
 	t.Run("rate limit enabled by default", func(t *testing.T) {
 		if !cfg.RateLimitEnabled {
 			t.Error("expected RateLimitEnabled=true by default")
@@ -79,10 +86,12 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	os.Setenv("FILE_ORG_ENABLED", "false")
 	os.Setenv("ANNAS_ARCHIVE_DOMAIN", "annas-archive.org")
 	os.Setenv("MIN_TORRENT_SIZE_BYTES", "50000")
+	os.Setenv("OIDC_PROXY_HEADERS_ENABLED", "true")
 	defer func() {
 		for _, key := range []string{
 			"LIBRARR_PORT", "LIBRARR_DB_PATH", "QB_URL",
 			"FILE_ORG_ENABLED", "ANNAS_ARCHIVE_DOMAIN", "MIN_TORRENT_SIZE_BYTES",
+			"OIDC_PROXY_HEADERS_ENABLED",
 		} {
 			os.Unsetenv(key)
 		}
@@ -107,6 +116,9 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	}
 	if cfg.MinTorrentSizeBytes != 50000 {
 		t.Errorf("expected 50000, got %d", cfg.MinTorrentSizeBytes)
+	}
+	if !cfg.OIDCProxyHeaders {
+		t.Error("expected OIDCProxyHeaders=true with env override")
 	}
 }
 


### PR DESCRIPTION
## What changed
- Added an explicit `OIDC_PROXY_HEADERS_ENABLED` toggle for trusted reverse-proxy SSO setups.
- When enabled, Librarr accepts Authentik identity headers, provisions the local user if needed, and creates the normal Librarr session automatically.
- Kept the existing username/password and standard OIDC flows unchanged unless the new toggle is enabled.
- Updated the README and example compose file to document the new option.

## Why
This removes the extra manual click on "Login with SSO" for deployments that already gate Librarr behind a trusted Authentik-aware reverse proxy.

## Validation
- `go test ./... -count=1`
- Live container rebuild and request check against `/api/config` with `X-Authentik-Username`