### PR TITLE
Grant admin on open instances so userless settings saves don't 403 (#76)

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -236,9 +236,14 @@ func authMiddleware(cfg *config.Config, database *db.DB, sessions *SessionStore,
 			}
 		}
 
-		// If no multi-user and no legacy auth, pass through.
+		// No multi-user, no legacy auth, no API key: the instance is open.
+		// Treat the local caller as an admin rather than passing through
+		// role-less, so admin-gated routes (e.g. POST /api/settings) work on
+		// userless instances instead of failing requireAdmin with a 403.
 		if !multiUser && !cfg.HasAuth() && !cfg.HasAPIKey() {
-			next.ServeHTTP(w, r)
+			ctx := context.WithValue(r.Context(), ctxUserRole, "admin")
+			ctx = context.WithValue(ctx, ctxUsername, "local")
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -575,3 +575,41 @@ func TestHandleAuthStatus_ProxyHeaderDoesNotCreateUser(t *testing.T) {
 		t.Fatalf("user count = %d, want 0", count)
 	}
 }
+
+// TestAuthMiddleware_OpenInstanceGrantsAdmin is a regression test for issue
+// #76: on a userless instance with no auth and no API key configured, the
+// open-access pass-through must mark the caller as admin so admin-gated routes
+// (POST /api/settings, etc.) work instead of failing requireAdmin with a 403.
+func TestAuthMiddleware_OpenInstanceGrantsAdmin(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	// Empty config => no legacy auth, no API key. No users in the DB => not
+	// multi-user. This is a fresh, open instance.
+	called := false
+	var gotRole string
+	final := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		gotRole, _ = r.Context().Value(ctxUserRole).(string)
+		w.WriteHeader(http.StatusNoContent)
+	}
+	handler := authMiddleware(&config.Config{}, database, NewSessionStore(), requireAdmin(final))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", rr.Code, rr.Body.String())
+	}
+	if !called {
+		t.Fatal("admin-gated handler was not reached on an open instance")
+	}
+	if gotRole != "admin" {
+		t.Fatalf("role = %q, want admin on an open instance", gotRole)
+	}
+}


### PR DESCRIPTION
Fixes #76.

## Problem

On a fresh instance with no users and no auth configured, saving settings (e.g. a Prowlarr API key) fails with `403 Forbidden`.

## Root cause

`POST /api/settings` is wrapped in `requireAdmin`, which reads `ctxUserRole` from the request context. The auth middleware has an open-access branch for instances with no DB users, no legacy auth, and no API key — but it passed the request through **without setting a role**:

```go
if !multiUser && !cfg.HasAuth() && !cfg.HasAPIKey() {
    next.ServeHTTP(w, r) // no ctxUserRole set
    return
}
```

So on a userless instance the role is empty and `requireAdmin` returns 403 for every admin-gated route.

## Fix

When the instance is open (no auth configured at all), treat the local caller as an admin — set `ctxUserRole=admin` / `ctxUsername=local` on the pass-through. There's no auth boundary to enforce in this mode, so the local user should have full control, which is the point of supporting userless instances.

Adds a regression test that runs the real `authMiddleware` -> `requireAdmin` chain on an open instance (403 before, 204 after).

## Verification

- New `TestAuthMiddleware_OpenInstanceGrantsAdmin`: fails with 403 on old code, passes after the fix.
- Full `internal/api` suite passes with `-race`; gofmt and `go vet` clean.