### PR TITLE
Normalize source domain configuration

### DIFF
--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/JeremiahM37/librarr/internal/netutil"
+	"github.com/JeremiahM37/librarr/internal/sources"
 )
 
 const maskedValue = "--------"
@@ -107,6 +108,9 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 			"success": false, "error": "No data provided",
 		})
 		return
+	}
+	if value, ok := data["annas_archive_domain"].(string); ok && value != "" {
+		data["annas_archive_domain"] = sources.NormalizeDomain(value)
 	}
 
 	// Don't save masked values (user didn't change them).

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -92,6 +92,18 @@ func TestSaveSettings_EmptyStringDeletesKey(t *testing.T) {
 	}
 }
 
+func TestSaveSettings_NormalizesAnnasDomain(t *testing.T) {
+	s, path := settingsTestServer(t)
+
+	saveSettings(t, s, map[string]interface{}{
+		"annas_archive_domain": " https://Annas-Archive.GD/search/ ",
+	})
+
+	if got := readSettingsFile(t, path)["annas_archive_domain"]; got != "annas-archive.gd" {
+		t.Errorf("expected normalized domain, got %v", got)
+	}
+}
+
 // TestSaveSettings_FalseBoolPersists — the empty-string-delete rule must NOT
 // drop legitimate falsy values like bool false. Toggles depend on this.
 func TestSaveSettings_FalseBoolPersists(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,7 @@ type Config struct {
 func Load() *Config {
 	cfg := buildFromEnv()
 	cfg.applySettingsFileOverrides()
+	cfg.AnnasArchiveDomain = sources.NormalizeDomain(cfg.AnnasArchiveDomain)
 	cfg.probeSettingsFileWritable()
 	return cfg
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,7 +84,7 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	os.Setenv("LIBRARR_DB_PATH", "/tmp/test.db")
 	os.Setenv("QB_URL", "http://localhost:9090")
 	os.Setenv("FILE_ORG_ENABLED", "false")
-	os.Setenv("ANNAS_ARCHIVE_DOMAIN", "annas-archive.org")
+	os.Setenv("ANNAS_ARCHIVE_DOMAIN", "https://annas-archive.org/search/")
 	os.Setenv("MIN_TORRENT_SIZE_BYTES", "50000")
 	os.Setenv("OIDC_PROXY_HEADERS_ENABLED", "true")
 	defer func() {
@@ -119,6 +119,20 @@ func TestLoad_EnvOverrides(t *testing.T) {
 	}
 	if !cfg.OIDCProxyHeaders {
 		t.Error("expected OIDCProxyHeaders=true with env override")
+	}
+}
+
+func TestLoad_NormalizesSettingsFileDomain(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := dir + "/settings.json"
+	if err := os.WriteFile(settingsPath, []byte(`{"annas_archive_domain":"https://Annas-Archive.GD/search/"}`), 0600); err != nil {
+		t.Fatalf("write settings file: %v", err)
+	}
+	t.Setenv("SETTINGS_FILE", settingsPath)
+
+	cfg := Load()
+	if cfg.AnnasArchiveDomain != "annas-archive.gd" {
+		t.Errorf("AnnasArchiveDomain = %q, want annas-archive.gd", cfg.AnnasArchiveDomain)
 	}
 }
 

--- a/internal/sources/load.go
+++ b/internal/sources/load.go
@@ -103,7 +103,7 @@ func decode(data []byte) (*Registry, error) {
 	if err := json.Unmarshal(data, &r); err != nil {
 		return nil, err
 	}
-	return &r, nil
+	return r.Normalize(), nil
 }
 
 // writeCache persists a successful registry fetch to disk. Failures are logged
@@ -129,5 +129,5 @@ func (r *Registry) ApplyEnvOverrides(getenv func(string) string) *Registry {
 	if v := getenv("ANNAS_ARCHIVE_DOMAIN"); v != "" {
 		r.Annas.Domain = v
 	}
-	return r
+	return r.Normalize()
 }

--- a/internal/sources/sources.go
+++ b/internal/sources/sources.go
@@ -15,6 +15,11 @@
 // take precedence over the registry value when they are set.
 package sources
 
+import (
+	"net/url"
+	"strings"
+)
+
 // Registry is the in-memory representation of the indexer registry.
 type Registry struct {
 	Version         int              `json:"version"`
@@ -77,4 +82,31 @@ func (r *Registry) WebNovel(id string) *WebNovelSite {
 		}
 	}
 	return nil
+}
+
+// NormalizeDomain accepts either a hostname or URL and returns only the host.
+// Source drivers that consume domain fields add their own scheme and paths.
+func NormalizeDomain(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	if !strings.Contains(value, "://") {
+		value = "//" + value
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" || parsed.User != nil {
+		return ""
+	}
+	return strings.ToLower(parsed.Host)
+}
+
+// Normalize canonicalizes host-only fields after any registry or env load.
+func (r *Registry) Normalize() *Registry {
+	r.Annas.Domain = NormalizeDomain(r.Annas.Domain)
+	for i := range r.AudioBookBay.Mirrors {
+		r.AudioBookBay.Mirrors[i] = NormalizeDomain(r.AudioBookBay.Mirrors[i])
+	}
+	return r
 }

--- a/internal/sources/sources_test.go
+++ b/internal/sources/sources_test.go
@@ -162,7 +162,7 @@ func TestApplyEnvOverrides(t *testing.T) {
 		want    string
 	}{
 		{"unset leaves value", nil, "starting.test", "starting.test"},
-		{"ANNAS_ARCHIVE_DOMAIN overrides", map[string]string{"ANNAS_ARCHIVE_DOMAIN": "override.test"}, "starting.test", "override.test"},
+		{"ANNAS_ARCHIVE_DOMAIN overrides", map[string]string{"ANNAS_ARCHIVE_DOMAIN": "https://Override.Test/search/"}, "starting.test", "override.test"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -172,6 +172,50 @@ func TestApplyEnvOverrides(t *testing.T) {
 				t.Errorf("Annas.Domain = %q, want %q", r.Annas.Domain, tc.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeDomain(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"hostname", "annas-archive.gl", "annas-archive.gl"},
+		{"URL", "https://Annas-Archive.GL/search?q=test", "annas-archive.gl"},
+		{"surrounding whitespace", "  audiobookbay.lu/  ", "audiobookbay.lu"},
+		{"host with port", "http://localhost:8080/path", "localhost:8080"},
+		{"invalid URL", "https://", ""},
+		{"userinfo rejected", "https://user@example.test", ""},
+		{"empty", "  ", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sources.NormalizeDomain(tc.input); got != tc.want {
+				t.Errorf("NormalizeDomain(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegistryNormalizeHostFields(t *testing.T) {
+	r := (&sources.Registry{
+		Annas: sources.AnnasSpec{Domain: "https://annas.example/search"},
+		AudioBookBay: sources.AudioBookBaySpec{Mirrors: []string{
+			"https://abb-one.example/",
+			"ABB-TWO.EXAMPLE/path",
+		}},
+	}).Normalize()
+
+	if r.Annas.Domain != "annas.example" {
+		t.Errorf("Annas.Domain = %q", r.Annas.Domain)
+	}
+	wantMirrors := []string{"abb-one.example", "abb-two.example"}
+	for i, want := range wantMirrors {
+		if r.AudioBookBay.Mirrors[i] != want {
+			t.Errorf("AudioBookBay.Mirrors[%d] = %q, want %q", i, r.AudioBookBay.Mirrors[i], want)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

- Normalize host-only source settings after registry, environment, and settings-file loading.
- Accept either a bare hostname or a full URL for Anna's Archive and AudioBookBay mirror domains.
- Store Anna's Archive UI settings in canonical hostname form.
- Reject malformed or credential-bearing domain values instead of constructing malformed requests.

## Why

Anna's Archive requests always add their own `https://` scheme. A custom value such as `https://annas-archive.gd` therefore produced `https://https//annas-archive.gd`, causing every search to fail at DNS resolution.

## Impact

Existing bare-hostname configurations are unchanged. Full URLs are reduced to their hostname before source drivers construct request URLs.

## Validation

- `go test ./...`
- Added coverage for registry, environment, settings-file, and Settings API normalization.
