### PR TITLE
Fix Anna's Archive download fallbacks

### DIFF
--- a/e2e/test_user_journey.py
+++ b/e2e/test_user_journey.py
@@ -98,6 +98,38 @@ def test_data_idx_maps_to_rendered_result_in_every_sort_mode(searched):
         assert mismatches == [], f"sort={mode}: {mismatches}"
 
 
+def test_retry_wait_shows_progress_in_search_and_downloads(searched):
+    page = searched["page"]
+    retry_text = page.evaluate("""() => {
+        const result = state.renderedResults[0];
+        const key = getDownloadKey(result);
+        state.trackedDownloadJobs.set('retry-probe', {
+            key, title: result.title, source: 'annas', url: result.url || ''
+        });
+        state.downloadJobs = [{
+            job_id: 'retry-probe', title: result.title, source: 'annas',
+            status: 'retry_wait', detail: 'Retry 1/2 scheduled',
+            retry_count: 1, max_retries: 2, error: 'download HTTP 504'
+        }];
+        renderSearchResults();
+        renderDownloadList();
+        return {
+            button: document.querySelector('[data-action="startDownload"]')?.innerText,
+            downloads: document.querySelector('#downloads-list')?.innerText,
+        };
+    }""")
+    assert "Retry 1/2 scheduled" in retry_text["button"]
+    assert "Retry 1/2 scheduled" in retry_text["downloads"]
+    assert "Attempt 2/3" in retry_text["downloads"]
+
+    page.evaluate("""() => {
+        state.trackedDownloadJobs.delete('retry-probe');
+        state.downloadJobs = [];
+        renderSearchResults();
+        renderDownloadList();
+    }""")
+
+
 def test_download_completes_and_lands_in_library(searched):
     page = searched["page"]
     # Download the first rendered card; remember which book it claims to be.

--- a/internal/download/annas_download_test.go
+++ b/internal/download/annas_download_test.go
@@ -1,0 +1,158 @@
+package download
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/organize"
+	"github.com/JeremiahM37/librarr/internal/search"
+	"github.com/JeremiahM37/librarr/internal/sources"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func exhaustedAnnasClient(t *testing.T) *http.Client {
+	t.Helper()
+	return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		status := http.StatusOK
+		body := ""
+		switch {
+		case req.URL.Host == "mirror.test" && req.URL.Path == "/ads.php":
+			body = `<a href="get.php?md5=original&key=test">GET</a>`
+		case req.URL.Host == "mirror.test" && req.URL.Path == "/get.php":
+			status = http.StatusGatewayTimeout
+		case req.URL.Host == "annas.test" && req.URL.Path == "/search":
+			body = `<a href="/md5/36eba0c0be766d6ba02cb234088c30ab">Chasing Molecules: Poisonous Products, Human Health</a>`
+		default:
+			t.Fatalf("unexpected request: %s", req.URL)
+		}
+		return &http.Response{
+			StatusCode: status,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})}
+}
+
+func exhaustedAnnasConfig(dir string) *config.Config {
+	return &config.Config{
+		AnnasArchiveDomain:  "annas.test",
+		IncomingDir:         filepath.Join(dir, "incoming"),
+		EbookDir:            filepath.Join(dir, "ebooks"),
+		UserAgent:           "test",
+		MaxRetries:          2,
+		RetryBackoffSeconds: 0,
+		Sources: &sources.Registry{
+			LibgenMirrors: []string{"https://mirror.test"},
+		},
+	}
+}
+
+func TestDownloadFromAnnasRejectsUnrelatedFallbackAndExhaustsCandidates(t *testing.T) {
+	cfg := exhaustedAnnasConfig(t.TempDir())
+	direct := NewDirectDownloader(cfg, exhaustedAnnasClient(t))
+	direct.validate = nil
+
+	_, _, _, err := direct.DownloadFromAnnas("original", "Human Transit", nil)
+	if err == nil || !strings.Contains(err.Error(), "all matching LibGen candidates exhausted") {
+		t.Fatalf("expected exhausted-candidates error, got %v", err)
+	}
+}
+
+func TestDownloadFromAnnasReturnsSuccessfulFallbackMD5(t *testing.T) {
+	const fallbackMD5 = "48d427b054f3199f44171ba55c21adb2"
+	pdf := append([]byte("%PDF-1.7\n"), bytes.Repeat([]byte{'x'}, 1500)...)
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		status := http.StatusOK
+		body := []byte{}
+		header := make(http.Header)
+		switch {
+		case req.URL.Host == "mirror.test" && req.URL.Path == "/ads.php" && req.URL.Query().Get("md5") == "original":
+			body = []byte("File not found in DB")
+		case req.URL.Host == "annas.test" && req.URL.Path == "/search":
+			body = []byte(`<a href="/md5/48d427b054f3199f44171ba55c21adb2">The Adventures of Sherlock Holmes</a>`)
+		case req.URL.Host == "mirror.test" && req.URL.Path == "/ads.php" && req.URL.Query().Get("md5") == fallbackMD5:
+			body = []byte(`<a href="get.php?md5=48d427b054f3199f44171ba55c21adb2&amp;key=test">GET</a>`)
+		case req.URL.Host == "mirror.test" && req.URL.Path == "/get.php":
+			header.Set("Content-Type", "application/pdf")
+			body = pdf
+		default:
+			t.Fatalf("unexpected request: %s", req.URL)
+		}
+		return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(bytes.NewReader(body)), Request: req}, nil
+	})}
+	cfg := exhaustedAnnasConfig(t.TempDir())
+	direct := NewDirectDownloader(cfg, client)
+	direct.validate = nil
+
+	_, _, downloadedMD5, err := direct.DownloadFromAnnas("original", "The Adventures of Sherlock Holmes", nil)
+	if err != nil {
+		t.Fatalf("download fallback: %v", err)
+	}
+	if downloadedMD5 != fallbackMD5 {
+		t.Errorf("downloaded MD5 = %q, want %q", downloadedMD5, fallbackMD5)
+	}
+}
+
+func TestAnnasTransientExhaustionUsesConfiguredRetries(t *testing.T) {
+	dir := t.TempDir()
+	cfg := exhaustedAnnasConfig(dir)
+	database, err := db.New(filepath.Join(dir, "librarr.db"))
+	if err != nil {
+		t.Fatalf("create DB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	direct := NewDirectDownloader(cfg, exhaustedAnnasClient(t))
+	direct.validate = nil
+	manager := NewManager(
+		cfg,
+		database,
+		nil,
+		nil,
+		direct,
+		organize.NewOrganizer(cfg),
+		nil,
+		search.NewHealthTracker(3, 300),
+	)
+
+	job, err := manager.StartAnnasDownload("original", "Human Transit")
+	if err != nil {
+		t.Fatalf("start download: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		manager.mu.Lock()
+		status := job.Status
+		manager.mu.Unlock()
+		if status == "dead_letter" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if job.Status != "dead_letter" {
+		t.Fatalf("status = %q, want dead_letter", job.Status)
+	}
+	if job.RetryCount != job.MaxRetries {
+		t.Errorf("retry count = %d, want %d", job.RetryCount, job.MaxRetries)
+	}
+	if job.Detail != "Max retries exceeded" {
+		t.Errorf("detail = %q", job.Detail)
+	}
+}

--- a/internal/download/annas_download_test.go
+++ b/internal/download/annas_download_test.go
@@ -76,7 +76,7 @@ func TestDownloadFromAnnasReturnsSuccessfulFallbackMD5(t *testing.T) {
 	pdf := append([]byte("%PDF-1.7\n"), bytes.Repeat([]byte{'x'}, 1500)...)
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		status := http.StatusOK
-		body := []byte{}
+		var body []byte
 		header := make(http.Header)
 		switch {
 		case req.URL.Host == "mirror.test" && req.URL.Path == "/ads.php" && req.URL.Query().Get("md5") == "original":

--- a/internal/download/direct.go
+++ b/internal/download/direct.go
@@ -20,6 +20,7 @@ import (
 	"github.com/JeremiahM37/librarr/internal/netutil"
 	"github.com/JeremiahM37/librarr/internal/organize"
 	"github.com/JeremiahM37/librarr/internal/zlibraryparse"
+	"github.com/PuerkitoBio/goquery"
 )
 
 // DirectDownloader handles direct HTTP file downloads (Anna's Archive, Gutenberg, etc.).
@@ -68,41 +69,86 @@ func (d *DirectDownloader) mirrors() []string {
 
 // DownloadFromAnnas downloads a file from Anna's Archive via libgen.
 // Returns the local file path and size, or an error.
-func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(string)) (string, int64, error) {
+func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(string)) (string, int64, string, error) {
 	if progressFn != nil {
 		progressFn("Fetching download link from Anna's Archive...")
 	}
 
-	// Step 1: Try each libgen mirror to get the download key.
-	downloadURL, mirrorErr := d.fetchLibgenDownloadURL(md5, progressFn)
-	if mirrorErr != nil {
-		// All libgen mirrors failed. Try alternative MD5 hashes by re-searching
-		// Anna's Archive — the same book often has multiple MD5s across mirrors.
+	attemptedURLs := make(map[string]bool)
+	filePath, fileSize, originalErr := d.downloadFromLibgenMirrors(md5, title, attemptedURLs, progressFn)
+	if originalErr == nil {
+		return filePath, fileSize, md5, nil
+	} else if progressFn != nil {
+		progressFn("Original file unavailable, searching matching alternatives...")
+	}
+
+	results, err := (&annasSearchHelper{cfg: d.cfg, client: d.client}).searchForTitle(context.Background(), title)
+	if err != nil {
+		return "", 0, "", fmt.Errorf("search alternative Anna's Archive files: %w", err)
+	}
+
+	lastErr := originalErr
+	matchingAlternatives := 0
+	for _, result := range results {
+		if result.MD5 == "" || result.MD5 == md5 || !titlesMatch(title, result.Title) {
+			continue
+		}
+		if matchingAlternatives >= 5 {
+			break
+		}
+		matchingAlternatives++
 		if progressFn != nil {
-			progressFn("All libgen mirrors failed, trying alternative MD5s...")
+			progressFn(fmt.Sprintf("Trying matching alternative %d...", matchingAlternatives))
 		}
-		altURL, altErr := d.tryAltMD5(title, md5, progressFn)
-		if altErr != nil {
-			if errors.Is(mirrorErr, errLibgenNoMatch) || errors.Is(altErr, errLibgenNoMatch) {
-				// noMatchError pairs the user-facing message with errLibgenNoMatch
-				// as a sentinel, so callers (e.g. manager.go) can detect the
-				// no-match case via errors.Is — not by string-matching the
-				// localized error message.
-				return "", 0, &noMatchError{msg: "Anna's Archive could not find a matching LibGen MD5 for this book. Download it manually from Anna's Archive or choose another source."}
-			}
-			return "", 0, fmt.Errorf("all libgen mirrors failed (%v); alt search also failed: %v", mirrorErr, altErr)
+		filePath, fileSize, err := d.downloadFromLibgenMirrors(result.MD5, title, attemptedURLs, progressFn)
+		if err == nil {
+			return filePath, fileSize, result.MD5, nil
 		}
-		return d.downloadFile(altURL, title, progressFn)
+		lastErr = err
 	}
 
-	slog.Info("found libgen download link", "title", title, "url", downloadURL[:min(60, len(downloadURL))])
-
-	if progressFn != nil {
-		progressFn("Downloading...")
+	if matchingAlternatives == 0 && errors.Is(originalErr, errLibgenNoMatch) {
+		return "", 0, "", &noMatchError{msg: "Anna's Archive could not find a matching LibGen MD5 for this book. Download it manually from Anna's Archive or choose another source."}
 	}
+	if lastErr == nil {
+		lastErr = errLibgenNoMatch
+	}
+	return "", 0, "", fmt.Errorf("all matching LibGen candidates exhausted: %w", lastErr)
+}
 
-	// Step 2: Download the file.
-	return d.downloadFile(downloadURL, title, progressFn)
+// downloadFromLibgenMirrors resolves and downloads one MD5 from each mirror.
+// A bad response or failed file verification advances to the next mirror.
+func (d *DirectDownloader) downloadFromLibgenMirrors(md5, title string, attemptedURLs map[string]bool, progressFn func(string)) (string, int64, error) {
+	var lastErr error
+	for i, mirror := range d.mirrors() {
+		if progressFn != nil {
+			progressFn(fmt.Sprintf("Trying mirror %d/%d...", i+1, len(d.mirrors())))
+		}
+		downloadURL, err := d.fetchLibgenDownloadURLFromMirror(mirror, md5)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if attemptedURLs[downloadURL] {
+			lastErr = fmt.Errorf("%s resolved to an already attempted download URL", mirror)
+			continue
+		}
+		attemptedURLs[downloadURL] = true
+
+		slog.Info("found libgen download link", "title", title, "md5", md5, "mirror", mirror)
+		if progressFn != nil {
+			progressFn(fmt.Sprintf("Downloading from mirror %d/%d...", i+1, len(d.mirrors())))
+		}
+		filePath, fileSize, err := d.downloadFile(downloadURL, title, progressFn)
+		if err == nil {
+			return filePath, fileSize, nil
+		}
+		lastErr = fmt.Errorf("%s download: %w", mirror, err)
+	}
+	if lastErr == nil {
+		lastErr = errLibgenNoMatch
+	}
+	return "", 0, lastErr
 }
 
 // fetchLibgenDownloadURL tries each libgen mirror to find a valid get.php
@@ -112,53 +158,54 @@ func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(
 // have the book while others don't.
 func (d *DirectDownloader) fetchLibgenDownloadURL(md5 string, progressFn func(string)) (string, error) {
 	var lastErr error
-	noMatch := false
+	allNoMatch := true
 	for i, mirror := range d.mirrors() {
 		if i > 0 && progressFn != nil {
 			progressFn(fmt.Sprintf("Trying mirror: %s", mirror))
 		}
 
-		adsURL := fmt.Sprintf("%s/ads.php?md5=%s", mirror, md5)
-		req, err := http.NewRequest("GET", adsURL, nil)
+		downloadURL, err := d.fetchLibgenDownloadURLFromMirror(mirror, md5)
 		if err != nil {
 			lastErr = err
+			if !errors.Is(err, errLibgenNoMatch) {
+				allNoMatch = false
+			}
 			continue
 		}
-		req.Header.Set("User-Agent", d.cfg.UserAgent)
-
-		resp, err := d.client.Do(req)
-		if err != nil {
-			lastErr = fmt.Errorf("%s: %w", mirror, err)
-			continue
-		}
-
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
-		resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			lastErr = fmt.Errorf("%s HTTP %d", mirror, resp.StatusCode)
-			continue
-		}
-
-		bodyStr := string(body)
-		if strings.Contains(bodyStr, "File not found in DB") || strings.Contains(bodyStr, "File not found") {
-			noMatch = true
-			lastErr = fmt.Errorf("%s: %w", mirror, errLibgenNoMatch)
-			continue
-		}
-
-		match := getLinkRe.FindSubmatch(body)
-		if len(match) < 2 {
-			lastErr = fmt.Errorf("%s: no get.php link for md5=%s", mirror, md5)
-			continue
-		}
-
-		return fmt.Sprintf("%s/%s", mirror, string(match[1])), nil
+		return downloadURL, nil
 	}
-	if noMatch {
+	if lastErr != nil && allNoMatch {
 		return "", fmt.Errorf("%w", errLibgenNoMatch)
 	}
 	return "", lastErr
+}
+
+func (d *DirectDownloader) fetchLibgenDownloadURLFromMirror(mirror, md5 string) (string, error) {
+	adsURL := fmt.Sprintf("%s/ads.php?md5=%s", mirror, md5)
+	req, err := http.NewRequest("GET", adsURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", d.cfg.UserAgent)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", mirror, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("%s HTTP %d", mirror, resp.StatusCode)
+	}
+	if strings.Contains(string(body), "File not found in DB") || strings.Contains(string(body), "File not found") {
+		return "", fmt.Errorf("%s: %w", mirror, errLibgenNoMatch)
+	}
+	match := getLinkRe.FindSubmatch(body)
+	if len(match) < 2 {
+		return "", fmt.Errorf("%s: no get.php link for md5=%s", mirror, md5)
+	}
+	return fmt.Sprintf("%s/%s", mirror, string(match[1])), nil
 }
 
 // DownloadFromURL downloads a file from any direct URL.
@@ -628,73 +675,18 @@ func (d *DirectDownloader) verifyEPUB(filePath, expectedTitle string) error {
 	return nil
 }
 
-// tryAltMD5 searches Anna's Archive for alternative MD5 hashes and tries them.
-func (d *DirectDownloader) tryAltMD5(title, originalMD5 string, progressFn func(string)) (string, error) {
-	ctx := context.Background()
-	annas := &annasSearchHelper{cfg: d.cfg, client: d.client}
-	results, err := annas.searchForTitle(ctx, title)
-	if err != nil {
-		return "", err
-	}
-
-	tried := 0
-	for _, r := range results {
-		if r.MD5 == "" || r.MD5 == originalMD5 {
-			continue
-		}
-		if tried >= 3 {
-			break
-		}
-		tried++
-
-		if progressFn != nil {
-			progressFn(fmt.Sprintf("Trying alt mirror %d/3...", tried))
-		}
-
-		// Use the first configured mirror as the primary alt-MD5 lookup.
-		primary := ""
-		if mm := d.mirrors(); len(mm) > 0 {
-			primary = mm[0]
-		}
-		if primary == "" {
-			continue
-		}
-		adsURL := fmt.Sprintf("%s/ads.php?md5=%s", primary, r.MD5)
-		req, err := http.NewRequest("GET", adsURL, nil)
-		if err != nil {
-			continue
-		}
-		req.Header.Set("User-Agent", d.cfg.UserAgent)
-
-		resp, err := d.client.Do(req)
-		if err != nil {
-			continue
-		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
-		resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			continue
-		}
-
-		match := getLinkRe.FindSubmatch(body)
-		if len(match) >= 2 {
-			downloadURL := fmt.Sprintf("%s/%s", primary, string(match[1]))
-			slog.Info("found alt libgen download link", "title", title, "alt_md5", r.MD5)
-			return downloadURL, nil
-		}
-	}
-
-	return "", fmt.Errorf("no alternative MD5 hashes had working download links")
-}
-
 // annasSearchHelper is a minimal helper to search Anna's Archive for alt MD5s.
 type annasSearchHelper struct {
 	cfg    *config.Config
 	client *http.Client
 }
 
-func (a *annasSearchHelper) searchForTitle(ctx context.Context, title string) ([]struct{ MD5 string }, error) {
+type annasSearchCandidate struct {
+	MD5   string
+	Title string
+}
+
+func (a *annasSearchHelper) searchForTitle(ctx context.Context, title string) ([]annasSearchCandidate, error) {
 	baseURL := fmt.Sprintf("https://%s/search", a.cfg.AnnasArchiveDomain)
 	req, err := http.NewRequestWithContext(ctx, "GET", baseURL, nil)
 	if err != nil {
@@ -716,19 +708,95 @@ func (a *annasSearchHelper) searchForTitle(ctx context.Context, title string) ([
 		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
-	md5Re := regexp.MustCompile(`/md5/([a-f0-9]+)`)
-	matches := md5Re.FindAllStringSubmatch(string(body), -1)
+	return parseAnnasSearchCandidates(io.LimitReader(resp.Body, 2*1024*1024))
+}
+
+func parseAnnasSearchCandidates(reader io.Reader) ([]annasSearchCandidate, error) {
+	doc, err := goquery.NewDocumentFromReader(reader)
+	if err != nil {
+		return nil, fmt.Errorf("parse Anna's Archive search HTML: %w", err)
+	}
 
 	seen := make(map[string]bool)
-	var results []struct{ MD5 string }
-	for _, m := range matches {
-		if len(m) >= 2 && !seen[m[1]] {
-			seen[m[1]] = true
-			results = append(results, struct{ MD5 string }{m[1]})
+	md5Re := regexp.MustCompile(`(?i)/md5/([a-f0-9]{32})`)
+	var results []annasSearchCandidate
+	doc.Find("a[href*='/md5/']").Each(func(_ int, selection *goquery.Selection) {
+		href, ok := selection.Attr("href")
+		if !ok {
+			return
+		}
+		match := md5Re.FindStringSubmatch(href)
+		candidateTitle := strings.TrimSpace(selection.Text())
+		if len(match) < 2 || candidateTitle == "" {
+			return
+		}
+		md5 := strings.ToLower(match[1])
+		if seen[md5] {
+			return
+		}
+		seen[md5] = true
+		results = append(results, annasSearchCandidate{MD5: md5, Title: candidateTitle})
+	})
+	return results, nil
+}
+
+var titleWordRe = regexp.MustCompile(`[\p{L}\p{N}]+`)
+
+var titleStopwords = map[string]bool{
+	"a": true, "an": true, "and": true, "at": true, "by": true,
+	"for": true, "from": true, "in": true, "of": true, "on": true,
+	"or": true, "the": true, "to": true, "with": true,
+}
+
+func titlesMatch(expected, candidate string) bool {
+	expectedWords := significantTitleWords(expected)
+	candidateWords := significantTitleWords(candidate)
+	if len(expectedWords) == 0 || len(candidateWords) == 0 {
+		return false
+	}
+
+	matches := 0
+	for word := range expectedWords {
+		if candidateWords[word] {
+			matches++
 		}
 	}
-	return results, nil
+	// Anna results often prefix an author or append a file extension, but a
+	// matching edition should still contain the book's primary title. Requiring
+	// that core prevents a generic subtitle fragment such as "Public Transit"
+	// from selecting an unrelated result.
+	primary := primaryTitle(expected)
+	primaryWords := significantTitleWords(primary)
+	primaryMatches := 0
+	for word := range primaryWords {
+		if candidateWords[word] {
+			primaryMatches++
+		}
+	}
+	if primary != expected && len(primaryWords) >= 2 && primaryMatches == len(primaryWords) {
+		return true
+	}
+
+	return matches >= 2 &&
+		float64(matches)/float64(len(expectedWords)) >= 0.5 &&
+		float64(matches)/float64(len(candidateWords)) >= 0.5
+}
+
+func primaryTitle(title string) string {
+	if before, _, ok := strings.Cut(title, ":"); ok {
+		return before
+	}
+	return title
+}
+
+func significantTitleWords(title string) map[string]bool {
+	words := make(map[string]bool)
+	for _, word := range titleWordRe.FindAllString(strings.ToLower(title), -1) {
+		if len(word) > 1 && !titleStopwords[word] && word != "epub" && word != "pdf" {
+			words[word] = true
+		}
+	}
+	return words
 }
 
 var unsafeCharsRe = regexp.MustCompile(`[^\w\s-]`)

--- a/internal/download/libgen_mirrors_test.go
+++ b/internal/download/libgen_mirrors_test.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,6 +13,91 @@ import (
 	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/sources/sourcestest"
 )
+
+func TestTitlesMatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		expected  string
+		candidate string
+		want      bool
+	}{
+		{"same title", "Human Transit: How Clearer Thinking About Public Transit Can Enrich Our Communities and Our Lives", "Human transit : how clearer thinking about public transit can enrich our communities and our lives", true},
+		{"short matching title", "Human Transit: How Clearer Thinking About Public Transit Can Enrich Our Communities and Our Lives", "Jarrett Walker - Human Transit.epub", true},
+		{"one generic word is insufficient", "Human Transit: How Clearer Thinking About Public Transit Can Enrich Our Communities and Our Lives", "Chasing Molecules: Poisonous Products, Human Health", false},
+		{"subtitle fragment is insufficient", "Human Transit: How Clearer Thinking About Public Transit Can Enrich Our Communities and Our Lives", "Public Transit", false},
+		{"unrelated", "Human Transit", "The Great Gatsby", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := titlesMatch(tc.expected, tc.candidate); got != tc.want {
+				t.Errorf("titlesMatch(%q, %q) = %v, want %v", tc.expected, tc.candidate, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseAnnasSearchCandidatesKeepsTitlesWithMD5s(t *testing.T) {
+	html := `<html><body>
+		<a href="/md5/11111111111111111111111111111111"><img alt="cover"></a>
+		<a href="/md5/11111111111111111111111111111111">Human Transit</a>
+		<a href="/md5/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">Uppercase MD5</a>
+		<a href="/md5/22222222222222222222222222222222">Chasing Molecules</a>
+	</body></html>`
+
+	results, err := parseAnnasSearchCandidates(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse candidates: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("got %d candidates, want 3: %+v", len(results), results)
+	}
+	if results[0].Title != "Human Transit" || results[0].MD5 != "11111111111111111111111111111111" {
+		t.Errorf("unexpected first candidate: %+v", results[0])
+	}
+	if results[1].MD5 != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Errorf("uppercase MD5 was not normalized: %+v", results[1])
+	}
+}
+
+func TestDownloadFromLibgenMirrorsContinuesAfterDownloadFailure(t *testing.T) {
+	failedDownloads := int32(0)
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/ads.php") {
+			_, _ = w.Write([]byte(`<a href="get.php?md5=book&key=first">GET</a>`))
+			return
+		}
+		atomic.AddInt32(&failedDownloads, 1)
+		w.WriteHeader(http.StatusGatewayTimeout)
+	}))
+	defer first.Close()
+
+	pdf := append([]byte("%PDF-1.7\n"), bytes.Repeat([]byte{'x'}, 1500)...)
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/ads.php") {
+			_, _ = w.Write([]byte(`<a href="get.php?md5=book&key=second">GET</a>`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write(pdf)
+	}))
+	defer second.Close()
+
+	cfg := newTestConfig([]string{first.URL, second.URL})
+	cfg.IncomingDir = t.TempDir()
+	d := NewDirectDownloader(cfg, second.Client())
+	d.validate = nil
+
+	filePath, fileSize, err := d.downloadFromLibgenMirrors("book", "Human Transit", make(map[string]bool), nil)
+	if err != nil {
+		t.Fatalf("download from mirrors: %v", err)
+	}
+	if atomic.LoadInt32(&failedDownloads) != 1 {
+		t.Errorf("first mirror download calls = %d, want 1", failedDownloads)
+	}
+	if !strings.HasSuffix(filePath, ".pdf") || fileSize != int64(len(pdf)) {
+		t.Errorf("unexpected downloaded file: path=%q size=%d", filePath, fileSize)
+	}
+}
 
 // newTestConfig builds a Config with the given libgen mirrors injected into
 // the runtime sources registry.
@@ -97,6 +183,26 @@ func TestFetchLibgenDownloadURL_AllMirrorsFail(t *testing.T) {
 	// Should report the LAST mirror's error
 	if !strings.Contains(err.Error(), "HTTP") {
 		t.Errorf("error should mention HTTP status: %v", err)
+	}
+}
+
+func TestFetchLibgenDownloadURL_MixedNoMatchAndServerErrorIsRetryable(t *testing.T) {
+	missing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("File not found in DB"))
+	}))
+	defer missing.Close()
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer broken.Close()
+
+	d := NewDirectDownloader(newTestConfig([]string{missing.URL, broken.URL}), broken.Client())
+	_, err := d.fetchLibgenDownloadURL("abc", nil)
+	if err == nil {
+		t.Fatal("expected mirror resolution failure")
+	}
+	if errors.Is(err, errLibgenNoMatch) {
+		t.Fatalf("mixed transient failure was classified as no-match: %v", err)
 	}
 }
 

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -248,7 +248,7 @@ func (m *Manager) RetryDeadLetterJob(jobID string) error {
 func (m *Manager) runAnnasDownload(job *models.DownloadJob) {
 	m.updateJob(job, "downloading", "Downloading from Anna's Archive...", "")
 
-	filePath, fileSize, err := m.direct.DownloadFromAnnas(job.MD5, job.Title, func(detail string) {
+	filePath, fileSize, downloadedMD5, err := m.direct.DownloadFromAnnas(job.MD5, job.Title, func(detail string) {
 		m.setJobProgress(job, detail)
 	})
 	if err != nil {
@@ -316,7 +316,7 @@ func (m *Manager) runAnnasDownload(job *models.DownloadJob) {
 		FileFormat:   "epub",
 		MediaType:    "ebook",
 		Source:       "annas",
-		SourceID:     job.MD5,
+		SourceID:     downloadedMD5,
 	})
 
 	// Trigger library imports.

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -529,6 +529,7 @@ const STATUS_STYLES = {
   queued:      { bg: 'bg-slate-500/20', text: 'text-slate-400', border: 'border-slate-500/30', label: 'Queued' },
   searching:   { bg: 'bg-indigo-500/20', text: 'text-indigo-400', border: 'border-indigo-500/30', label: 'Searching' },
   importing:   { bg: 'bg-purple-500/20', text: 'text-purple-400', border: 'border-purple-500/30', label: 'Importing' },
+  retry_wait:  { bg: 'bg-amber-500/20', text: 'text-amber-400', border: 'border-amber-500/30', label: 'Retry Wait' },
 };
 
 const TERMINAL_DOWNLOAD_STATUSES = new Set(['completed', 'error', 'dead_letter']);
@@ -1161,6 +1162,7 @@ function renderBookCard(result, index) {
   const isDownloading = state.pendingDownloads.has(downloadKey);
   const isTrackedAnnaDownload = hasTrackedAnnaDownload(downloadKey);
   const isTrackedDirectDownload = hasTrackedDirectDownload(downloadKey);
+  const trackedJob = getTrackedDownloadJob(downloadKey);
   const downloadOutcome = state.downloadOutcomes.get(downloadKey);
   const coverHtml = result.cover_url
     ? `<img src="${escapeHtml(result.cover_url)}" alt="" class="w-full h-48 object-cover" loading="lazy" data-ph-title="${escapeHtml(result.title || '')}" data-ph-idx="${index}">`
@@ -1192,6 +1194,9 @@ function renderBookCard(result, index) {
     success: `<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>`,
     error: `<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 8v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/></svg>`,
   };
+  const displayButtonText = buttonState === 'loading' && trackedJob?.detail
+    ? escapeHtml(trackedJob.detail)
+    : (buttonText[buttonState] || buttonText.idle);
 
   return `
     <div class="book-card bg-slate-900 rounded-xl overflow-hidden border border-slate-800 hover:border-slate-600 flex flex-col">
@@ -1211,7 +1216,7 @@ function renderBookCard(result, index) {
           class="w-full ${buttonStyles[buttonState] || buttonStyles.idle} text-white text-sm font-medium py-1.5 rounded-lg transition-colors flex items-center justify-center gap-1.5 disabled:opacity-100"
         >
           ${buttonIcon[buttonState] || buttonIcon.idle}
-          ${buttonText[buttonState] || buttonText.idle}
+          <span class="truncate">${displayButtonText}</span>
         </button>
       </div>
     </div>
@@ -1269,6 +1274,15 @@ function hasTrackedDirectDownload(downloadKey) {
     if (tracked.key === downloadKey && tracked.source !== 'annas') return true;
   }
   return false;
+}
+
+function getTrackedDownloadJob(downloadKey) {
+  for (const [jobId, tracked] of state.trackedDownloadJobs.entries()) {
+    if (tracked.key !== downloadKey) continue;
+    const job = state.downloadJobs.find(candidate => String(candidate.job_id) === String(jobId));
+    if (job) return job;
+  }
+  return null;
 }
 
 function setDownloadOutcome(downloadKey, status, persist = false) {
@@ -1456,6 +1470,8 @@ function renderDownloadJob(job) {
           ${job.source ? `<span class="text-xs text-slate-500">${escapeHtml(job.source)}</span>` : ''}
         </div>
         <h4 class="text-sm font-medium text-white truncate" title="${escapeHtml(job.title || '')}">${escapeHtml(job.title || 'Unknown')}</h4>
+        ${job.detail ? `<p class="text-xs text-slate-400 mt-1 truncate" title="${escapeHtml(job.detail)}">${escapeHtml(job.detail)}</p>` : ''}
+        ${job.max_retries > 0 && job.retry_count > 0 ? `<p class="text-xs text-amber-400 mt-1">${escapeHtml(`Attempt ${Math.min(job.retry_count + 1, job.max_retries + 1)}/${job.max_retries + 1}`)}</p>` : ''}
         ${job.error ? `<p class="text-xs text-red-400 mt-1 truncate">${escapeHtml(job.error)}</p>` : ''}
         ${showProgress ? `
           <div class="mt-2 w-full bg-slate-800 rounded-full h-1.5">
@@ -1503,6 +1519,12 @@ function syncTrackedDownloadJobs(jobs) {
     }
 
     hasPendingTrackedJob = true;
+    Object.assign(tracked, {
+      status: job.status,
+      detail: job.detail || '',
+      retryCount: job.retry_count || 0,
+      maxRetries: job.max_retries || 0,
+    });
     setDownloadOutcome(tracked.key, 'loading', true);
   }
 


### PR DESCRIPTION
## Summary
- try every configured LibGen mirror through download and EPUB verification
- search Anna's Archive for title-matched alternative MD5s when the original file fails
- reject unrelated fallback titles and preserve retries for transient mirror failures
- show live retry details and attempt counts in the search and downloads UI
- record the MD5 of the fallback file that was actually downloaded

## Root cause
Librarr stopped after resolving the first LibGen download URL, even when that URL returned a gateway error or the downloaded EPUB failed title verification. Its alternative search collected MD5s without preserving their titles, which allowed unrelated search results such to be selected.

## Validation
- `go test ./... -skip TestSaveSettings_WriteFailureDoesNotLeakPath`
- `go test -race ./internal/download -count=1`
- `go vet ./internal/download ./internal/api`
- `node --check web/static/js/app.js`
- `python3 -m py_compile e2e/test_user_journey.py`
- targeted Chromium E2E retry-progress test
- live Anna's Archive fallback test with the public-domain The Adventures of Sherlock Holmes EPUB