### PR TITLE
Fix download-recursion and unchecked CSPRNG bugs

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -7,6 +7,7 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -79,10 +80,14 @@ func NewSessionStore() *SessionStore {
 	return s
 }
 
-// Create generates a new session token for a user, valid for 24 hours.
-func (s *SessionStore) Create(userID int64, username, role string) string {
+// Create generates a new session token for a user, valid for 24 hours. It
+// returns an error if the system CSPRNG fails, so callers fail closed rather
+// than mint a predictable all-zero token.
+func (s *SessionStore) Create(userID int64, username, role string) (string, error) {
 	b := make([]byte, 32)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate session token: %w", err)
+	}
 	token := hex.EncodeToString(b)
 
 	s.mu.Lock()
@@ -94,13 +99,16 @@ func (s *SessionStore) Create(userID int64, username, role string) string {
 	}
 	s.mu.Unlock()
 
-	return token
+	return token, nil
 }
 
-// CreatePendingTOTP creates a temporary token for TOTP verification (5 min expiry).
-func (s *SessionStore) CreatePendingTOTP(userID int64) string {
+// CreatePendingTOTP creates a temporary token for TOTP verification (5 min
+// expiry). Like Create, it fails closed if the CSPRNG errors.
+func (s *SessionStore) CreatePendingTOTP(userID int64) (string, error) {
 	b := make([]byte, 32)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate pending TOTP token: %w", err)
+	}
 	token := hex.EncodeToString(b)
 
 	s.mu.Lock()
@@ -110,7 +118,7 @@ func (s *SessionStore) CreatePendingTOTP(userID int64) string {
 	}
 	s.mu.Unlock()
 
-	return token
+	return token, nil
 }
 
 // ValidatePendingTOTP checks and consumes a pending TOTP token.
@@ -374,7 +382,14 @@ func handleLogin(cfg *config.Config, database *db.DB, sessions *SessionStore) ht
 
 			// If TOTP is enabled, return pending token.
 			if user.TOTPEnabled {
-				pendingToken := sessions.CreatePendingTOTP(user.ID)
+				pendingToken, err := sessions.CreatePendingTOTP(user.ID)
+				if err != nil {
+					writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+						"success": false,
+						"error":   "Failed to create session",
+					})
+					return
+				}
 				writeJSON(w, http.StatusOK, map[string]interface{}{
 					"success":         true,
 					"needs_totp":      true,
@@ -385,7 +400,14 @@ func handleLogin(cfg *config.Config, database *db.DB, sessions *SessionStore) ht
 
 			// No TOTP — create full session.
 			database.UpdateLastLogin(user.ID)
-			token := sessions.Create(user.ID, user.Username, user.Role)
+			token, err := sessions.Create(user.ID, user.Username, user.Role)
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+					"success": false,
+					"error":   "Failed to create session",
+				})
+				return
+			}
 			setSessionCookie(w, r, token, 86400)
 
 			database.LogActivity(user.Username, "login", user.Username, "User logged in")
@@ -416,7 +438,14 @@ func handleLogin(cfg *config.Config, database *db.DB, sessions *SessionStore) ht
 			return
 		}
 
-		token := sessions.Create(0, cfg.AuthUsername, "admin")
+		token, err := sessions.Create(0, cfg.AuthUsername, "admin")
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+				"success": false,
+				"error":   "Failed to create session",
+			})
+			return
+		}
 		setSessionCookie(w, r, token, 86400)
 
 		database.LogActivity(cfg.AuthUsername, "login", cfg.AuthUsername, "User logged in (legacy)")
@@ -466,7 +495,14 @@ func handleLoginTOTP(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 		// Try TOTP code first.
 		if validateTOTPCode(user.TOTPSecret, req.Code) {
 			database.UpdateLastLogin(user.ID)
-			token := sessions.Create(user.ID, user.Username, user.Role)
+			token, err := sessions.Create(user.ID, user.Username, user.Role)
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+					"success": false,
+					"error":   "Failed to create session",
+				})
+				return
+			}
 			setSessionCookie(w, r, token, 86400)
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"success":  true,
@@ -482,7 +518,14 @@ func handleLoginTOTP(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 		used, _ := database.UseBackupCode(user.ID, codeHash)
 		if used {
 			database.UpdateLastLogin(user.ID)
-			token := sessions.Create(user.ID, user.Username, user.Role)
+			token, err := sessions.Create(user.ID, user.Username, user.Role)
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+					"success": false,
+					"error":   "Failed to create session",
+				})
+				return
+			}
 			setSessionCookie(w, r, token, 86400)
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"success":          true,
@@ -603,7 +646,14 @@ func handleRegister(database *db.DB, sessions *SessionStore) http.HandlerFunc {
 		// If first user, auto-login.
 		if isFirstUser {
 			database.UpdateLastLogin(id)
-			token := sessions.Create(id, req.Username, role)
+			token, err := sessions.Create(id, req.Username, role)
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+					"success": false,
+					"error":   "Failed to create session",
+				})
+				return
+			}
 			setSessionCookie(w, r, token, 86400)
 			writeJSON(w, http.StatusCreated, map[string]interface{}{
 				"success":  true,

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -17,7 +17,10 @@ import (
 func TestSessionStore_CreateAndGet(t *testing.T) {
 	store := NewSessionStore()
 
-	token := store.Create(1, "testuser", "admin")
+	token, err := store.Create(1, "testuser", "admin")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
 	if token == "" {
 		t.Fatal("expected non-empty token")
 	}
@@ -39,7 +42,10 @@ func TestSessionStore_CreateAndGet(t *testing.T) {
 
 func TestSessionStore_Valid(t *testing.T) {
 	store := NewSessionStore()
-	token := store.Create(1, "user", "admin")
+	token, err := store.Create(1, "user", "admin")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
 
 	if !store.Valid(token) {
 		t.Error("expected token to be valid")
@@ -52,7 +58,10 @@ func TestSessionStore_Valid(t *testing.T) {
 
 func TestSessionStore_Delete(t *testing.T) {
 	store := NewSessionStore()
-	token := store.Create(1, "user", "admin")
+	token, err := store.Create(1, "user", "admin")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
 
 	store.Delete(token)
 	if store.Valid(token) {
@@ -62,7 +71,10 @@ func TestSessionStore_Delete(t *testing.T) {
 
 func TestSessionStore_Expiry(t *testing.T) {
 	store := NewSessionStore()
-	token := store.Create(1, "user", "admin")
+	token, err := store.Create(1, "user", "admin")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
 
 	// Manually expire the session
 	store.mu.Lock()
@@ -86,7 +98,10 @@ func TestSessionStore_PendingTOTP(t *testing.T) {
 	store := NewSessionStore()
 
 	t.Run("create and validate", func(t *testing.T) {
-		token := store.CreatePendingTOTP(42)
+		token, err := store.CreatePendingTOTP(42)
+		if err != nil {
+			t.Fatalf("CreatePendingTOTP: %v", err)
+		}
 		if token == "" {
 			t.Fatal("expected non-empty pending token")
 		}
@@ -101,7 +116,10 @@ func TestSessionStore_PendingTOTP(t *testing.T) {
 	})
 
 	t.Run("consumed after first use", func(t *testing.T) {
-		token := store.CreatePendingTOTP(1)
+		token, err := store.CreatePendingTOTP(1)
+		if err != nil {
+			t.Fatalf("CreatePendingTOTP: %v", err)
+		}
 		store.ValidatePendingTOTP(token)
 
 		_, valid := store.ValidatePendingTOTP(token)
@@ -111,7 +129,10 @@ func TestSessionStore_PendingTOTP(t *testing.T) {
 	})
 
 	t.Run("expired pending TOTP", func(t *testing.T) {
-		token := store.CreatePendingTOTP(1)
+		token, err := store.CreatePendingTOTP(1)
+		if err != nil {
+			t.Fatalf("CreatePendingTOTP: %v", err)
+		}
 
 		store.mu.Lock()
 		store.pendingTOTP[token].Expiry = time.Now().Add(-1 * time.Minute)
@@ -136,7 +157,10 @@ func TestSessionStore_UniqueTokens(t *testing.T) {
 	tokens := make(map[string]bool)
 
 	for i := 0; i < 100; i++ {
-		token := store.Create(int64(i), "user", "admin")
+		token, err := store.Create(int64(i), "user", "admin")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
 		if tokens[token] {
 			t.Fatalf("duplicate token generated: %s", token)
 		}

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -91,17 +91,21 @@ func NewOIDCHandler(cfg *config.Config, database *db.DB, sessions *SessionStore)
 	return h
 }
 
-// generateState creates a random state string for CSRF protection.
-func (h *OIDCHandler) generateState() string {
+// generateState creates a random state string for CSRF protection. It returns
+// an error if the CSPRNG fails, so login fails closed rather than proceed with
+// a predictable state nonce.
+func (h *OIDCHandler) generateState() (string, error) {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate OIDC state: %w", err)
+	}
 	state := hex.EncodeToString(b)
 
 	h.mu.Lock()
 	h.states[state] = time.Now().Add(10 * time.Minute)
 	h.mu.Unlock()
 
-	return state
+	return state, nil
 }
 
 // validateState checks and consumes a state nonce.
@@ -138,7 +142,11 @@ func (h *OIDCHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		oauth2Cfg.RedirectURL = fmt.Sprintf("%s://%s/auth/oidc/callback", scheme, host)
 	}
 
-	state := h.generateState()
+	state, err := h.generateState()
+	if err != nil {
+		http.Error(w, "Failed to start login", http.StatusInternalServerError)
+		return
+	}
 	http.Redirect(w, r, oauth2Cfg.AuthCodeURL(state), http.StatusFound)
 }
 
@@ -263,7 +271,11 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 	// Create session.
 	h.db.UpdateLastLogin(user.ID)
-	sessionToken := h.sessions.Create(user.ID, user.Username, user.Role)
+	sessionToken, err := h.sessions.Create(user.ID, user.Username, user.Role)
+	if err != nil {
+		http.Error(w, "Failed to create session", http.StatusInternalServerError)
+		return
+	}
 	setSessionCookie(w, r, sessionToken, 86400)
 
 	// Redirect to app root.

--- a/internal/api/requests.go
+++ b/internal/api/requests.go
@@ -14,11 +14,15 @@ import (
 	"github.com/JeremiahM37/librarr/internal/models"
 )
 
-// generateRequestID returns a random hex ID for a request.
-func generateRequestID() string {
+// generateRequestID returns a random hex ID for a request. It fails closed if
+// the CSPRNG errors rather than return a predictable all-zero ID that could
+// collide with an existing request.
+func generateRequestID() (string, error) {
 	b := make([]byte, 16)
-	rand.Read(b)
-	return hex.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate request ID: %w", err)
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // handleCreateRequest handles POST /api/requests — any authenticated user.
@@ -64,9 +68,18 @@ func (s *Server) handleCreateRequest(w http.ResponseWriter, r *http.Request) {
 	userID := getUserIDFromContext(r)
 	username, _ := r.Context().Value(ctxUsername).(string)
 
+	requestID, err := generateRequestID()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"success": false,
+			"error":   "Failed to create request",
+		})
+		return
+	}
+
 	now := time.Now()
 	request := &models.Request{
-		ID:             generateRequestID(),
+		ID:             requestID,
 		UserID:         userID,
 		Username:       username,
 		Title:          req.Title,

--- a/internal/api/sso_proxy.go
+++ b/internal/api/sso_proxy.go
@@ -191,7 +191,11 @@ func ensureSessionForUser(w http.ResponseWriter, r *http.Request, sessions *Sess
 		}
 	}
 
-	token := sessions.Create(user.ID, user.Username, user.Role)
+	token, err := sessions.Create(user.ID, user.Username, user.Role)
+	if err != nil {
+		slog.Error("failed to create SSO proxy session", "error", err, "username", user.Username)
+		return false
+	}
 	setSessionCookie(w, r, token, 86400)
 	return true
 }

--- a/internal/download/direct.go
+++ b/internal/download/direct.go
@@ -198,10 +198,21 @@ func (d *DirectDownloader) downloadFileWithClient(client *http.Client, fileURL, 
 }
 
 func (d *DirectDownloader) downloadFileWithClientAndUserAgent(client *http.Client, fileURL, title string, progressFn func(string), userAgent string) (string, int64, error) {
-	return d.downloadFileAttempt(client, fileURL, title, progressFn, true, userAgent)
+	return d.downloadFileAttempt(client, fileURL, title, progressFn, true, userAgent, 0)
 }
 
-func (d *DirectDownloader) downloadFileAttempt(client *http.Client, fileURL, title string, progressFn func(string), allowChallenge bool, userAgent string) (string, int64, error) {
+// maxDownloadHops bounds how many times downloadFileAttempt will follow an HTML
+// "GET" page (or retry after a browser challenge) before giving up. Without it,
+// a malicious or misconfigured mirror can serve an HTML page whose download
+// link points at another HTML page, recursing until the goroutine stack is
+// exhausted and the download job wedges.
+const maxDownloadHops = 5
+
+func (d *DirectDownloader) downloadFileAttempt(client *http.Client, fileURL, title string, progressFn func(string), allowChallenge bool, userAgent string, depth int) (string, int64, error) {
+	if depth > maxDownloadHops {
+		return "", 0, fmt.Errorf("too many download hops (exceeded %d): mirror kept returning HTML instead of a file", maxDownloadHops)
+	}
+
 	// Re-validate on every hop. This is the single chokepoint every download
 	// request funnels through, including URLs scraped from HTML "GET" pages,
 	// which are attacker-influenced and never pass the entry-point guard.
@@ -232,7 +243,7 @@ func (d *DirectDownloader) downloadFileAttempt(client *http.Client, fileURL, tit
 				return "", 0, err
 			}
 			_ = addCookie(client, fileURL, "c_time", "0.1")
-			return d.downloadFileAttempt(client, fileURL, title, progressFn, false, userAgent)
+			return d.downloadFileAttempt(client, fileURL, title, progressFn, false, userAgent, depth+1)
 		}
 		return "", 0, fmt.Errorf("zlibrary browser challenge changed or could not be solved")
 	}
@@ -256,13 +267,13 @@ func (d *DirectDownloader) downloadFileAttempt(client *http.Client, fileURL, tit
 			fileLink := regexp.MustCompile(`href="(https?://[^"]*\.(epub|pdf|mobi)[^"]*)"`).FindStringSubmatch(bodyStr)
 			if len(fileLink) < 2 {
 				if dlLink := zlibraryparse.FindDownloadLinkInHTML(fileURL, body); dlLink != "" {
-					return d.downloadFileWithClientAndUserAgent(client, dlLink, title, progressFn, userAgent)
+					return d.downloadFileAttempt(client, dlLink, title, progressFn, true, userAgent, depth+1)
 				}
 				return "", 0, fmt.Errorf("no download link found in HTML response")
 			}
-			return d.downloadFileWithClientAndUserAgent(client, fileLink[1], title, progressFn, userAgent)
+			return d.downloadFileAttempt(client, fileLink[1], title, progressFn, true, userAgent, depth+1)
 		}
-		return d.downloadFileWithClientAndUserAgent(client, getLink[1], title, progressFn, userAgent)
+		return d.downloadFileAttempt(client, getLink[1], title, progressFn, true, userAgent, depth+1)
 	}
 
 	// Save to incoming directory.

--- a/internal/download/direct_test.go
+++ b/internal/download/direct_test.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/JeremiahM37/librarr/internal/config"
@@ -260,6 +262,36 @@ func TestDownloadFile_TooSmallRejected(t *testing.T) {
 	files, _ := os.ReadDir(dir)
 	if len(files) > 0 {
 		t.Errorf("file should have been cleaned up, found: %v", files[0].Name())
+	}
+}
+
+// TestDownloadFile_HTMLLoopIsBounded verifies that a mirror which keeps serving
+// an HTML page whose "GET" link points at another HTML page cannot recurse
+// forever. The hop limit must turn it into a clean error instead of exhausting
+// the goroutine stack.
+func TestDownloadFile_HTMLLoopIsBounded(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "text/html")
+		// A GET link that points right back at another HTML page on this server.
+		_, _ = fmt.Fprintf(w, `<html><body><a href="http://%s/next">GET</a></body></html>`, r.Host)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{IncomingDir: t.TempDir(), UserAgent: "test"}
+	d := NewDirectDownloader(cfg, server.Client())
+	d.validate = nil // httptest serves on loopback; not exercising the SSRF guard here
+
+	_, _, err := d.downloadFile(server.URL, "Loop", nil)
+	if err == nil {
+		t.Fatal("expected an error from an unbounded HTML redirect loop, got nil")
+	}
+	if !strings.Contains(err.Error(), "too many download hops") {
+		t.Errorf("expected hop-limit error, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got > maxDownloadHops+2 {
+		t.Errorf("made %d requests; hop limit should cap it near %d", got, maxDownloadHops)
 	}
 }
 


### PR DESCRIPTION
## What & why

Two latent bugs found while auditing the download and auth paths. Both are real (verified against current `main`), self-contained, and covered by tests.

### 1. Unbounded HTML-follow recursion in the direct downloader
`downloadFileAttempt` follows a mirror's HTML `GET` link by recursing into itself (via `downloadFileWithClientAndUserAgent`). There was **no depth limit**, so a malicious or misconfigured mirror that serves an HTML page whose link points at *another* HTML page recurses forever — growing the goroutine stack until it's exhausted and the download job wedges.

**Fix:** thread a `maxDownloadHops` (5) cap through the recursion — covering both the HTML-link follow and the browser-challenge retry — so a loop becomes a clean error instead of a stack overflow. Adds a regression test that serves a self-referential `GET` page and asserts the hop limit trips (and that it makes only a bounded number of requests).

### 2. Unchecked `crypto/rand.Read` on token generation
`SessionStore.Create`, `CreatePendingTOTP`, `OIDCHandler.generateState`, and `generateRequestID` generated tokens with `crypto/rand.Read` but **discarded the error**. If the system CSPRNG ever failed, the buffer stays all-zero and we'd mint a predictable, colliding session/CSRF token on the auth path.

**Fix:** return an error from those functions and have callers fail the request (HTTP 500) instead of proceeding — matching the pattern already used in `invites.go:54` and `sso_proxy.go:158`.

## Validation
- `go build ./...`, `go vet ./...`, `gofmt` clean
- `go test ./...` — all packages pass
- `go test -race ./internal/download/... ./internal/api/...` — pass
- New regression test `TestDownloadFile_HTMLLoopIsBounded`
