### PR TITLE
Ignore canceled search requests

### DIFF
--- a/internal/search/searcher.go
+++ b/internal/search/searcher.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -92,6 +93,10 @@ func (m *Manager) SearchWithAuthor(ctx context.Context, tab, query, author strin
 
 			res, err := src.Search(searchCtx, query)
 			if err != nil {
+				if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+					slog.Debug("search canceled by client", "source", src.Name())
+					return
+				}
 				slog.Error("search failed", "source", src.Name(), "error", err)
 				m.health.RecordFailure(src.Name(), err.Error(), "search")
 				return


### PR DESCRIPTION
## What changed
- Treat client-canceled search requests as cancellations, not source failures.
- Avoid incrementing the ABB search failure streak when a user aborts a live search.

## Why
- The ABB source was being marked unhealthy after repeated `context canceled` errors from normal typing and aborted search requests.
- That could open the circuit breaker and suppress later real searches.

## Validation
- `go test ./internal/search`
- Verified live audiobook searches return ABB results for real titles such as `Project Hail Mary`, `Dungeon Crawler Carl`, and `Macronomicon` after deploying the fix locally.