### PR TITLE
Stream search results

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -240,6 +240,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/search", s.handleSearch)
 	s.mux.HandleFunc("GET /api/search/audiobooks", s.handleSearchAudiobooks)
 	s.mux.HandleFunc("GET /api/search/manga", s.handleSearchManga)
+	s.mux.HandleFunc("GET /api/search/stream", s.handleSearchStream)
+	s.mux.HandleFunc("GET /api/search/audiobooks/stream", s.handleSearchAudiobooksStream)
+	s.mux.HandleFunc("GET /api/search/manga/stream", s.handleSearchMangaStream)
 
 	// Downloads.
 	s.mux.HandleFunc("POST /api/download", s.handleDownload)
@@ -542,4 +545,10 @@ type statusWriter struct {
 func (w *statusWriter) WriteHeader(status int) {
 	w.status = status
 	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *statusWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -8,6 +9,18 @@ import (
 )
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	s.handleSearchTab(w, r, "main", "Ebook search: %s")
+}
+
+func (s *Server) handleSearchAudiobooks(w http.ResponseWriter, r *http.Request) {
+	s.handleSearchTab(w, r, "audiobook", "")
+}
+
+func (s *Server) handleSearchManga(w http.ResponseWriter, r *http.Request) {
+	s.handleSearchTab(w, r, "manga", "")
+}
+
+func (s *Server) handleSearchTab(w http.ResponseWriter, r *http.Request, tab, activityFormat string) {
 	query := truncateSearchQuery(r.URL.Query().Get("q"))
 	if query == "" {
 		writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -16,12 +29,12 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-
-	username, _ := r.Context().Value(ctxUsername).(string)
-	s.db.LogActivity(username, "search", query, fmt.Sprintf("Ebook search: %s", query))
-
+	if activityFormat != "" {
+		username, _ := r.Context().Value(ctxUsername).(string)
+		s.db.LogActivity(username, "search", query, fmt.Sprintf(activityFormat, query))
+	}
 	author := truncateSearchQuery(r.URL.Query().Get("author"))
-	results, elapsed := s.searchMgr.SearchWithAuthor(r.Context(), "main", query, author)
+	results, elapsed := s.searchMgr.SearchWithAuthor(r.Context(), tab, query, author)
 	if results == nil {
 		results = []models.SearchResult{}
 	}
@@ -43,39 +56,19 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) handleSearchAudiobooks(w http.ResponseWriter, r *http.Request) {
-	query := truncateSearchQuery(r.URL.Query().Get("q"))
-	if query == "" {
-		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"results": []interface{}{},
-			"error":   "No query provided",
-		})
-		return
-	}
-
-	author := truncateSearchQuery(r.URL.Query().Get("author"))
-	results, elapsed := s.searchMgr.SearchWithAuthor(r.Context(), "audiobook", query, author)
-	if results == nil {
-		results = []models.SearchResult{}
-	}
-
-	resp := map[string]interface{}{
-		"results":        results,
-		"search_time_ms": elapsed,
-		"sources":        s.searchMgr.SourceMeta(),
-	}
-
-	if s.metadataClient != nil {
-		meta, err := s.metadataClient.FetchMetadataCtx(r.Context(), query, author)
-		if err == nil && meta != nil {
-			resp["metadata"] = meta
-		}
-	}
-
-	writeJSON(w, http.StatusOK, resp)
+func (s *Server) handleSearchStream(w http.ResponseWriter, r *http.Request) {
+	s.handleSearchStreamTab(w, r, "main", "Ebook search: %s")
 }
 
-func (s *Server) handleSearchManga(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleSearchAudiobooksStream(w http.ResponseWriter, r *http.Request) {
+	s.handleSearchStreamTab(w, r, "audiobook", "")
+}
+
+func (s *Server) handleSearchMangaStream(w http.ResponseWriter, r *http.Request) {
+	s.handleSearchStreamTab(w, r, "manga", "")
+}
+
+func (s *Server) handleSearchStreamTab(w http.ResponseWriter, r *http.Request, tab, activityFormat string) {
 	query := truncateSearchQuery(r.URL.Query().Get("q"))
 	if query == "" {
 		writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -84,25 +77,72 @@ func (s *Server) handleSearchManga(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{"error": "streaming unsupported"})
+		return
+	}
+	if activityFormat != "" {
+		username, _ := r.Context().Value(ctxUsername).(string)
+		s.db.LogActivity(username, "search", query, fmt.Sprintf(activityFormat, query))
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
 
 	author := truncateSearchQuery(r.URL.Query().Get("author"))
-	results, elapsed := s.searchMgr.SearchWithAuthor(r.Context(), "manga", query, author)
-	if results == nil {
-		results = []models.SearchResult{}
+	var allResults []models.SearchResult
+	emit := func(event string, payload interface{}) bool {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return true
+		}
+		if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
 	}
 
-	resp := map[string]interface{}{
-		"results":        results,
-		"search_time_ms": elapsed,
-		"sources":        s.searchMgr.SourceMeta(),
+	if !emit("started", map[string]interface{}{
+		"results": []models.SearchResult{},
+		"sources": s.searchMgr.SourceMeta(),
+	}) {
+		return
 	}
 
-	if s.metadataClient != nil {
-		meta, err := s.metadataClient.FetchMetadataCtx(r.Context(), query, author)
-		if err == nil && meta != nil {
-			resp["metadata"] = meta
+	for update := range s.searchMgr.SearchStream(r.Context(), tab, query, author) {
+		if len(update.Results) > 0 {
+			allResults = append(allResults, update.Results...)
+		}
+		results := s.searchMgr.ProcessResults(allResults, query, author)
+		if results == nil {
+			results = []models.SearchResult{}
+		}
+		payload := map[string]interface{}{
+			"source":         update.Source,
+			"source_done":    update.Done,
+			"circuit_open":   update.CircuitOpen,
+			"results":        results,
+			"search_time_ms": update.ElapsedMilli,
+			"sources":        s.searchMgr.SourceMeta(),
+		}
+		if update.Err != nil {
+			payload["error"] = update.Err.Error()
+		}
+		if !emit("results", payload) {
+			return
 		}
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	finalResults := s.searchMgr.ProcessResults(allResults, query, author)
+	if finalResults == nil {
+		finalResults = []models.SearchResult{}
+	}
+	emit("complete", map[string]interface{}{
+		"results": finalResults,
+		"sources": s.searchMgr.SourceMeta(),
+	})
 }

--- a/internal/api/torznab_routing_test.go
+++ b/internal/api/torznab_routing_test.go
@@ -85,3 +85,18 @@ func TestTorznabAliasHandlesTrailingSlashCorrectly(t *testing.T) {
 		t.Errorf("expected 404 for unregistered /api/, got %d", w.Code)
 	}
 }
+
+func TestStatusWriterPreservesFlusher(t *testing.T) {
+	rr := httptest.NewRecorder()
+	wrapped := &statusWriter{ResponseWriter: rr, status: http.StatusOK}
+
+	flusher, ok := interface{}(wrapped).(http.Flusher)
+	if !ok {
+		t.Fatal("statusWriter should implement http.Flusher")
+	}
+	flusher.Flush()
+
+	if !rr.Flushed {
+		t.Fatal("Flush did not reach the underlying response writer")
+	}
+}

--- a/internal/search/searcher.go
+++ b/internal/search/searcher.go
@@ -35,6 +35,16 @@ type Manager struct {
 	foreignLangFilter bool // runtime-configurable via UI; initialised from config
 }
 
+// SourceSearchUpdate reports one source's contribution to a streaming search.
+type SourceSearchUpdate struct {
+	Source       string
+	Results      []models.SearchResult
+	Err          error
+	CircuitOpen  bool
+	Done         bool
+	ElapsedMilli int64
+}
+
 // NewManager creates a search manager with the given sources.
 func NewManager(cfg *config.Config, sources []Searcher, health *HealthTracker) *Manager {
 	return &Manager{
@@ -114,15 +124,99 @@ func (m *Manager) SearchWithAuthor(ctx context.Context, tab, query, author strin
 
 	wg.Wait()
 
-	// Apply relevance and foreign-language filtering.
+	results = m.processResults(results, query, author)
+
+	elapsed := time.Since(start).Milliseconds()
+	return results, elapsed
+}
+
+// SearchStream runs a query and emits an update when each source finishes.
+func (m *Manager) SearchStream(ctx context.Context, tab, query, author string) <-chan SourceSearchUpdate {
+	start := time.Now()
+	updates := make(chan SourceSearchUpdate)
+
+	go func() {
+		defer close(updates)
+		var wg sync.WaitGroup
+		sendUpdate := func(update SourceSearchUpdate) bool {
+			select {
+			case updates <- update:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+
+		for _, s := range m.sources {
+			if !s.Enabled() || s.SearchTab() != tab {
+				continue
+			}
+			if !m.health.CanSearch(s.Name()) {
+				slog.Warn("source circuit open, skipping", "source", s.Name())
+				if !sendUpdate(SourceSearchUpdate{
+					Source:       s.Name(),
+					CircuitOpen:  true,
+					Done:         true,
+					ElapsedMilli: time.Since(start).Milliseconds(),
+				}) {
+					return
+				}
+				continue
+			}
+
+			wg.Add(1)
+			go func(src Searcher) {
+				defer wg.Done()
+
+				searchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				defer cancel()
+
+				res, err := src.Search(searchCtx, query)
+				if err != nil {
+					if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+						slog.Debug("search canceled by client", "source", src.Name())
+						return
+					}
+					slog.Error("search failed", "source", src.Name(), "error", err)
+					m.health.RecordFailure(src.Name(), err.Error(), "search")
+					sendUpdate(SourceSearchUpdate{
+						Source:       src.Name(),
+						Err:          err,
+						Done:         true,
+						ElapsedMilli: time.Since(start).Milliseconds(),
+					})
+					return
+				}
+
+				m.health.RecordSuccess(src.Name(), "search")
+				for i := range res {
+					if res[i].Source == "" {
+						res[i].Source = src.Name()
+					}
+				}
+				sendUpdate(SourceSearchUpdate{
+					Source:       src.Name(),
+					Results:      res,
+					Done:         true,
+					ElapsedMilli: time.Since(start).Milliseconds(),
+				})
+			}(s)
+		}
+		wg.Wait()
+	}()
+
+	return updates
+}
+
+// ProcessResults applies the same post-processing used by normal searches.
+func (m *Manager) ProcessResults(results []models.SearchResult, query, author string) []models.SearchResult {
+	return m.processResults(results, query, author)
+}
+
+func (m *Manager) processResults(results []models.SearchResult, query, author string) []models.SearchResult {
 	results = FilterResults(results, query, m.ForeignLangFilterEnabled())
-	// Apply suspicious keyword, seed, size, dedup, and sorting filters.
 	results = FilterAndSortResults(results, query, m.cfg.MinTorrentSizeBytes, m.cfg.MaxTorrentSizeBytes)
-
-	// Score all results.
 	results = ScoreResults(results, query, author)
-
-	// Re-sort by score (highest first), preserving filter order as tiebreaker.
 	for i := 0; i < len(results); i++ {
 		for j := i + 1; j < len(results); j++ {
 			if results[j].Score > results[i].Score {
@@ -130,9 +224,7 @@ func (m *Manager) SearchWithAuthor(ctx context.Context, tab, query, author strin
 			}
 		}
 	}
-
-	elapsed := time.Since(start).Milliseconds()
-	return results, elapsed
+	return results
 }
 
 // GetSources returns all registered sources.

--- a/internal/search/searcher.go
+++ b/internal/search/searcher.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -133,7 +134,7 @@ func (m *Manager) SearchWithAuthor(ctx context.Context, tab, query, author strin
 // SearchStream runs a query and emits an update when each source finishes.
 func (m *Manager) SearchStream(ctx context.Context, tab, query, author string) <-chan SourceSearchUpdate {
 	start := time.Now()
-	updates := make(chan SourceSearchUpdate)
+	updates := make(chan SourceSearchUpdate, len(m.sources))
 
 	go func() {
 		defer close(updates)

--- a/internal/search/searcher_test.go
+++ b/internal/search/searcher_test.go
@@ -1,10 +1,28 @@
 package search
 
 import (
+	"context"
 	"testing"
 
+	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/models"
 )
+
+type stubSearcher struct {
+	name    string
+	tab     string
+	results []models.SearchResult
+	err     error
+}
+
+func (s stubSearcher) Name() string         { return s.name }
+func (s stubSearcher) Label() string        { return s.name }
+func (s stubSearcher) Enabled() bool        { return true }
+func (s stubSearcher) SearchTab() string    { return s.tab }
+func (s stubSearcher) DownloadType() string { return "direct" }
+func (s stubSearcher) Search(context.Context, string) ([]models.SearchResult, error) {
+	return s.results, s.err
+}
 
 func TestIsMultilangSource(t *testing.T) {
 	tests := []struct {
@@ -28,6 +46,45 @@ func TestIsMultilangSource(t *testing.T) {
 				t.Errorf("isMultilangSource(%q) = %v, want %v", tt.source, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestSearchStreamEmitsSourceUpdates(t *testing.T) {
+	mgr := NewManager(&config.Config{}, []Searcher{
+		stubSearcher{
+			name: "one",
+			tab:  "main",
+			results: []models.SearchResult{{
+				Title:  "Project Hail Mary",
+				Source: "one",
+			}},
+		},
+		stubSearcher{
+			name: "two",
+			tab:  "main",
+			results: []models.SearchResult{{
+				Title:  "Project Hail Mary Audiobook",
+				Source: "two",
+			}},
+		},
+	}, NewHealthTracker(3, 300))
+
+	var all []models.SearchResult
+	seen := map[string]bool{}
+	for update := range mgr.SearchStream(context.Background(), "main", "Project Hail Mary", "") {
+		if update.Err != nil {
+			t.Fatalf("unexpected stream error: %v", update.Err)
+		}
+		seen[update.Source] = true
+		all = append(all, update.Results...)
+	}
+
+	if !seen["one"] || !seen["two"] {
+		t.Fatalf("stream updates = %#v, want one and two", seen)
+	}
+	processed := mgr.ProcessResults(all, "Project Hail Mary", "")
+	if len(processed) != 2 {
+		t.Fatalf("processed results = %d, want 2", len(processed))
 	}
 }
 

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -981,6 +981,7 @@ document.getElementById('search-input').addEventListener('keydown', (e) => {
 async function doSearch(query) {
   const endpoints = { ebooks: '/api/search', audiobooks: '/api/search/audiobooks', manga: '/api/search/manga' };
   const endpoint = endpoints[state.searchTab] || '/api/search';
+  const streamEndpoint = `${endpoint}/stream`;
 
   // Abort any in-flight search — prevents stale results from overwriting
   // the new search when the old request finishes after the new one starts.
@@ -997,34 +998,102 @@ async function doSearch(query) {
   document.getElementById('search-spinner').classList.remove('hidden');
 
   try {
-    const data = await apiJson(`${endpoint}?q=${encodeURIComponent(query)}`, {
-      signal: searchAbort.signal,
-    });
-
-    // Discard if a newer search was started while we were waiting.
-    if (gen !== searchGeneration) return;
-
-    state.searchResults = data.results || [];
-    document.getElementById('search-spinner').classList.add('hidden');
-    hideSearchSkeleton();
-
-    if (state.searchResults.length === 0) {
-      document.getElementById('search-no-results').classList.remove('hidden');
-      document.getElementById('search-sort-bar').classList.add('hidden');
-    } else {
-      document.getElementById('search-sort-bar').classList.remove('hidden');
-      document.getElementById('search-result-count').textContent = t('n_results', {n: state.searchResults.length});
-      renderSearchResults();
-    }
+    await doStreamingSearch(streamEndpoint, query, gen, searchAbort.signal);
   } catch (err) {
     if (err.name === 'AbortError') return; // expected — new search superseded this one
     if (gen !== searchGeneration) return;
-    document.getElementById('search-spinner').classList.add('hidden');
-    hideSearchSkeleton();
-    if (err.message !== 'Unauthorized') {
-      showToast(t('search_failed', {msg: err.message}), 'error');
+    try {
+      await doJsonSearch(endpoint, query, gen, searchAbort.signal);
+    } catch (fallbackErr) {
+      if (fallbackErr.name === 'AbortError') return;
+      if (gen !== searchGeneration) return;
+      document.getElementById('search-spinner').classList.add('hidden');
+      hideSearchSkeleton();
+      if (fallbackErr.message !== 'Unauthorized') {
+        showToast(t('search_failed', {msg: fallbackErr.message}), 'error');
+      }
     }
   }
+}
+
+async function doJsonSearch(endpoint, query, gen, signal) {
+  const data = await apiJson(`${endpoint}?q=${encodeURIComponent(query)}`, { signal });
+  if (gen !== searchGeneration) return;
+  updateSearchResults(data.results || [], false);
+}
+
+async function doStreamingSearch(endpoint, query, gen, signal) {
+  const resp = await api(`${endpoint}?q=${encodeURIComponent(query)}`, {
+    signal,
+    headers: { Accept: 'text/event-stream' },
+  });
+  if (!resp.ok || !resp.body) throw new Error(`API error: ${resp.status}`);
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let completed = false;
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const frames = buffer.split('\n\n');
+    buffer = frames.pop() || '';
+    for (const frame of frames) {
+      const evt = parseSSEFrame(frame);
+      if (!evt || gen !== searchGeneration) continue;
+      if (evt.event === 'results' || evt.event === 'complete') {
+        updateSearchResults(evt.data.results || [], evt.event !== 'complete');
+        completed = evt.event === 'complete';
+      }
+    }
+  }
+
+  if (gen === searchGeneration && !completed) {
+    document.getElementById('search-spinner').classList.add('hidden');
+    if (state.searchResults.length === 0) {
+      hideSearchSkeleton();
+      document.getElementById('search-no-results').classList.remove('hidden');
+    }
+  }
+}
+
+function parseSSEFrame(frame) {
+  let event = 'message';
+  const dataLines = [];
+  frame.split('\n').forEach(line => {
+    if (line.startsWith('event:')) event = line.slice(6).trim();
+    if (line.startsWith('data:')) dataLines.push(line.slice(5).trimStart());
+  });
+  if (dataLines.length === 0) return null;
+  try {
+    return { event, data: JSON.parse(dataLines.join('\n')) };
+  } catch {
+    return null;
+  }
+}
+
+function updateSearchResults(results, searching) {
+  state.searchResults = results || [];
+  document.getElementById('search-spinner').classList.toggle('hidden', !searching);
+
+  if (state.searchResults.length === 0) {
+    document.getElementById('search-sort-bar').classList.add('hidden');
+    if (searching) {
+      document.getElementById('search-no-results').classList.add('hidden');
+      return;
+    }
+    hideSearchSkeleton();
+    document.getElementById('search-no-results').classList.toggle('hidden', searching);
+    return;
+  }
+
+  hideSearchSkeleton();
+  document.getElementById('search-no-results').classList.add('hidden');
+  document.getElementById('search-sort-bar').classList.remove('hidden');
+  document.getElementById('search-result-count').textContent = t('n_results', {n: state.searchResults.length});
+  renderSearchResults();
 }
 
 function showSearchSkeleton() {


### PR DESCRIPTION
## What changed
- Added streaming search endpoints for ebooks, audiobooks, and manga using Server-Sent Events.
- Updated the web UI to consume streamed search result snapshots and render results as sources finish.
- Kept existing JSON search endpoints intact for compatibility and fallback.
- Treat client-canceled search requests as cancellations, not source failures, so live-search aborts do not open source circuit breakers.
- Forward `http.Flusher` through the logging response writer so SSE works through middleware.
- Prevent the search UI from briefly flashing blank between the placeholder skeleton and the first real results.

## Why
Slow torrent sources can take up to the source timeout, which makes the UI feel stalled even when faster sources already have useful results.

## Validation
- `go test ./internal/search`
- `go test ./internal/api -run "TestStatusWriterPreservesFlusher|TestTorznabAlias|TestOpenAPI|Test.*Search"`
- `go build ./cmd/librarr`
- Rebuilt and recreated the local `librarr` container.
- Verified `/api/search/audiobooks/stream?q=Project%20Hail%20Mary` emitted `started`, multiple `results`, `complete`, and included results.

## Notes
- Full `go test ./internal/api` still hits the existing unrelated `TestSaveSettings_WriteFailureDoesNotLeakPath` failure (`expected 500`, got `200`).
