### PR TITLE
Add off-by-default live registry canary test

### DIFF
--- a/.github/workflows/live-registry.yml
+++ b/.github/workflows/live-registry.yml
@@ -1,0 +1,20 @@
+name: Live Registry Canary
+# Validates the live librarr-sources companion registry the production binary
+# fetches at runtime. Runs on a schedule (and on demand) only — never on push
+# or PR — so a GitHub/raw outage can't block normal CI or releases. A failure
+# means the registry is unreachable, returning bad data, or its schema drifted.
+on:
+  schedule:
+    - cron: '17 6 * * 1' # weekly, Monday 06:17 UTC
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: {go-version: '1.25.x', cache: false, check-latest: true}
+      - name: live registry test
+        run: go test -tags live ./internal/sources/ -run TestLive -v -count=1

--- a/internal/sources/live_test.go
+++ b/internal/sources/live_test.go
@@ -1,0 +1,63 @@
+//go:build live
+
+// This file is excluded from the default build. It holds tests that hit the
+// real network and are meant to run on a schedule (or manually), never as part
+// of `go test ./...`. Run with:
+//
+//	go test -tags live ./internal/sources/ -run TestLive -v
+package sources_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/sources"
+)
+
+// TestLiveDefaultRegistry fetches the registry from the real default URL the
+// production binary uses and asserts it is reachable and complete.
+//
+// Unlike TestCanonicalRegistryIsComplete (which validates the in-repo fixture),
+// this catches drift in the live librarr-sources companion repo: the file
+// moving or being removed, a non-2xx response, malformed JSON, or a schema
+// change that leaves fields the code depends on empty. Any of those degrades
+// production to an empty registry — "search returns no results" — with no other
+// signal, so this canary runs on a schedule to surface it early.
+//
+// Empty path and URL force sources.Load down the default-URL fetch path, and a
+// fresh temp cache dir guarantees a real network fetch rather than a cached hit.
+func TestLiveDefaultRegistry(t *testing.T) {
+	cache := filepath.Join(t.TempDir(), "sources-cache.json")
+	r := sources.Load("", "", cache)
+
+	if r.Version <= 0 {
+		t.Fatalf("live registry has no version (%d) — the default URL is likely unreachable, "+
+			"returned a non-2xx, or served malformed JSON", r.Version)
+	}
+
+	// Mirror the field set from TestCanonicalRegistryIsComplete so live drift is
+	// held to the same completeness bar as the fixture.
+	checks := map[string]bool{
+		"Annas.Domain":          r.Annas.Domain == "",
+		"LibgenMirrors":         len(r.LibgenMirrors) == 0,
+		"AudioBookBay.Mirrors":  len(r.AudioBookBay.Mirrors) == 0,
+		"AudioBookBay.Trackers": len(r.AudioBookBay.Trackers) == 0,
+		"WebNovels":             len(r.WebNovels) == 0,
+		"Gutenberg.URL":         r.Gutenberg.URL == "",
+		"MangaDex.APIURL":       r.MangaDex.APIURL == "",
+		"MangaDex.UploadsURL":   r.MangaDex.UploadsURL == "",
+		"MangaDex.WebURL":       r.MangaDex.WebURL == "",
+		"OpenLibrary.SearchURL": r.OpenLibrary.SearchURL == "",
+		"OpenLibrary.CoverURL":  r.OpenLibrary.CoverURL == "",
+		"Librivox.URL":          r.Librivox.URL == "",
+		"StandardEbooks.URL":    r.StandardEbooks.URL == "",
+		"Nyaa.URL":              r.Nyaa.URL == "",
+		"ThePirateBay.URL":      r.ThePirateBay.URL == "",
+		"ZLibraryDefault":       r.ZLibraryDefault == "",
+	}
+	for field, empty := range checks {
+		if empty {
+			t.Errorf("live registry: %s is empty (schema drift in librarr-sources?)", field)
+		}
+	}
+}


### PR DESCRIPTION
Adds a live-network canary for the `librarr-sources` registry the binary fetches at runtime. Kept separate from the hermetic-test fix in #74.

**Why:** nothing currently guards the live registry. If that file moves or is removed, returns a non-2xx, serves malformed JSON, or drifts from the Go structs, production silently falls back to an empty registry (search returns nothing) with no signal.

**What:**
- `TestLiveDefaultRegistry` behind the `live` build tag — fetches via the real default-URL path and asserts the registry is reachable and complete (same field set as the fixture's `TestCanonicalRegistryIsComplete`).
- A schedule-only workflow (weekly + manual `workflow_dispatch`) runs it with `-tags live`.

The build tag keeps it out of `go test ./...`, so normal CI and releases aren't affected by a GitHub/raw outage.

Verified: `go test -tags live ./internal/sources/ -run TestLive` passes against the live registry; `go test ./...` (no tag) excludes it; gofmt/vet clean.