### PR TITLE
Populate file formats in search results

### DIFF
--- a/internal/search/annas.go
+++ b/internal/search/annas.go
@@ -15,6 +15,8 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
+var annasMetadataFormatRe = regexp.MustCompile(`(?i)·\s*([a-z0-9]+)\s*·`)
+
 // AnnasArchive searches Anna's Archive by scraping HTML results.
 type AnnasArchive struct {
 	cfg    *config.Config
@@ -111,7 +113,6 @@ func (a *AnnasArchive) doSearch(ctx context.Context, query, ext string, seenMD5 
 			metadataSizes = append(metadataSizes, m[1])
 		}
 	}
-
 	// Collect title links (the ones with text, not image wrappers).
 	resultIdx := 0
 	doc.Find("a[href*='/md5/']").Each(func(_ int, s *goquery.Selection) {
@@ -138,6 +139,13 @@ func (a *AnnasArchive) doSearch(ctx context.Context, query, ext string, seenMD5 
 		if resultIdx < len(metadataSizes) {
 			sizeHuman = metadataSizes[resultIdx]
 		}
+		format := ext
+		metadataText := s.Closest("div.flex").Find("div.font-semibold").Last().Text()
+		if match := annasMetadataFormatRe.FindStringSubmatch(metadataText); len(match) > 1 {
+			format = strings.ToLower(match[1])
+		} else if format == "" {
+			format = extractFormatFromTitle(title)
+		}
 		resultIdx++
 
 		// Extract author from "LastName, FirstName - Title" format.
@@ -155,6 +163,7 @@ func (a *AnnasArchive) doSearch(ctx context.Context, query, ext string, seenMD5 
 			Title:     title,
 			Author:    author,
 			SizeHuman: sizeHuman,
+			Format:    format,
 			MD5:       md5,
 			URL:       fmt.Sprintf("https://%s/md5/%s", a.cfg.AnnasArchiveDomain, md5),
 		})

--- a/internal/search/annas_test.go
+++ b/internal/search/annas_test.go
@@ -93,6 +93,9 @@ func TestAnnasArchive_DoSearchParsesHTML(t *testing.T) {
 	if results[0].Source != "annas" {
 		t.Errorf("expected source annas, got %s", results[0].Source)
 	}
+	if results[0].Format != "epub" {
+		t.Errorf("expected format epub, got %s", results[0].Format)
+	}
 }
 
 // rewriteTransport redirects all HTTPS requests to the test server.
@@ -154,6 +157,32 @@ func TestAnnasArchive_SeenMD5Dedup(t *testing.T) {
 	}
 	if len(results) != 0 {
 		t.Errorf("expected 0 results (already seen MD5), got %d", len(results))
+	}
+}
+
+func TestAnnasArchive_FormatStaysWithResultCard(t *testing.T) {
+	htmlContent := `<html><body>
+		<div class="flex"><div class="flex"><a href="/md5/11111111111111111111111111111111">No Metadata</a></div></div>
+		<div class="flex"><div class="flex"><a href="/md5/22222222222222222222222222222222">PDF Book</a><div class="font-semibold">English [en] · PDF · 1.2MB</div></div></div>
+	</body></html>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(htmlContent))
+	}))
+	defer server.Close()
+
+	a := &AnnasArchive{
+		cfg:    &config.Config{AnnasArchiveDomain: "example.com", UserAgent: "test"},
+		client: &http.Client{Transport: &rewriteTransport{serverURL: server.URL}},
+	}
+	results, err := a.doSearch(context.Background(), "book", "", make(map[string]bool))
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if results[0].Format != "" || results[1].Format != "pdf" {
+		t.Errorf("formats = [%q, %q], want [\"\", \"pdf\"]", results[0].Format, results[1].Format)
 	}
 }
 

--- a/internal/search/format_population_test.go
+++ b/internal/search/format_population_test.go
@@ -1,0 +1,91 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/models"
+	"github.com/JeremiahM37/librarr/internal/sources/sourcestest"
+)
+
+func TestDirectProvidersPopulateKnownFormats(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		configure  func(*config.Config, string)
+		searcher   func(*config.Config, *http.Client) Searcher
+		wantFormat string
+	}{
+		{
+			name: "gutenberg epub",
+			body: `{"results":[{"id":1,"title":"Test Book","formats":{"application/epub+zip":"https://example.com/book.epub"}}]}`,
+			configure: func(cfg *config.Config, url string) {
+				cfg.Sources.Gutenberg.URL = url
+			},
+			searcher:   func(cfg *config.Config, client *http.Client) Searcher { return NewGutenberg(cfg, client) },
+			wantFormat: "epub",
+		},
+		{
+			name: "standard ebooks epub",
+			body: `<feed><entry><title>Test Book</title><id>/ebooks/test-author/test-book</id><author><name>Test Author</name></author></entry></feed>`,
+			configure: func(cfg *config.Config, url string) {
+				cfg.Sources.StandardEbooks.URL = url
+			},
+			searcher:   func(cfg *config.Config, client *http.Client) Searcher { return NewStandardEbooks(cfg, client) },
+			wantFormat: "epub",
+		},
+		{
+			name: "librivox zip",
+			body: `{"books":[{"id":"1","title":"Test Book","url_zip_file":"https://example.com/book.zip"}]}`,
+			configure: func(cfg *config.Config, url string) {
+				cfg.Sources.Librivox.URL = url
+			},
+			searcher:   func(cfg *config.Config, client *http.Client) Searcher { return NewLibrivox(cfg, client) },
+			wantFormat: "zip",
+		},
+		{
+			name: "nyaa title format",
+			body: `<rss><channel><item><title>Test Book [CBZ]</title><link>https://example.com/book.torrent</link><seeders>1</seeders></item></channel></rss>`,
+			configure: func(cfg *config.Config, url string) {
+				cfg.Sources.Nyaa.URL = url
+			},
+			searcher:   func(cfg *config.Config, client *http.Client) Searcher { return NewNyaaManga(cfg, client) },
+			wantFormat: "cbz",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			defer server.Close()
+
+			registry, err := sourcestest.Registry()
+			if err != nil {
+				t.Fatalf("load test registry: %v", err)
+			}
+			cfg := &config.Config{Sources: registry, UserAgent: "test"}
+			tc.configure(cfg, server.URL)
+			results, err := tc.searcher(cfg, server.Client()).Search(context.Background(), "Test Book")
+			if err != nil {
+				t.Fatalf("search: %v", err)
+			}
+			assertSingleFormat(t, results, tc.wantFormat)
+		})
+	}
+}
+
+func assertSingleFormat(t *testing.T, results []models.SearchResult, want string) {
+	t.Helper()
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].Format != want {
+		t.Errorf("format = %q, want %q", results[0].Format, want)
+	}
+}

--- a/internal/search/gutenberg.go
+++ b/internal/search/gutenberg.go
@@ -85,6 +85,7 @@ func (g *Gutenberg) Search(ctx context.Context, query string) ([]models.SearchRe
 			SourceID:      fmt.Sprintf("gutenberg-%d", book.ID),
 			GutenbergID:   book.ID,
 			EpubURL:       epubURL,
+			Format:        "epub",
 			CoverURL:      coverURL,
 			SizeHuman:     "Public Domain",
 			DownloadCount: book.DownloadCount,

--- a/internal/search/librivox.go
+++ b/internal/search/librivox.go
@@ -118,6 +118,7 @@ func (l *Librivox) Search(ctx context.Context, query string) ([]models.SearchRes
 				CoverURL:    cover,
 				SizeHuman:   sizeHuman,
 				MediaType:   "audiobook",
+				Format:      "zip",
 			})
 		}
 

--- a/internal/search/nyaa.go
+++ b/internal/search/nyaa.go
@@ -110,6 +110,7 @@ func (n *NyaaManga) Search(ctx context.Context, query string) ([]models.SearchRe
 			SizeHuman:   item.Size,
 			Indexer:     "Nyaa",
 			MediaType:   "manga",
+			Format:      extractFormatFromTitle(title),
 		})
 	}
 

--- a/internal/search/prowlarr.go
+++ b/internal/search/prowlarr.go
@@ -191,6 +191,7 @@ func (p *Prowlarr) doSearch(ctx context.Context, params prowlarrSearchParams) ([
 			InfoHash:         item.InfoHash,
 			GUID:             item.GUID,
 			DownloadProtocol: protocol,
+			Format:           extractFormatFromTitle(item.Title),
 		})
 	}
 

--- a/internal/search/prowlarr_test.go
+++ b/internal/search/prowlarr_test.go
@@ -70,7 +70,7 @@ func TestProwlarr_Enabled(t *testing.T) {
 func TestProwlarr_Search(t *testing.T) {
 	items := []prowlarrItem{
 		{
-			Title:       "Test Book",
+			Title:       "Test Book [EPUB]",
 			Size:        1000000,
 			Seeders:     5,
 			Leechers:    2,
@@ -117,8 +117,11 @@ func TestProwlarr_Search(t *testing.T) {
 	if r0.Source != "torrent" {
 		t.Errorf("expected source torrent, got %s", r0.Source)
 	}
-	if r0.Title != "Test Book" {
-		t.Errorf("expected title Test Book, got %s", r0.Title)
+	if r0.Title != "Test Book [EPUB]" {
+		t.Errorf("expected title Test Book [EPUB], got %s", r0.Title)
+	}
+	if r0.Format != "epub" {
+		t.Errorf("expected format epub, got %s", r0.Format)
 	}
 	if r0.DownloadProtocol != "torrent" {
 		t.Errorf("expected protocol torrent, got %s", r0.DownloadProtocol)

--- a/internal/search/scorer.go
+++ b/internal/search/scorer.go
@@ -1,7 +1,7 @@
 package search
 
 import (
-	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/JeremiahM37/librarr/internal/models"
@@ -237,26 +237,14 @@ func extractContentWords(s string) []string {
 	return words
 }
 
-// extractFormatFromTitle tries to find a file extension in the title.
+var formatTokenRe = regexp.MustCompile(`(?i)(?:^|[^a-z0-9])(epub|mobi|pdf|azw3|cbz|cbr|djvu|fb2|m4b|mp3|m4a|aac|flac|ogg|zip)(?:$|[^a-z0-9])`)
+
+// extractFormatFromTitle finds a standalone file format token in a release title.
 func extractFormatFromTitle(title string) string {
-	lower := strings.ToLower(title)
-
-	// Check for extension in brackets like [EPUB] or (PDF).
-	formats := []string{"epub", "mobi", "pdf", "azw3", "cbz", "cbr", "djvu", "fb2"}
-	for _, f := range formats {
-		if strings.Contains(lower, f) {
-			return f
-		}
+	match := formatTokenRe.FindStringSubmatch(title)
+	if len(match) > 1 {
+		return strings.ToLower(match[1])
 	}
-
-	// Check file extension.
-	ext := strings.TrimPrefix(filepath.Ext(lower), ".")
-	for _, f := range formats {
-		if ext == f {
-			return f
-		}
-	}
-
 	return ""
 }
 

--- a/internal/search/scorer_test.go
+++ b/internal/search/scorer_test.go
@@ -216,6 +216,10 @@ func TestExtractFormatFromTitle(t *testing.T) {
 		{"Book Title [EPUB]", "epub"},
 		{"Book Title (PDF)", "pdf"},
 		{"book.mobi", "mobi"},
+		{"Audiobook-WEB-MP3-DE", "mp3"},
+		{"Audiobook [M4B]", "m4b"},
+		{"Audiobook MP3.zip", "mp3"},
+		{"A Magnum Opus", ""},
 		{"No format here", ""},
 	}
 	for _, tt := range tests {

--- a/internal/search/standardebooks.go
+++ b/internal/search/standardebooks.go
@@ -127,6 +127,7 @@ func (s *StandardEbooks) Search(ctx context.Context, query string) ([]models.Sea
 			SourceID:    fmt.Sprintf("standardebooks-%s", path),
 			EpubURL:     epubURL,
 			DownloadURL: epubURL,
+			Format:      "epub",
 		})
 	}
 

--- a/internal/search/thepiratebay.go
+++ b/internal/search/thepiratebay.go
@@ -202,6 +202,7 @@ func (t *ThePirateBay) searchCategory(ctx context.Context, query, category strin
 			SizeHuman:   sizeHuman,
 			Indexer:     "ThePirateBay",
 			MediaType:   mediaType,
+			Format:      extractFormatFromTitle(name),
 		})
 	}
 

--- a/internal/search/thepiratebay_test.go
+++ b/internal/search/thepiratebay_test.go
@@ -24,7 +24,7 @@ func testCfgWithSourcesURL(tpbURL string) *config.Config {
 // and should be filtered out. The third entry is a duplicate info_hash
 // that should also be dropped.
 const apibayFixture = `[
-  {"id":"1","name":"Programming Go","info_hash":"AABBCCDD0011","leechers":"4","seeders":"17","size":"4194304","num_files":"1","username":"anon","added":"1700000000","category":"601"},
+  {"id":"1","name":"Programming Go EPUB","info_hash":"AABBCCDD0011","leechers":"4","seeders":"17","size":"4194304","num_files":"1","username":"anon","added":"1700000000","category":"601"},
   {"id":"2","name":"Dead Torrent","info_hash":"11223344DEAD","leechers":"0","seeders":"0","size":"1024","num_files":"1","username":"anon","added":"1700000000","category":"601"},
   {"id":"3","name":"Programming Go (dup)","info_hash":"AABBCCDD0011","leechers":"2","seeders":"5","size":"4194304","num_files":"1","username":"anon","added":"1700000000","category":"601"}
 ]`
@@ -74,6 +74,9 @@ func TestThePirateBaySearch(t *testing.T) {
 	}
 	if r.InfoHash != "AABBCCDD0011" {
 		t.Errorf("InfoHash = %q", r.InfoHash)
+	}
+	if r.Format != "epub" {
+		t.Errorf("Format = %q, want epub", r.Format)
 	}
 	if !strings.HasPrefix(r.MagnetURL, "magnet:?xt=urn:btih:AABBCCDD0011") {
 		t.Errorf("MagnetURL missing info_hash: %q", r.MagnetURL)


### PR DESCRIPTION
## Summary
- populate known formats for Anna's Archive, Gutenberg, Standard Ebooks, and LibriVox results
- infer standalone ebook, manga, and audiobook format tokens for Prowlarr, The Pirate Bay, and Nyaa releases
- preserve the existing search-result display without frontend changes
- add provider and edge-case coverage for format extraction

## Behavior
Explicit provider metadata takes precedence. Torrent and NZB formats are inferred conservatively from standalone release-title tokens, avoiding substring matches such as `opus` in ordinary prose. LibriVox reports the downloaded ZIP container rather than assuming the codec of every enclosed track.

## Validation
- `go test ./internal/search -count=1`
- `go test ./... -skip TestSaveSettings_WriteFailureDoesNotLeakPath`
- `staticcheck ./...`
- `git diff --check`
- isolated live search confirmed format values for 50 Anna's Archive, 9 Gutenberg, and 4 Standard Ebooks results