### PR TITLE
Don't treat Transmission tracker warnings/errors as fatal

### DIFF
--- a/internal/download/transmission.go
+++ b/internal/download/transmission.go
@@ -313,8 +313,16 @@ func (t *TransmissionClient) doRequest(url string, body []byte) (*http.Response,
 //
 // Transmission status codes: 0 stopped, 1 check-wait, 2 checking,
 // 3 download-wait, 4 downloading, 5 seed-wait, 6 seeding.
+//
+// Transmission error codes: 0 ok, 1 tracker warning, 2 tracker error,
+// 3 local error. Only a local error (3 — disk full, permissions, missing
+// data) is fatal. Tracker warning/error are NOT: the torrent keeps working
+// via DHT/PEX/webseeds and routinely shows code 1/2 on public torrents with a
+// flaky tracker. Treating those as "error" would both mislabel healthy
+// torrents and let ClearFinished remove a still-downloading torrent, so we
+// fall through to the status-based mapping for codes 1 and 2.
 func mapTransmissionState(status int, percentDone float64, errCode int) string {
-	if errCode != 0 {
+	if errCode == 3 {
 		return "error"
 	}
 	switch status {

--- a/internal/download/transmission_test.go
+++ b/internal/download/transmission_test.go
@@ -260,7 +260,10 @@ func TestMapTransmissionState(t *testing.T) {
 		{4, 0.3, 0, "downloading"},
 		{5, 1.0, 0, "queuedUP"},
 		{6, 1.0, 0, "uploading"},
-		{4, 0.3, 3, "error"}, // error code overrides status
+		{4, 0.3, 3, "error"},       // local error (code 3) is fatal
+		{4, 0.3, 1, "downloading"}, // tracker warning is non-fatal — keep downloading
+		{4, 0.3, 2, "downloading"}, // tracker error is non-fatal — keep downloading
+		{6, 1.0, 2, "uploading"},   // seeding with a dead tracker is still seeding/complete
 	}
 	for _, c := range cases {
 		if got := mapTransmissionState(c.status, c.percentDone, c.errCode); got != c.want {


### PR DESCRIPTION
Follow-up to #68.

## Problem

`mapTransmissionState` treated **any** non-zero Transmission error code as the `"error"` state:

```go
if errCode != 0 {
    return "error"
}
```

But Transmission's error codes are `0` ok, `1` tracker **warning**, `2` tracker **error**, `3` **local** error. Codes 1 and 2 are *non-fatal* — the torrent keeps downloading and seeding via DHT/PEX/webseeds, and public torrents routinely report a tracker warning/error when one tracker is flaky or dead. Only code 3 (disk full, permissions, missing data) is a real failure.

Mapping 1/2 to `"error"` had two consequences:

1. **Cosmetic:** healthy, actively-downloading torrents showed as errored in the downloads view.
2. **Worse — data loss:** `Manager.ClearFinished()` removes any torrent whose state is `"error"`, so clicking **Clear finished** could remove a torrent that was still downloading and merely had a tracker warning. (qBittorrent never enters an error state for tracker issues, so this was a Transmission-only regression introduced in #68.)

## Fix

Only treat local errors (code 3) as fatal; let codes 1 and 2 fall through to the normal status-based mapping. One-line change plus regression tests for codes 1 and 2.

```go
if errCode == 3 {
    return "error"
}
```

## Tests

`TestMapTransmissionState` gains cases asserting that a tracker warning (1) and tracker error (2) map to `downloading`/`uploading` by status rather than `error`. Full suite green (`go build`/`vet`/`gofmt`/`go test ./...`).
