### PR TITLE
Add Transmission as a first-class torrent download client (#67)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,15 @@
 LIBRARR_PORT=5050
 LIBRARR_DB_PATH=/data/librarr.db
 
+# Torrent download client.
+# Librarr supports qBittorrent and Transmission. Configure one (or both and pick
+# with TORRENT_CLIENT). qBittorrent categories and Transmission labels both use
+# the QB_*_CATEGORY values below, and downloads land in the QB_*_SAVE_PATH dirs.
+#
+# TORRENT_CLIENT selects the active backend when both are configured:
+#   (empty) = auto (qBittorrent preferred), "qbittorrent", or "transmission".
+TORRENT_CLIENT=
+
 # qBittorrent
 QB_URL=http://qbittorrent:8080
 QB_USER=admin
@@ -11,6 +20,12 @@ QB_AUDIOBOOK_SAVE_PATH=/audiobooks-incoming
 QB_AUDIOBOOK_CATEGORY=audiobooks
 QB_MANGA_SAVE_PATH=/manga-incoming
 QB_MANGA_CATEGORY=manga
+
+# Transmission (alternative to qBittorrent). Requires Transmission 3.0+ for
+# label support. User/pass are optional (only if RPC auth is enabled).
+TRANSMISSION_URL=
+TRANSMISSION_USER=
+TRANSMISSION_PASS=
 
 # Prowlarr (optional -- for torrent indexer search)
 PROWLARR_URL=http://prowlarr:9696

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Librarr searches all configured indexers in parallel, scores results by confiden
 
 ### Download Management
 
-- **4 download clients** -- qBittorrent, Transmission, Deluge, SABnzbd with priority ordering
+- **Multiple download clients** -- qBittorrent or Transmission for torrents, plus SABnzbd for Usenet
 - **Request/approval workflow** -- pending, approved, searching, downloading, completed states with per-request notifications
 - **Scheduled wishlist searches** -- background scheduler auto-searches and downloads wishlist items on a configurable interval
 - **Torrent completion watcher** -- polls download client, auto-imports completed downloads
@@ -215,8 +215,14 @@ the identity header, the next request will sign the browser back in.
 
 ### Download Clients
 
+Librarr sends torrents to **either qBittorrent or Transmission**. Configure one,
+or configure both and choose with `TORRENT_CLIENT`. The category/save-path
+settings below apply to both (Transmission uses the category as a torrent label,
+which requires Transmission 3.0+).
+
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `TORRENT_CLIENT` | | Active torrent backend when both are configured: empty (auto, qBittorrent preferred), `qbittorrent`, or `transmission` |
 | `QB_URL` | | qBittorrent Web UI URL |
 | `QB_USER` | `admin` | qBittorrent username |
 | `QB_PASS` | | qBittorrent password |
@@ -227,7 +233,10 @@ the identity header, the next request will sign the browser back in.
 | `QB_MANGA_SAVE_PATH` | `/manga-incoming` | Manga download path |
 | `QB_MANGA_CATEGORY` | `manga` | Torrent category for manga |
 | `QB_PRIORITY` | `1` | Download client priority (lower = preferred) |
-| `REMOVE_TORRENT_AFTER_IMPORT` | `true` | Remove torrent from qBittorrent after a successful import. Set to `false` to keep seeding (required for private trackers with seed-time minimums). |
+| `REMOVE_TORRENT_AFTER_IMPORT` | `true` | Remove torrent from the torrent client after a successful import. Set to `false` to keep seeding (required for private trackers with seed-time minimums). |
+| `TRANSMISSION_URL` | | Transmission RPC URL (e.g. `http://transmission:9091`) |
+| `TRANSMISSION_USER` | | Transmission RPC username (optional — only if RPC auth is enabled) |
+| `TRANSMISSION_PASS` | | Transmission RPC password (optional) |
 | `SABNZBD_URL` | | SABnzbd URL |
 | `SABNZBD_API_KEY` | | SABnzbd API key |
 | `SABNZBD_CATEGORY` | `librarr` | NZB download category |
@@ -531,6 +540,7 @@ Legacy per-source env vars (e.g. `PROWLARR_URL` and other per-driver overrides) 
 |--------|------|-------------|
 | POST | `/api/test/prowlarr` | Test Prowlarr connection |
 | POST | `/api/test/qbittorrent` | Test qBittorrent connection |
+| POST | `/api/test/transmission` | Test Transmission connection |
 | POST | `/api/test/audiobookshelf` | Test Audiobookshelf connection |
 | POST | `/api/test/kavita` | Test Kavita connection |
 | POST | `/api/test/sabnzbd` | Test SABnzbd connection |

--- a/cmd/librarr/main.go
+++ b/cmd/librarr/main.go
@@ -82,14 +82,22 @@ func main() {
 
 	// Initialize download components.
 	qb := download.NewQBittorrentClient(cfg)
+	transmission := download.NewTransmissionClient(cfg)
 	sab := download.NewSABnzbdClient(cfg)
+	torrentClient := download.SelectTorrentClient(cfg, qb, transmission)
+	if torrentClient != nil {
+		slog.Info("active torrent client", "client", torrentClient.Name())
+	} else {
+		slog.Info("no torrent client configured")
+	}
 	directDL := download.NewDirectDownloader(cfg, &http.Client{Timeout: 5 * time.Minute})
 	organizer := organize.NewOrganizer(cfg)
 	targets := organize.NewLibraryTargets(cfg)
-	downloadMgr := download.NewManager(cfg, database, qb, sab, directDL, organizer, targets, health)
+	downloadMgr := download.NewManager(cfg, database, torrentClient, sab, directDL, organizer, targets, health)
 
-	// Try to connect to qBittorrent on startup.
-	if cfg.HasQBittorrent() {
+	// Try to connect to qBittorrent on startup (Transmission has no persistent
+	// login — it handshakes a session id lazily on first request).
+	if cfg.ActiveTorrentClient() == "qbittorrent" {
 		if err := qb.Login(); err != nil {
 			slog.Warn("qBittorrent initial login failed (will retry on demand)", "error", err)
 		}
@@ -100,7 +108,7 @@ func main() {
 	defer stop()
 
 	// Start torrent completion watcher.
-	watcher := download.NewWatcher(cfg, database, qb, organizer, targets, health)
+	watcher := download.NewWatcher(cfg, database, torrentClient, organizer, targets, health)
 	go watcher.Start(ctx)
 
 	// Start audiobook folder scanner (Feature 21).
@@ -108,7 +116,7 @@ func main() {
 	go scanner.Start(ctx)
 
 	// Create HTTP server (also initializes webhook sender, scheduler, series detector).
-	server := api.NewServer(cfg, database, searchMgr, downloadMgr, qb, sab, organizer, targets)
+	server := api.NewServer(cfg, database, searchMgr, downloadMgr, qb, transmission, sab, organizer, targets)
 
 	// Start scheduled search goroutine.
 	go server.StartScheduler(ctx)

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -70,10 +70,10 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTorrentDownload(w http.ResponseWriter, r *http.Request, req models.DownloadRequest) {
-	if !s.cfg.HasQBittorrent() {
+	if !s.cfg.HasTorrentClient() {
 		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
 			"success": false,
-			"error":   "qBittorrent not configured",
+			"error":   "No torrent download client configured",
 		})
 		return
 	}

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -95,6 +95,8 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]interface{}{
 		"prowlarr":            configObj(s.cfg.HasProwlarr(), s.cfg.ProwlarrURL),
 		"qbittorrent":         configObj(s.cfg.HasQBittorrent(), s.cfg.QBUrl),
+		"transmission":        configObj(s.cfg.HasTransmission(), s.cfg.TransmissionURL),
+		"torrent_client":      s.cfg.ActiveTorrentClient(),
 		"audiobookshelf":      s.cfg.HasAudiobookshelf(),
 		"kavita":              s.cfg.HasKavita(),
 		"calibre":             s.cfg.HasCalibre(),

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -29,6 +29,7 @@ type Server struct {
 	searchMgr      *search.Manager
 	downloadMgr    *download.Manager
 	qb             *download.QBittorrentClient
+	transmission   *download.TransmissionClient
 	sab            *download.SABnzbdClient
 	mux            *http.ServeMux
 	sessions       *SessionStore
@@ -46,7 +47,7 @@ type Server struct {
 }
 
 // NewServer creates the HTTP API server.
-func NewServer(cfg *config.Config, database *db.DB, searchMgr *search.Manager, downloadMgr *download.Manager, qb *download.QBittorrentClient, sab *download.SABnzbdClient, organizer *organize.Organizer, targets *organize.LibraryTargets) *Server {
+func NewServer(cfg *config.Config, database *db.DB, searchMgr *search.Manager, downloadMgr *download.Manager, qb *download.QBittorrentClient, transmission *download.TransmissionClient, sab *download.SABnzbdClient, organizer *organize.Organizer, targets *organize.LibraryTargets) *Server {
 	sessions := NewSessionStore()
 
 	// Initialize webhook sender.
@@ -99,6 +100,7 @@ func NewServer(cfg *config.Config, database *db.DB, searchMgr *search.Manager, d
 		searchMgr:      searchMgr,
 		downloadMgr:    downloadMgr,
 		qb:             qb,
+		transmission:   transmission,
 		sab:            sab,
 		mux:            http.NewServeMux(),
 		sessions:       sessions,
@@ -289,6 +291,7 @@ func (s *Server) registerRoutes() {
 	// Connection tests (admin only — SSRF risk).
 	s.mux.HandleFunc("POST /api/test/prowlarr", requireAdmin(s.handleTestProwlarr))
 	s.mux.HandleFunc("POST /api/test/qbittorrent", requireAdmin(s.handleTestQBittorrent))
+	s.mux.HandleFunc("POST /api/test/transmission", requireAdmin(s.handleTestTransmission))
 	s.mux.HandleFunc("POST /api/test/audiobookshelf", requireAdmin(s.handleTestAudiobookshelf))
 	s.mux.HandleFunc("POST /api/test/kavita", requireAdmin(s.handleTestKavita))
 	s.mux.HandleFunc("POST /api/test/sabnzbd", requireAdmin(s.handleTestSABnzbd))

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -14,14 +14,15 @@ const maskedValue = "--------"
 
 // sensitiveKeys are settings keys that should be masked in GET responses.
 var sensitiveKeys = map[string]bool{
-	"prowlarr_api_key": true,
-	"qb_pass":          true,
-	"abs_token":        true,
-	"kavita_pass":      true,
-	"api_key":          true,
-	"auth_password":    true,
-	"komga_pass":       true,
-	"sabnzbd_api_key":  true,
+	"prowlarr_api_key":  true,
+	"qb_pass":           true,
+	"abs_token":         true,
+	"kavita_pass":       true,
+	"api_key":           true,
+	"auth_password":     true,
+	"komga_pass":        true,
+	"sabnzbd_api_key":   true,
+	"transmission_pass": true,
 }
 
 func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
@@ -51,6 +52,10 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
 		"qb_url":               s.cfg.QBUrl,
 		"qb_user":              s.cfg.QBUser,
 		"qb_pass":              s.cfg.QBPass,
+		"transmission_url":     s.cfg.TransmissionURL,
+		"transmission_user":    s.cfg.TransmissionUser,
+		"transmission_pass":    s.cfg.TransmissionPass,
+		"torrent_client":       s.cfg.TorrentClient,
 		"prowlarr_url":         s.cfg.ProwlarrURL,
 		"prowlarr_api_key":     s.cfg.ProwlarrAPIKey,
 		"sabnzbd_url":          s.cfg.SABnzbdURL,
@@ -255,6 +260,12 @@ func (s *Server) handleTestProwlarr(w http.ResponseWriter, r *http.Request) {
 // handleTestQBittorrent actually tests qBittorrent login.
 func (s *Server) handleTestQBittorrent(w http.ResponseWriter, _ *http.Request) {
 	result := s.qb.Diagnose()
+	writeJSON(w, http.StatusOK, result)
+}
+
+// handleTestTransmission tests the Transmission RPC connection.
+func (s *Server) handleTestTransmission(w http.ResponseWriter, _ *http.Request) {
+	result := s.transmission.Diagnose()
 	writeJSON(w, http.StatusOK, result)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/JeremiahM37/librarr/internal/sources"
 )
@@ -158,6 +159,10 @@ type Config struct {
 	TransmissionURL  string
 	TransmissionUser string
 	TransmissionPass string
+
+	// TorrentClient explicitly selects the active torrent backend
+	// ("qbittorrent" or "transmission"). Empty means auto-detect.
+	TorrentClient string
 
 	// User Agent
 	UserAgent string
@@ -380,6 +385,8 @@ func buildFromEnv() *Config {
 		TransmissionUser: getEnv("TRANSMISSION_USER", ""),
 		TransmissionPass: getEnv("TRANSMISSION_PASS", ""),
 
+		TorrentClient: getEnv("TORRENT_CLIENT", ""),
+
 		UserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
 
 		WebhookURL:  getEnv("WEBHOOK_URL", ""),
@@ -469,6 +476,37 @@ func (c *Config) HasTransmission() bool {
 	return c.TransmissionURL != ""
 }
 
+// HasTorrentClient returns true if any torrent download backend is configured.
+func (c *Config) HasTorrentClient() bool {
+	return c.HasQBittorrent() || c.HasTransmission()
+}
+
+// ActiveTorrentClient resolves which torrent backend handles torrents:
+//   - an explicit, configured TORRENT_CLIENT wins ("qbittorrent"/"qbit"/"qb"
+//     or "transmission");
+//   - otherwise qBittorrent is preferred for backward compatibility;
+//   - otherwise Transmission if it alone is configured;
+//   - else "" (no torrent client).
+func (c *Config) ActiveTorrentClient() string {
+	switch strings.ToLower(strings.TrimSpace(c.TorrentClient)) {
+	case "qbittorrent", "qbit", "qb":
+		if c.HasQBittorrent() {
+			return "qbittorrent"
+		}
+	case "transmission":
+		if c.HasTransmission() {
+			return "transmission"
+		}
+	}
+	if c.HasQBittorrent() {
+		return "qbittorrent"
+	}
+	if c.HasTransmission() {
+		return "transmission"
+	}
+	return ""
+}
+
 // HasFlibusta returns true if Flibusta is configured and enabled.
 func (c *Config) HasFlibusta() bool {
 	return c.FlibustaEnabled && c.FlibustaURL != ""
@@ -505,6 +543,10 @@ func (c *Config) applySettingsFileOverrides() {
 		"qb_url":                    &c.QBUrl,
 		"qb_user":                   &c.QBUser,
 		"qb_pass":                   &c.QBPass,
+		"transmission_url":          &c.TransmissionURL,
+		"transmission_user":         &c.TransmissionUser,
+		"transmission_pass":         &c.TransmissionPass,
+		"torrent_client":            &c.TorrentClient,
 		"prowlarr_url":              &c.ProwlarrURL,
 		"prowlarr_api_key":          &c.ProwlarrAPIKey,
 		"sabnzbd_url":               &c.SABnzbdURL,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -419,3 +419,33 @@ func TestRemoveTorrentAfterImportDisabled(t *testing.T) {
 		t.Error("RemoveTorrentAfterImport should be false when explicitly disabled")
 	}
 }
+
+func TestActiveTorrentClient(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"none", Config{}, ""},
+		{"qb only", Config{QBUrl: "http://qb"}, "qbittorrent"},
+		{"transmission only", Config{TransmissionURL: "http://tr"}, "transmission"},
+		{"both default prefers qb", Config{QBUrl: "http://qb", TransmissionURL: "http://tr"}, "qbittorrent"},
+		{"explicit transmission", Config{QBUrl: "http://qb", TransmissionURL: "http://tr", TorrentClient: "transmission"}, "transmission"},
+		{"explicit qb alias", Config{QBUrl: "http://qb", TransmissionURL: "http://tr", TorrentClient: "qbit"}, "qbittorrent"},
+		{"explicit transmission but unconfigured falls back", Config{QBUrl: "http://qb", TorrentClient: "transmission"}, "qbittorrent"},
+	}
+	for _, c := range cases {
+		if got := c.cfg.ActiveTorrentClient(); got != c.want {
+			t.Errorf("%s: ActiveTorrentClient() = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestHasTorrentClient(t *testing.T) {
+	if (&Config{}).HasTorrentClient() {
+		t.Error("empty config should have no torrent client")
+	}
+	if !(&Config{TransmissionURL: "http://tr"}).HasTorrentClient() {
+		t.Error("transmission-only config should report a torrent client")
+	}
+}

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -20,7 +20,7 @@ import (
 type Manager struct {
 	cfg           *config.Config
 	db            *db.DB
-	qb            *QBittorrentClient
+	torrent       TorrentClient
 	sab           *SABnzbdClient
 	direct        *DirectDownloader
 	organizer     *organize.Organizer
@@ -38,11 +38,11 @@ func (m *Manager) SetWebhookSender(ws *webhook.Sender) {
 }
 
 // NewManager creates a download manager.
-func NewManager(cfg *config.Config, database *db.DB, qb *QBittorrentClient, sab *SABnzbdClient, direct *DirectDownloader, organizer *organize.Organizer, targets *organize.LibraryTargets, health *search.HealthTracker) *Manager {
+func NewManager(cfg *config.Config, database *db.DB, torrent TorrentClient, sab *SABnzbdClient, direct *DirectDownloader, organizer *organize.Organizer, targets *organize.LibraryTargets, health *search.HealthTracker) *Manager {
 	m := &Manager{
 		cfg:       cfg,
 		db:        database,
-		qb:        qb,
+		torrent:   torrent,
 		sab:       sab,
 		direct:    direct,
 		organizer: organizer,
@@ -92,9 +92,12 @@ func (m *Manager) StartAnnasDownload(md5, title string) (*models.DownloadJob, er
 	return job, nil
 }
 
-// StartTorrentDownload adds a torrent to qBittorrent.
+// StartTorrentDownload adds a torrent to the active torrent client.
 func (m *Manager) StartTorrentDownload(torrentURL, title, savePath, category string) error {
-	return m.qb.AddTorrent(torrentURL, title, savePath, category)
+	if m.torrent == nil {
+		return fmt.Errorf("no torrent download client configured")
+	}
+	return m.torrent.AddTorrent(torrentURL, title, savePath, category)
 }
 
 // StartNZBDownload sends an NZB URL to SABnzbd.
@@ -408,8 +411,8 @@ func (m *Manager) runDirectDownload(job *models.DownloadJob, fileURL, sourceID, 
 func (m *Manager) GetDownloads() []models.DownloadStatus {
 	var downloads []models.DownloadStatus
 
-	// qBittorrent torrents.
-	if m.cfg.HasQBittorrent() {
+	// Active torrent client (qBittorrent or Transmission).
+	if m.torrent != nil {
 		for _, cat := range []struct {
 			name  string
 			label string
@@ -418,7 +421,7 @@ func (m *Manager) GetDownloads() []models.DownloadStatus {
 			{m.cfg.QBAudiobookCategory, "audiobook"},
 			{m.cfg.QBMangaCategory, "manga"},
 		} {
-			torrents, err := m.qb.GetTorrents(cat.name)
+			torrents, err := m.torrent.GetTorrents(cat.name)
 			if err != nil {
 				continue
 			}
@@ -487,9 +490,12 @@ func mapSABStatus(status string) string {
 	}
 }
 
-// DeleteTorrent removes a torrent from qBittorrent.
+// DeleteTorrent removes a torrent from the active torrent client.
 func (m *Manager) DeleteTorrent(hash string) error {
-	return m.qb.DeleteTorrent(hash, true)
+	if m.torrent == nil {
+		return fmt.Errorf("no torrent download client configured")
+	}
+	return m.torrent.DeleteTorrent(hash, true)
 }
 
 // DeleteJob removes a background download job.
@@ -517,18 +523,18 @@ func (m *Manager) ClearFinished() (int, int, error) {
 		return jobsCleared, 0, err
 	}
 
-	// Clear completed qBittorrent torrents.
+	// Clear completed torrents from the active torrent client.
 	torrentsCleared := 0
-	if m.cfg.HasQBittorrent() {
+	if m.torrent != nil {
 		for _, cat := range []string{m.cfg.QBCategory, m.cfg.QBAudiobookCategory, m.cfg.QBMangaCategory} {
-			torrents, err := m.qb.GetTorrents(cat)
+			torrents, err := m.torrent.GetTorrents(cat)
 			if err != nil {
 				continue
 			}
 			for _, t := range torrents {
 				status := MapTorrentStatus(t.State)
 				if status == "completed" || t.State == "error" || t.State == "missingFiles" {
-					if err := m.qb.DeleteTorrent(t.Hash, false); err == nil {
+					if err := m.torrent.DeleteTorrent(t.Hash, false); err == nil {
 						torrentsCleared++
 					}
 				}

--- a/internal/download/qbittorrent.go
+++ b/internal/download/qbittorrent.go
@@ -28,6 +28,9 @@ type QBittorrentClient struct {
 	lastError     string
 }
 
+// Name identifies this client in logs and the TorrentClient interface.
+func (q *QBittorrentClient) Name() string { return "qbittorrent" }
+
 // NewQBittorrentClient creates a new qBittorrent API client.
 func NewQBittorrentClient(cfg *config.Config) *QBittorrentClient {
 	return &QBittorrentClient{

--- a/internal/download/torrentclient.go
+++ b/internal/download/torrentclient.go
@@ -1,0 +1,51 @@
+package download
+
+import "github.com/JeremiahM37/librarr/internal/config"
+
+// TorrentClient is the common interface implemented by every torrent download
+// backend (qBittorrent, Transmission). The rest of Librarr — the download
+// Manager and the completion Watcher — talks to torrents exclusively through
+// this interface so the active backend is a single configuration choice rather
+// than a hard dependency.
+//
+// All implementations report torrent state using the qBittorrent state
+// vocabulary so callers can keep using MapTorrentStatus uniformly. Listing and
+// deletion are scoped to torrents Librarr itself added (qBittorrent categories,
+// Transmission labels), so Librarr never touches a user's unrelated torrents.
+type TorrentClient interface {
+	// AddTorrent submits a torrent URL or magnet link. savePath and category
+	// fall back to the client's configured defaults when empty.
+	AddTorrent(torrentURL, title, savePath, category string) error
+	// GetTorrents returns torrents Librarr added under the given category
+	// (empty category returns all Librarr-scoped torrents).
+	GetTorrents(category string) ([]TorrentInfo, error)
+	// GetTorrentFiles lists the files contained in a torrent by hash.
+	GetTorrentFiles(hash string) ([]TorrentFile, error)
+	// DeleteTorrent removes a torrent by hash, optionally deleting its data.
+	DeleteTorrent(hash string, deleteFiles bool) error
+	// Diagnose reports connectivity/auth status for the settings "Test" button.
+	Diagnose() map[string]interface{}
+	// Name is the lowercase client identifier, e.g. "qbittorrent".
+	Name() string
+}
+
+// Compile-time assertions that both backends satisfy the interface.
+var (
+	_ TorrentClient = (*QBittorrentClient)(nil)
+	_ TorrentClient = (*TransmissionClient)(nil)
+)
+
+// SelectTorrentClient returns the active torrent backend per the configuration,
+// or nil when no torrent client is configured. The selection rule lives in
+// config.ActiveTorrentClient (explicit TORRENT_CLIENT override, else
+// qBittorrent-preferred auto-detect).
+func SelectTorrentClient(cfg *config.Config, qb *QBittorrentClient, tr *TransmissionClient) TorrentClient {
+	switch cfg.ActiveTorrentClient() {
+	case "qbittorrent":
+		return qb
+	case "transmission":
+		return tr
+	default:
+		return nil
+	}
+}

--- a/internal/download/transmission.go
+++ b/internal/download/transmission.go
@@ -5,14 +5,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"path"
 	"sync"
 	"time"
 
 	"github.com/JeremiahM37/librarr/internal/config"
 )
 
-// TransmissionClient wraps the Transmission RPC API.
+// TransmissionClient wraps the Transmission RPC API and satisfies TorrentClient.
+//
+// Transmission has no persistent login; instead the RPC endpoint answers the
+// first request with 409 Conflict plus an X-Transmission-Session-Id header that
+// must be echoed on subsequent requests (CSRF protection). We cache that id and
+// transparently re-handshake when it expires. Librarr scopes its torrents with
+// the qBittorrent-style category mapped onto a Transmission label, so listing
+// and clearing never touch the user's other torrents.
 type TransmissionClient struct {
 	cfg       *config.Config
 	client    *http.Client
@@ -30,6 +39,9 @@ func NewTransmissionClient(cfg *config.Config) *TransmissionClient {
 	}
 }
 
+// Name identifies this client in logs and the TorrentClient interface.
+func (t *TransmissionClient) Name() string { return "transmission" }
+
 // transmissionRequest is the RPC request format.
 type transmissionRequest struct {
 	Method    string                 `json:"method"`
@@ -42,130 +54,200 @@ type transmissionResponse struct {
 	Arguments map[string]interface{} `json:"arguments,omitempty"`
 }
 
-// AddTorrent adds a torrent by URL or magnet link.
-func (t *TransmissionClient) AddTorrent(url, downloadDir string) (map[string]interface{}, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+// transmissionTorrent is the typed view of a torrent-get result row.
+type transmissionTorrent struct {
+	ID           int      `json:"id"`
+	Name         string   `json:"name"`
+	Status       int      `json:"status"`
+	PercentDone  float64  `json:"percentDone"`
+	TotalSize    int64    `json:"totalSize"`
+	RateDownload int64    `json:"rateDownload"`
+	HashString   string   `json:"hashString"`
+	DownloadDir  string   `json:"downloadDir"`
+	Error        int      `json:"error"`
+	Labels       []string `json:"labels"`
+}
+
+// AddTorrent submits a torrent URL or magnet link to Transmission. The Librarr
+// category is attached as a Transmission label so the torrent can be found again
+// by GetTorrents; savePath becomes the download-dir. Both fall back to the
+// configured qBittorrent-equivalent defaults when empty, matching the
+// qBittorrent client's behaviour for drop-in parity.
+func (t *TransmissionClient) AddTorrent(torrentURL, title, savePath, category string) error {
+	if savePath == "" {
+		savePath = t.cfg.QBSavePath
+	}
+	if category == "" {
+		category = t.cfg.QBCategory
+	}
 
 	args := map[string]interface{}{
-		"filename": url,
+		"filename": torrentURL,
+		"paused":   false,
 	}
-	if downloadDir != "" {
-		args["download-dir"] = downloadDir
+	if savePath != "" {
+		args["download-dir"] = savePath
+	}
+	if category != "" {
+		args["labels"] = []string{category}
 	}
 
+	t.mu.Lock()
 	resp, err := t.call("torrent-add", args)
-	if err != nil {
-		return nil, err
-	}
-	if resp.Result != "success" {
-		return nil, fmt.Errorf("transmission: %s", resp.Result)
-	}
-
-	// The response may have "torrent-added" or "torrent-duplicate".
-	if added, ok := resp.Arguments["torrent-added"]; ok {
-		if m, ok := added.(map[string]interface{}); ok {
-			return m, nil
-		}
-	}
-	if dup, ok := resp.Arguments["torrent-duplicate"]; ok {
-		if m, ok := dup.(map[string]interface{}); ok {
-			return m, nil
-		}
-	}
-
-	return resp.Arguments, nil
-}
-
-// GetTorrent returns status info for torrents matching the given IDs.
-// If ids is nil, returns all torrents.
-func (t *TransmissionClient) GetTorrent(ids []int, fields []string) ([]map[string]interface{}, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if fields == nil {
-		fields = []string{"id", "name", "status", "percentDone", "totalSize", "rateDownload", "hashString"}
-	}
-
-	args := map[string]interface{}{
-		"fields": fields,
-	}
-	if ids != nil {
-		args["ids"] = ids
-	}
-
-	resp, err := t.call("torrent-get", args)
-	if err != nil {
-		return nil, err
-	}
-	if resp.Result != "success" {
-		return nil, fmt.Errorf("transmission: %s", resp.Result)
-	}
-
-	torrentsRaw, ok := resp.Arguments["torrents"]
-	if !ok {
-		return nil, nil
-	}
-
-	// Convert to []map[string]interface{}.
-	torrentsJSON, err := json.Marshal(torrentsRaw)
-	if err != nil {
-		return nil, err
-	}
-	var torrents []map[string]interface{}
-	if err := json.Unmarshal(torrentsJSON, &torrents); err != nil {
-		return nil, err
-	}
-	return torrents, nil
-}
-
-// RemoveTorrent removes torrents by ID.
-func (t *TransmissionClient) RemoveTorrent(ids []int, deleteData bool) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	resp, err := t.call("torrent-remove", map[string]interface{}{
-		"ids":               ids,
-		"delete-local-data": deleteData,
-	})
+	t.mu.Unlock()
 	if err != nil {
 		return err
 	}
 	if resp.Result != "success" {
-		return fmt.Errorf("transmission: %s", resp.Result)
+		return fmt.Errorf("transmission add torrent: %s", resp.Result)
+	}
+
+	// A "torrent-duplicate" result is not an error — the torrent is already
+	// present, which is the desired end state.
+	slog.Info("torrent added to Transmission", "title", title, "category", category)
+	return nil
+}
+
+// GetTorrents returns Librarr-scoped torrents, optionally filtered to a single
+// category (label). State is reported using the qBittorrent vocabulary so
+// callers can keep using MapTorrentStatus.
+func (t *TransmissionClient) GetTorrents(category string) ([]TorrentInfo, error) {
+	fields := []string{
+		"id", "name", "status", "percentDone", "totalSize",
+		"rateDownload", "hashString", "downloadDir", "error", "labels",
+	}
+
+	t.mu.Lock()
+	resp, err := t.call("torrent-get", map[string]interface{}{"fields": fields})
+	t.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if resp.Result != "success" {
+		return nil, fmt.Errorf("transmission get torrents: %s", resp.Result)
+	}
+
+	raw, ok := resp.Arguments["torrents"]
+	if !ok {
+		return nil, nil
+	}
+	rawJSON, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var rows []transmissionTorrent
+	if err := json.Unmarshal(rawJSON, &rows); err != nil {
+		return nil, err
+	}
+
+	var out []TorrentInfo
+	for _, r := range rows {
+		// Only surface torrents Librarr added (those carrying our label).
+		if !hasLabel(r.Labels, category) {
+			continue
+		}
+		out = append(out, TorrentInfo{
+			Name:        r.Name,
+			Hash:        r.HashString,
+			State:       mapTransmissionState(r.Status, r.PercentDone, r.Error),
+			Progress:    r.PercentDone,
+			TotalSize:   r.TotalSize,
+			DlSpeed:     r.RateDownload,
+			Category:    firstLabel(r.Labels),
+			SavePath:    r.DownloadDir,
+			ContentPath: path.Join(r.DownloadDir, r.Name),
+		})
+	}
+	return out, nil
+}
+
+// GetTorrentFiles lists the files inside a torrent identified by hash.
+func (t *TransmissionClient) GetTorrentFiles(hash string) ([]TorrentFile, error) {
+	t.mu.Lock()
+	resp, err := t.call("torrent-get", map[string]interface{}{
+		"ids":    []string{hash},
+		"fields": []string{"files"},
+	})
+	t.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if resp.Result != "success" {
+		return nil, fmt.Errorf("transmission get files: %s", resp.Result)
+	}
+
+	raw, ok := resp.Arguments["torrents"]
+	if !ok {
+		return nil, nil
+	}
+	rawJSON, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var rows []struct {
+		Files []struct {
+			Name string `json:"name"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(rawJSON, &rows); err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	var files []TorrentFile
+	for _, f := range rows[0].Files {
+		files = append(files, TorrentFile{Name: f.Name})
+	}
+	return files, nil
+}
+
+// DeleteTorrent removes a torrent by hash. Transmission accepts SHA-1 hash
+// strings directly in the "ids" array.
+func (t *TransmissionClient) DeleteTorrent(hash string, deleteFiles bool) error {
+	t.mu.Lock()
+	resp, err := t.call("torrent-remove", map[string]interface{}{
+		"ids":               []string{hash},
+		"delete-local-data": deleteFiles,
+	})
+	t.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if resp.Result != "success" {
+		return fmt.Errorf("transmission remove torrent: %s", resp.Result)
 	}
 	return nil
 }
 
-// Diagnose tests the Transmission connection.
+// Diagnose tests the Transmission connection for the settings "Test" button.
 func (t *TransmissionClient) Diagnose() map[string]interface{} {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+	if !t.cfg.HasTransmission() {
+		return map[string]interface{}{"success": false, "error": "Transmission not configured"}
+	}
 
+	t.mu.Lock()
 	resp, err := t.call("session-get", nil)
+	t.mu.Unlock()
 	if err != nil {
-		return map[string]interface{}{
-			"success": false,
-			"error":   err.Error(),
-		}
+		return map[string]interface{}{"success": false, "error": err.Error()}
 	}
 	if resp.Result != "success" {
-		return map[string]interface{}{
-			"success": false,
-			"error":   resp.Result,
-		}
+		return map[string]interface{}{"success": false, "error": resp.Result}
 	}
-	return map[string]interface{}{
-		"success": true,
+
+	result := map[string]interface{}{"success": true}
+	if v, ok := resp.Arguments["version"].(string); ok {
+		result["version"] = v
 	}
+	return result
 }
 
+// call performs an RPC call, transparently handling the 409 session-id
+// handshake. Callers must hold t.mu.
 func (t *TransmissionClient) call(method string, args map[string]interface{}) (*transmissionResponse, error) {
-	reqBody := transmissionRequest{
-		Method:    method,
-		Arguments: args,
-	}
-
+	reqBody := transmissionRequest{Method: method, Arguments: args}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, err
@@ -177,7 +259,8 @@ func (t *TransmissionClient) call(method string, args map[string]interface{}) (*
 		return nil, err
 	}
 
-	// Handle 409 Conflict — Transmission requires a session-id header.
+	// Handle 409 Conflict — Transmission requires a session-id header that it
+	// hands back on the first request. Cache it and replay once.
 	if resp.StatusCode == http.StatusConflict {
 		t.sessionID = resp.Header.Get("X-Transmission-Session-Id")
 		resp.Body.Close()
@@ -194,6 +277,9 @@ func (t *TransmissionClient) call(method string, args map[string]interface{}) (*
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, fmt.Errorf("transmission: authentication failed")
 	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("transmission: HTTP %d", resp.StatusCode)
+	}
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -204,7 +290,6 @@ func (t *TransmissionClient) call(method string, args map[string]interface{}) (*
 	if err := json.Unmarshal(respBody, &trResp); err != nil {
 		return nil, fmt.Errorf("transmission: invalid JSON response")
 	}
-
 	return &trResp, nil
 }
 
@@ -221,4 +306,55 @@ func (t *TransmissionClient) doRequest(url string, body []byte) (*http.Response,
 		req.SetBasicAuth(t.cfg.TransmissionUser, t.cfg.TransmissionPass)
 	}
 	return t.client.Do(req)
+}
+
+// mapTransmissionState converts a Transmission status code into the qBittorrent
+// state vocabulary so MapTorrentStatus works uniformly across backends.
+//
+// Transmission status codes: 0 stopped, 1 check-wait, 2 checking,
+// 3 download-wait, 4 downloading, 5 seed-wait, 6 seeding.
+func mapTransmissionState(status int, percentDone float64, errCode int) string {
+	if errCode != 0 {
+		return "error"
+	}
+	switch status {
+	case 0: // stopped — distinguish finished vs paused-incomplete
+		if percentDone >= 1 {
+			return "pausedUP"
+		}
+		return "pausedDL"
+	case 1, 2: // verifying
+		return "checkingDL"
+	case 3: // queued to download
+		return "queuedDL"
+	case 4: // downloading
+		return "downloading"
+	case 5: // queued to seed
+		return "queuedUP"
+	case 6: // seeding (treated as completed, like qBittorrent "uploading")
+		return "uploading"
+	default:
+		return "downloading"
+	}
+}
+
+// hasLabel reports whether labels contains want. An empty want matches any
+// torrent (used for "list everything Librarr could see").
+func hasLabel(labels []string, want string) bool {
+	if want == "" {
+		return true
+	}
+	for _, l := range labels {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+func firstLabel(labels []string) string {
+	if len(labels) > 0 {
+		return labels[0]
+	}
+	return ""
 }

--- a/internal/download/transmission_test.go
+++ b/internal/download/transmission_test.go
@@ -1,0 +1,270 @@
+package download
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+)
+
+// mockTransmission is a configurable Transmission RPC test double. It enforces
+// the 409 session-id handshake on the first request, then records and answers
+// torrent-add / torrent-get / torrent-remove / session-get calls.
+type mockTransmission struct {
+	requireSession bool
+	sessionID      string
+	gotSession     bool
+
+	lastMethod string
+	lastArgs   map[string]interface{}
+
+	// torrents returned by torrent-get (already shaped as RPC rows).
+	torrents []map[string]interface{}
+	// files returned for torrent-get fields=["files"].
+	files []map[string]interface{}
+}
+
+func (m *mockTransmission) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// CSRF handshake: first request (or any without the header) gets 409.
+		if m.requireSession && r.Header.Get("X-Transmission-Session-Id") != m.sessionID {
+			w.Header().Set("X-Transmission-Session-Id", m.sessionID)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		m.gotSession = true
+
+		body, _ := io.ReadAll(r.Body)
+		var req transmissionRequest
+		_ = json.Unmarshal(body, &req)
+		m.lastMethod = req.Method
+		m.lastArgs = req.Arguments
+
+		resp := transmissionResponse{Result: "success", Arguments: map[string]interface{}{}}
+		switch req.Method {
+		case "session-get":
+			resp.Arguments["version"] = "4.0.5"
+		case "torrent-get":
+			// If the caller asked for files, answer with the files payload.
+			if fields, ok := req.Arguments["fields"].([]interface{}); ok && hasField(fields, "files") {
+				resp.Arguments["torrents"] = []map[string]interface{}{
+					{"files": m.files},
+				}
+			} else {
+				resp.Arguments["torrents"] = m.torrents
+			}
+		case "torrent-add":
+			resp.Arguments["torrent-added"] = map[string]interface{}{
+				"hashString": "newhash", "id": 1, "name": "added",
+			}
+		case "torrent-remove":
+			// no-op success
+		}
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func hasField(fields []interface{}, want string) bool {
+	for _, f := range fields {
+		if s, ok := f.(string); ok && s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestTransmission(serverURL string) *TransmissionClient {
+	return NewTransmissionClient(&config.Config{
+		TransmissionURL: serverURL,
+		QBSavePath:      "/downloads",
+		QBCategory:      "librarr",
+	})
+}
+
+func TestTransmission_SessionHandshakeAndDiagnose(t *testing.T) {
+	mock := &mockTransmission{requireSession: true, sessionID: "sess-xyz"}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	tc := newTestTransmission(srv.URL)
+	res := tc.Diagnose()
+	if res["success"] != true {
+		t.Fatalf("Diagnose expected success, got %#v", res)
+	}
+	if res["version"] != "4.0.5" {
+		t.Errorf("expected version 4.0.5, got %v", res["version"])
+	}
+	if tc.sessionID != "sess-xyz" {
+		t.Errorf("expected session id to be cached, got %q", tc.sessionID)
+	}
+}
+
+func TestTransmission_DiagnoseNotConfigured(t *testing.T) {
+	tc := NewTransmissionClient(&config.Config{})
+	res := tc.Diagnose()
+	if res["success"] != false {
+		t.Fatalf("expected failure when not configured, got %#v", res)
+	}
+}
+
+func TestTransmission_AddTorrentSetsLabelAndDownloadDir(t *testing.T) {
+	mock := &mockTransmission{requireSession: true, sessionID: "s"}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	tc := newTestTransmission(srv.URL)
+	if err := tc.AddTorrent("magnet:?xt=urn:btih:abc", "Some Book", "/audiobooks-incoming", "audiobooks"); err != nil {
+		t.Fatalf("AddTorrent error: %v", err)
+	}
+	if mock.lastMethod != "torrent-add" {
+		t.Fatalf("expected torrent-add, got %s", mock.lastMethod)
+	}
+	if mock.lastArgs["download-dir"] != "/audiobooks-incoming" {
+		t.Errorf("download-dir = %v, want /audiobooks-incoming", mock.lastArgs["download-dir"])
+	}
+	labels, ok := mock.lastArgs["labels"].([]interface{})
+	if !ok || len(labels) != 1 || labels[0] != "audiobooks" {
+		t.Errorf("labels = %v, want [audiobooks]", mock.lastArgs["labels"])
+	}
+	if mock.lastArgs["filename"] != "magnet:?xt=urn:btih:abc" {
+		t.Errorf("filename = %v", mock.lastArgs["filename"])
+	}
+}
+
+func TestTransmission_AddTorrentFallsBackToDefaults(t *testing.T) {
+	mock := &mockTransmission{}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	tc := newTestTransmission(srv.URL) // QBSavePath=/downloads, QBCategory=librarr
+	if err := tc.AddTorrent("http://x/t.torrent", "T", "", ""); err != nil {
+		t.Fatalf("AddTorrent error: %v", err)
+	}
+	if mock.lastArgs["download-dir"] != "/downloads" {
+		t.Errorf("download-dir default = %v, want /downloads", mock.lastArgs["download-dir"])
+	}
+	labels := mock.lastArgs["labels"].([]interface{})
+	if labels[0] != "librarr" {
+		t.Errorf("label default = %v, want librarr", labels[0])
+	}
+}
+
+func TestTransmission_GetTorrentsFiltersByLabelAndMapsState(t *testing.T) {
+	mock := &mockTransmission{
+		torrents: []map[string]interface{}{
+			{ // ours, seeding (status 6) => uploading => completed
+				"name": "Mine", "hashString": "h1", "status": 6,
+				"percentDone": 1.0, "totalSize": 1000, "rateDownload": 0,
+				"downloadDir": "/downloads", "error": 0, "labels": []string{"librarr"},
+			},
+			{ // someone else's torrent — must be filtered out
+				"name": "NotMine", "hashString": "h2", "status": 4,
+				"percentDone": 0.5, "totalSize": 2000, "rateDownload": 500,
+				"downloadDir": "/other", "error": 0, "labels": []string{"sonarr"},
+			},
+			{ // ours, downloading (status 4)
+				"name": "Mine2", "hashString": "h3", "status": 4,
+				"percentDone": 0.25, "totalSize": 4000, "rateDownload": 100,
+				"downloadDir": "/downloads", "error": 0, "labels": []string{"librarr"},
+			},
+		},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	tc := newTestTransmission(srv.URL)
+	got, err := tc.GetTorrents("librarr")
+	if err != nil {
+		t.Fatalf("GetTorrents error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 librarr torrents, got %d: %#v", len(got), got)
+	}
+
+	byHash := map[string]TorrentInfo{}
+	for _, ti := range got {
+		byHash[ti.Hash] = ti
+	}
+	if _, ok := byHash["h2"]; ok {
+		t.Error("non-librarr torrent leaked into results")
+	}
+	if MapTorrentStatus(byHash["h1"].State) != "completed" {
+		t.Errorf("seeding torrent should map to completed, got %q -> %q", byHash["h1"].State, MapTorrentStatus(byHash["h1"].State))
+	}
+	if MapTorrentStatus(byHash["h3"].State) != "downloading" {
+		t.Errorf("downloading torrent state = %q -> %q", byHash["h3"].State, MapTorrentStatus(byHash["h3"].State))
+	}
+	if byHash["h1"].ContentPath != "/downloads/Mine" {
+		t.Errorf("ContentPath = %q, want /downloads/Mine", byHash["h1"].ContentPath)
+	}
+	if byHash["h3"].Progress != 0.25 {
+		t.Errorf("Progress = %v, want 0.25", byHash["h3"].Progress)
+	}
+}
+
+func TestTransmission_GetTorrentFiles(t *testing.T) {
+	mock := &mockTransmission{
+		files: []map[string]interface{}{
+			{"name": "Book/chapter1.epub", "length": 100},
+			{"name": "Book/chapter2.epub", "length": 200},
+		},
+	}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	tc := newTestTransmission(srv.URL)
+	files, err := tc.GetTorrentFiles("h1")
+	if err != nil {
+		t.Fatalf("GetTorrentFiles error: %v", err)
+	}
+	if len(files) != 2 || files[0].Name != "Book/chapter1.epub" {
+		t.Fatalf("unexpected files: %#v", files)
+	}
+}
+
+func TestTransmission_DeleteTorrentSendsHashAndFlag(t *testing.T) {
+	mock := &mockTransmission{}
+	srv := httptest.NewServer(mock.handler())
+	defer srv.Close()
+
+	tc := newTestTransmission(srv.URL)
+	if err := tc.DeleteTorrent("h1", true); err != nil {
+		t.Fatalf("DeleteTorrent error: %v", err)
+	}
+	if mock.lastMethod != "torrent-remove" {
+		t.Fatalf("expected torrent-remove, got %s", mock.lastMethod)
+	}
+	if mock.lastArgs["delete-local-data"] != true {
+		t.Errorf("delete-local-data = %v, want true", mock.lastArgs["delete-local-data"])
+	}
+	ids, ok := mock.lastArgs["ids"].([]interface{})
+	if !ok || len(ids) != 1 || ids[0] != "h1" {
+		t.Errorf("ids = %v, want [h1]", mock.lastArgs["ids"])
+	}
+}
+
+func TestMapTransmissionState(t *testing.T) {
+	cases := []struct {
+		status      int
+		percentDone float64
+		errCode     int
+		want        string
+	}{
+		{0, 0.5, 0, "pausedDL"},
+		{0, 1.0, 0, "pausedUP"},
+		{2, 0.0, 0, "checkingDL"},
+		{3, 0.0, 0, "queuedDL"},
+		{4, 0.3, 0, "downloading"},
+		{5, 1.0, 0, "queuedUP"},
+		{6, 1.0, 0, "uploading"},
+		{4, 0.3, 3, "error"}, // error code overrides status
+	}
+	for _, c := range cases {
+		if got := mapTransmissionState(c.status, c.percentDone, c.errCode); got != c.want {
+			t.Errorf("mapTransmissionState(%d,%v,%d) = %q, want %q", c.status, c.percentDone, c.errCode, got, c.want)
+		}
+	}
+}

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -18,11 +18,12 @@ import (
 	"github.com/JeremiahM37/librarr/internal/search"
 )
 
-// Watcher monitors qBittorrent for completed torrents and runs the import pipeline.
+// Watcher monitors the active torrent client for completed torrents and runs
+// the import pipeline.
 type Watcher struct {
 	cfg       *config.Config
 	db        *db.DB
-	qb        *QBittorrentClient
+	torrent   TorrentClient
 	organizer *organize.Organizer
 	targets   *organize.LibraryTargets
 	health    *search.HealthTracker
@@ -32,11 +33,11 @@ type Watcher struct {
 }
 
 // NewWatcher creates a new torrent completion watcher.
-func NewWatcher(cfg *config.Config, database *db.DB, qb *QBittorrentClient, organizer *organize.Organizer, targets *organize.LibraryTargets, health *search.HealthTracker) *Watcher {
+func NewWatcher(cfg *config.Config, database *db.DB, torrent TorrentClient, organizer *organize.Organizer, targets *organize.LibraryTargets, health *search.HealthTracker) *Watcher {
 	return &Watcher{
 		cfg:       cfg,
 		db:        database,
-		qb:        qb,
+		torrent:   torrent,
 		organizer: organizer,
 		targets:   targets,
 		health:    health,
@@ -45,12 +46,12 @@ func NewWatcher(cfg *config.Config, database *db.DB, qb *QBittorrentClient, orga
 
 // Start begins the background watcher loop. It blocks until ctx is cancelled.
 func (w *Watcher) Start(ctx context.Context) {
-	if !w.cfg.HasQBittorrent() {
-		slog.Info("torrent watcher disabled (qBittorrent not configured)")
+	if w.torrent == nil {
+		slog.Info("torrent watcher disabled (no torrent client configured)")
 		return
 	}
 
-	slog.Info("torrent completion watcher started", "interval", "30s")
+	slog.Info("torrent completion watcher started", "client", w.torrent.Name(), "interval", "30s")
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
@@ -79,7 +80,7 @@ func (w *Watcher) checkCompleted() {
 	}
 
 	for _, cat := range categories {
-		torrents, err := w.qb.GetTorrents(cat.name)
+		torrents, err := w.torrent.GetTorrents(cat.name)
 		if err != nil {
 			continue
 		}
@@ -127,7 +128,7 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 	// Optionally remove torrent from qBit after import. Default is to remove;
 	// set REMOVE_TORRENT_AFTER_IMPORT=false to keep seeding (e.g. private trackers).
 	if w.cfg.RemoveTorrentAfterImport {
-		if err := w.qb.DeleteTorrent(t.Hash, false); err != nil {
+		if err := w.torrent.DeleteTorrent(t.Hash, false); err != nil {
 			slog.Warn("failed to remove torrent after import", "hash", t.Hash, "error", err)
 		} else {
 			slog.Info("removed completed torrent", "name", t.Name)
@@ -159,8 +160,8 @@ func (w *Watcher) resolveLocalPath(t TorrentInfo, mediaType string) string {
 	// Fetch files from qBittorrent to find the actual root folder/file.
 	var files []TorrentFile
 	var err error
-	if w.qb != nil {
-		files, err = w.qb.GetTorrentFiles(t.Hash)
+	if w.torrent != nil {
+		files, err = w.torrent.GetTorrentFiles(t.Hash)
 	}
 	if err == nil && len(files) > 0 {
 		var firstPart string

--- a/internal/download/watcher_test.go
+++ b/internal/download/watcher_test.go
@@ -194,7 +194,7 @@ func TestResolveLocalPathUsesGetTorrentFilesWhenContentPathEmpty(t *testing.T) {
 			QBAudiobookSavePath: "/downloads/audiobooks-incoming",
 			IncomingDir:         "/downloads/incoming",
 		},
-		qb: qb,
+		torrent: qb,
 	}
 
 	got := w.resolveLocalPath(TorrentInfo{
@@ -222,7 +222,7 @@ func TestResolveLocalPathSingleFileNoSubfolder(t *testing.T) {
 			QBAudiobookSavePath: "/downloads/audiobooks-incoming",
 			IncomingDir:         "/downloads/incoming",
 		},
-		qb: qb,
+		torrent: qb,
 	}
 
 	got := w.resolveLocalPath(TorrentInfo{
@@ -251,7 +251,7 @@ func TestResolveLocalPathMultiFileDifferentRootsFallsBack(t *testing.T) {
 			QBAudiobookSavePath: "/downloads/audiobooks-incoming",
 			IncomingDir:         "/downloads/incoming",
 		},
-		qb: qb,
+		torrent: qb,
 	}
 
 	got := w.resolveLocalPath(TorrentInfo{
@@ -286,7 +286,7 @@ func TestResolveLocalPathAPIErrorFallsBackToName(t *testing.T) {
 			QBAudiobookSavePath: "/downloads/audiobooks-incoming",
 			IncomingDir:         "/downloads/incoming",
 		},
-		qb: qb,
+		torrent: qb,
 	}
 
 	got := w.resolveLocalPath(TorrentInfo{
@@ -313,7 +313,7 @@ func TestResolveLocalPathContentPathTakesPrecedence(t *testing.T) {
 			QBAudiobookSavePath: "/downloads/audiobooks-incoming",
 			IncomingDir:         "/downloads/incoming",
 		},
-		qb: qb,
+		torrent: qb,
 	}
 
 	got := w.resolveLocalPath(TorrentInfo{

--- a/web/index.html
+++ b/web/index.html
@@ -483,6 +483,37 @@ tailwind.config = {
             </div>
           </div>
 
+          <!-- Transmission -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">Transmission</h4>
+              <button onclick="saveIntegration('transmission')" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">URL</label>
+                <input type="text" id="setting-transmission_url" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="http://transmission:9091">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Username</label>
+                <input type="text" id="setting-transmission_user" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="(optional)">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Password</label>
+                <input type="password" id="setting-transmission_pass" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="(optional)">
+              </div>
+            </div>
+            <div class="mt-3">
+              <label class="block text-xs text-slate-500 mb-1">Active torrent client</label>
+              <select id="setting-torrent_client" class="w-full md:w-1/3 bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200">
+                <option value="">Auto (qBittorrent preferred)</option>
+                <option value="qbittorrent">qBittorrent</option>
+                <option value="transmission">Transmission</option>
+              </select>
+              <p class="text-xs text-slate-500 mt-1">Only matters when both qBittorrent and Transmission are configured. Restart the container after changing.</p>
+            </div>
+          </div>
+
           <!-- SABnzbd -->
           <div class="bg-slate-800/40 rounded-lg p-4">
             <div class="flex items-center justify-between mb-3">
@@ -604,6 +635,13 @@ tailwind.config = {
             <div class="flex items-center gap-2">
               <span id="test-qbittorrent-status" class="text-xs text-slate-500" data-i18n="not_tested">Not tested</span>
               <button onclick="testConnection('qbittorrent')" class="px-2.5 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-slate-300 rounded transition-colors" data-i18n="btn_test">Test</button>
+            </div>
+          </div>
+          <div class="flex items-center justify-between bg-slate-800/50 rounded-lg px-4 py-3">
+            <span class="text-sm text-slate-300" data-i18n="conn_transmission">Transmission</span>
+            <div class="flex items-center gap-2">
+              <span id="test-transmission-status" class="text-xs text-slate-500" data-i18n="not_tested">Not tested</span>
+              <button onclick="testConnection('transmission')" class="px-2.5 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-slate-300 rounded transition-colors" data-i18n="btn_test">Test</button>
             </div>
           </div>
           <div class="flex items-center justify-between bg-slate-800/50 rounded-lg px-4 py-3">
@@ -824,6 +862,7 @@ const I18N = {
     s_connection_tests: 'Connection Tests',
     conn_prowlarr: 'Prowlarr',
     conn_qbittorrent: 'qBittorrent',
+    conn_transmission: 'Transmission',
     conn_sabnzbd: 'SABnzbd',
     conn_audiobookshelf: 'Audiobookshelf',
     conn_kavita: 'Kavita',
@@ -1024,6 +1063,7 @@ const I18N = {
     s_connection_tests: 'Проверка подключений',
     conn_prowlarr: 'Prowlarr',
     conn_qbittorrent: 'qBittorrent',
+    conn_transmission: 'Transmission',
     conn_sabnzbd: 'SABnzbd',
     conn_audiobookshelf: 'Audiobookshelf',
     conn_kavita: 'Kavita',
@@ -2615,6 +2655,7 @@ document.getElementById('change-password-form').addEventListener('submit', async
 const INTEGRATION_FIELDS = {
   prowlarr:       ['prowlarr_url', 'prowlarr_api_key'],
   qbittorrent:    ['qb_url', 'qb_user', 'qb_pass'],
+  transmission:   ['transmission_url', 'transmission_user', 'transmission_pass', 'torrent_client'],
   sabnzbd:        ['sabnzbd_url', 'sabnzbd_api_key', 'sabnzbd_category'],
   audiobookshelf: ['abs_url', 'abs_token'],
   kavita:         ['kavita_url', 'kavita_user', 'kavita_pass'],
@@ -2683,6 +2724,7 @@ async function loadConfig() {
 
     if (data.prowlarr) items.push(configItem('Prowlarr', data.prowlarr.url || t('not_configured')));
     if (data.qbittorrent) items.push(configItem('qBittorrent', data.qbittorrent.url || t('not_configured')));
+    if (data.transmission) items.push(configItem('Transmission', data.transmission.url || t('not_configured')));
     if (data.sabnzbd) items.push(configItem('SABnzbd', data.sabnzbd.url || t('not_configured')));
     if (data.kavita_url) items.push(configItem('Kavita', data.kavita_url));
     if (data.audiobookshelf_url) items.push(configItem('Audiobookshelf', data.audiobookshelf_url));


### PR DESCRIPTION
Closes #67.

## Summary

`Transmission` (and `Deluge`) RPC clients already existed in `internal/download/`, but **only qBittorrent was ever wired into the download path** — the `Manager`, the completion `Watcher`, and the API all referenced `*QBittorrentClient` directly, so the Transmission client was effectively dead code and the feature in #67 was unimplemented. The README already advertised Transmission support, which wasn't actually true.

This PR introduces a small `TorrentClient` abstraction and routes every torrent operation through the *active* client, so qBittorrent and Transmission are now interchangeable.

## What changed

- **`internal/download/torrentclient.go` (new):** `TorrentClient` interface (`AddTorrent`/`GetTorrents`/`GetTorrentFiles`/`DeleteTorrent`/`Diagnose`/`Name`) + `SelectTorrentClient`. Compile-time assertions that both backends satisfy it.
- **`transmission.go`:** rewritten to implement `TorrentClient`. It
  - keeps the `409` session-id handshake (CSRF),
  - reports state using the **qBittorrent state vocabulary** so `MapTorrentStatus` stays uniform across backends,
  - scopes its view to **Librarr-added torrents only**, via a Transmission **label** (= the existing per-media category) — so Librarr never lists or clears a user's unrelated torrents,
  - maps the category → label and save-path → download-dir for drop-in parity with the qBittorrent client.
- **`Manager` + `Watcher`:** now hold a `TorrentClient` instead of a concrete `*QBittorrentClient`.
- **Config:** `TORRENT_CLIENT` selector (empty = auto, qBittorrent-preferred / `qbittorrent` / `transmission`), `HasTorrentClient()` / `ActiveTorrentClient()`, plus settings-file persistence for the Transmission fields.
- **API:** `POST /api/test/transmission`, Transmission surfaced in `/api/config` + `/api/settings`, and torrent downloads no longer hard-require qBittorrent.
- **Settings UI:** Transmission card (URL / user / pass) + an "active torrent client" selector + a connection-test row.
- **Docs:** `README.md` and `.env.example` updated (and the inaccurate "4 download clients … with priority ordering" line corrected).

> Scope note: Transmission requires **3.0+** for label support. Deluge remains unwired (out of scope for #67); its dead client is left untouched.

## Tests

- `internal/download/transmission_test.go` (new): RPC client against an `httptest` Transmission double — 409 handshake, `Diagnose`, `AddTorrent` (label + download-dir, and default fallbacks), `GetTorrents` label-filtering + status mapping + content-path, `GetTorrentFiles`, `DeleteTorrent`, and `mapTransmissionState`.
- `internal/config/config_test.go`: `ActiveTorrentClient` / `HasTorrentClient` selection matrix.
- Full suite green: `go build ./...`, `go vet ./...`, `gofmt`, `go test ./...`.

## Manual end-to-end verification

Built a static binary and ran it against a **real Transmission 4.0.5/4.1.2** daemon (linuxserver/transmission), driving everything through the normal `/api/download` user flow:

- `POST /api/test/transmission` → `{"success":true,"version":"4.1.2 …"}` (live session handshake).
- Added a torrent through Librarr → appeared in Transmission carrying the `librarr` label.
- A `sonarr`-labelled torrent added out-of-band was correctly **not** shown by Librarr (label scoping).
- Completed torrent → watcher imported the EPUB, organized it into the library (author extracted from EPUB metadata), recorded the library item, then auto-removed the torrent (`REMOVE_TORRENT_AFTER_IMPORT`).
- User-facing `DELETE /api/downloads/torrent/{hash}` removed it from Transmission.
