### PR TITLE
Feat/annas archive fast download

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,10 +49,10 @@ LIBRARR_SOURCES_PATH=            # e.g. /data/sources.json
 
 # Legacy per-source overrides — set to override values from the registry.
 ANNAS_ARCHIVE_DOMAIN=
-# Membership/donator secret key for VIP fast downloads (/dyn/api/fast_download.json).
-# Also accepted as AA_DONATOR_KEY. Without this, Anna's Archive downloads use LibGen mirrors.
+# Account secret key from the AA login page (also called a donator key in some tools).
+# Enables membership fast downloads via /dyn/api/fast_download.json when membership is active.
+# Alias AA_DONATOR_KEY is still accepted. Without this, Anna's Archive downloads use LibGen mirrors.
 ANNAS_ARCHIVE_SECRET_KEY=
-# AA_DONATOR_KEY=
 
 # Circuit Breaker
 CIRCUIT_BREAKER_THRESHOLD=3

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ LIBRARR_SOURCES_PATH=            # e.g. /data/sources.json
 
 # Legacy per-source overrides — set to override values from the registry.
 ANNAS_ARCHIVE_DOMAIN=
+# Membership/donator secret key for VIP fast downloads (/dyn/api/fast_download.json).
+# Also accepted as AA_DONATOR_KEY. Without this, Anna's Archive downloads use LibGen mirrors.
+ANNAS_ARCHIVE_SECRET_KEY=
+# AA_DONATOR_KEY=
 
 # Circuit Breaker
 CIRCUIT_BREAKER_THRESHOLD=3

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Librarr searches all configured indexers in parallel, scores results by confiden
 ### Download Management
 
 - **Multiple download clients** -- qBittorrent or Transmission for torrents, plus SABnzbd for Usenet
-- **Anna's Archive VIP fast download** -- optional membership secret key uses `/dyn/api/fast_download.json`, with LibGen mirror fallback
+- **Anna's Archive membership fast download** -- optional account secret key uses `/dyn/api/fast_download.json`, with LibGen mirror fallback
 - **Request/approval workflow** -- pending, approved, searching, downloading, completed states with per-request notifications
 - **Scheduled wishlist searches** -- background scheduler auto-searches and downloads wishlist items on a configurable interval
 - **Torrent completion watcher** -- polls download client, auto-imports completed downloads
@@ -255,7 +255,7 @@ which requires Transmission 3.0+).
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ANNAS_ARCHIVE_DOMAIN` | (from sources registry) | AA mirror hostname (no scheme) |
-| `ANNAS_ARCHIVE_SECRET_KEY` | | Membership/donator secret key for VIP `/dyn/api/fast_download.json`. Alias: `AA_DONATOR_KEY`. Without a key, downloads use public LibGen mirrors. |
+| `ANNAS_ARCHIVE_SECRET_KEY` | | Account secret key from the AA login page (also called a donator key in some tools). Used for `/dyn/api/fast_download.json` when the account has an active membership. Env alias `AA_DONATOR_KEY` is still accepted. Without a key, downloads use public LibGen mirrors. |
 
 ### Library Imports
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Librarr searches all configured indexers in parallel, scores results by confiden
 ### Download Management
 
 - **Multiple download clients** -- qBittorrent or Transmission for torrents, plus SABnzbd for Usenet
+- **Anna's Archive VIP fast download** -- optional membership secret key uses `/dyn/api/fast_download.json`, with LibGen mirror fallback
 - **Request/approval workflow** -- pending, approved, searching, downloading, completed states with per-request notifications
 - **Scheduled wishlist searches** -- background scheduler auto-searches and downloads wishlist items on a configurable interval
 - **Torrent completion watcher** -- polls download client, auto-imports completed downloads
@@ -248,6 +249,13 @@ which requires Transmission 3.0+).
 |----------|---------|-------------|
 | `PROWLARR_URL` | | Prowlarr URL |
 | `PROWLARR_API_KEY` | | Prowlarr API key |
+
+### Anna's Archive
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ANNAS_ARCHIVE_DOMAIN` | (from sources registry) | AA mirror hostname (no scheme) |
+| `ANNAS_ARCHIVE_SECRET_KEY` | | Membership/donator secret key for VIP `/dyn/api/fast_download.json`. Alias: `AA_DONATOR_KEY`. Without a key, downloads use public LibGen mirrors. |
 
 ### Library Imports
 

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -16,15 +16,17 @@ const maskedValue = "--------"
 
 // sensitiveKeys are settings keys that should be masked in GET responses.
 var sensitiveKeys = map[string]bool{
-	"prowlarr_api_key":  true,
-	"qb_pass":           true,
-	"abs_token":         true,
-	"kavita_pass":       true,
-	"api_key":           true,
-	"auth_password":     true,
-	"komga_pass":        true,
-	"sabnzbd_api_key":   true,
-	"transmission_pass": true,
+	"prowlarr_api_key":         true,
+	"qb_pass":                  true,
+	"abs_token":                true,
+	"kavita_pass":              true,
+	"api_key":                  true,
+	"auth_password":            true,
+	"komga_pass":               true,
+	"sabnzbd_api_key":          true,
+	"transmission_pass":        true,
+	"annas_archive_secret_key": true,
+	"annas_secret_key":         true,
 }
 
 func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
@@ -35,6 +37,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
 	defaults := map[string]interface{}{
 		"file_org_enabled":            s.cfg.FileOrgEnabled,
 		"annas_archive_domain":        s.cfg.AnnasArchiveDomain,
+		"annas_archive_secret_key":    s.cfg.AnnasArchiveSecretKey,
 		"ebook_dir":                   s.cfg.EbookDir,
 		"audiobook_dir":               s.cfg.AudiobookDir,
 		"manga_dir":                   s.cfg.MangaDir,
@@ -171,6 +174,13 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 			s.cfg.RemoveTorrentAfterImport = b
 			slog.Info("remove torrent after import updated", "enabled", b)
 		}
+	}
+	if v, ok := data["annas_archive_domain"].(string); ok && v != "" {
+		s.cfg.AnnasArchiveDomain = sources.NormalizeDomain(v)
+	}
+	if v, ok := data["annas_archive_secret_key"].(string); ok && v != "" {
+		s.cfg.AnnasArchiveSecretKey = v
+		slog.Info("annas archive secret key updated")
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{"success": true})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -582,14 +582,14 @@ func (c *Config) applySettingsFileOverrides() {
 		"komga_library_path":        &c.KomgaLibraryPath,
 		"calibre_url":               &c.CalibreURL,
 		"calibre_library_path":      &c.CalibreLibraryPath,
-		"annas_archive_domain":     &c.AnnasArchiveDomain,
-		"annas_archive_secret_key": &c.AnnasArchiveSecretKey,
-		"ebook_dir":                &c.EbookDir,
-		"audiobook_dir":            &c.AudiobookDir,
-		"manga_dir":                &c.MangaDir,
-		"incoming_dir":             &c.IncomingDir,
-		"manga_incoming_dir":       &c.MangaIncomingDir,
-		"flibusta_url":             &c.FlibustaURL,
+		"annas_archive_domain":      &c.AnnasArchiveDomain,
+		"annas_archive_secret_key":  &c.AnnasArchiveSecretKey,
+		"ebook_dir":                 &c.EbookDir,
+		"audiobook_dir":             &c.AudiobookDir,
+		"manga_dir":                 &c.MangaDir,
+		"incoming_dir":              &c.IncomingDir,
+		"manga_incoming_dir":        &c.MangaIncomingDir,
+		"flibusta_url":              &c.FlibustaURL,
 	}
 	for key, fieldPtr := range strPtrs {
 		v, ok := raw[key]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,7 @@ type Config struct {
 
 	// Anna's Archive
 	AnnasArchiveDomain    string
-	AnnasArchiveSecretKey string // membership/donator key for /dyn/api/fast_download.json
+	AnnasArchiveSecretKey string // AA account secret key for /dyn/api/fast_download.json
 
 	// Sources is the runtime indexer-endpoint registry. Drivers read URLs,
 	// mirrors, and per-site config from here instead of from hardcoded

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,8 @@ type Config struct {
 	TorznabAPIKey string
 
 	// Anna's Archive
-	AnnasArchiveDomain string
+	AnnasArchiveDomain    string
+	AnnasArchiveSecretKey string // membership/donator key for /dyn/api/fast_download.json
 
 	// Sources is the runtime indexer-endpoint registry. Drivers read URLs,
 	// mirrors, and per-site config from here instead of from hardcoded
@@ -305,7 +306,8 @@ func buildFromEnv() *Config {
 
 		TorznabAPIKey: getEnv("TORZNAB_API_KEY", ""),
 
-		AnnasArchiveDomain: annasDomain,
+		AnnasArchiveDomain:    annasDomain,
+		AnnasArchiveSecretKey: firstNonEmpty(getEnv("ANNAS_ARCHIVE_SECRET_KEY", ""), getEnv("AA_DONATOR_KEY", "")),
 
 		CircuitBreakerThreshold: getEnvInt("CIRCUIT_BREAKER_THRESHOLD", 3),
 		CircuitBreakerTimeout:   getEnvInt("CIRCUIT_BREAKER_TIMEOUT", 300),
@@ -580,13 +582,14 @@ func (c *Config) applySettingsFileOverrides() {
 		"komga_library_path":        &c.KomgaLibraryPath,
 		"calibre_url":               &c.CalibreURL,
 		"calibre_library_path":      &c.CalibreLibraryPath,
-		"annas_archive_domain":      &c.AnnasArchiveDomain,
-		"ebook_dir":                 &c.EbookDir,
-		"audiobook_dir":             &c.AudiobookDir,
-		"manga_dir":                 &c.MangaDir,
-		"incoming_dir":              &c.IncomingDir,
-		"manga_incoming_dir":        &c.MangaIncomingDir,
-		"flibusta_url":              &c.FlibustaURL,
+		"annas_archive_domain":     &c.AnnasArchiveDomain,
+		"annas_archive_secret_key": &c.AnnasArchiveSecretKey,
+		"ebook_dir":                &c.EbookDir,
+		"audiobook_dir":            &c.AudiobookDir,
+		"manga_dir":                &c.MangaDir,
+		"incoming_dir":             &c.IncomingDir,
+		"manga_incoming_dir":       &c.MangaIncomingDir,
+		"flibusta_url":             &c.FlibustaURL,
 	}
 	for key, fieldPtr := range strPtrs {
 		v, ok := raw[key]
@@ -598,6 +601,12 @@ func (c *Config) applySettingsFileOverrides() {
 			continue
 		}
 		*fieldPtr = s
+	}
+	// Prefer canonical key; accept legacy alias used by some deployments.
+	if c.AnnasArchiveSecretKey == "" {
+		if s, ok := raw["annas_secret_key"].(string); ok && s != "" {
+			c.AnnasArchiveSecretKey = s
+		}
 	}
 
 	boolPtrs := map[string]*bool{
@@ -651,6 +660,15 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // splitCSV splits a comma-separated value into trimmed, non-empty entries.

--- a/internal/download/annas_download_test.go
+++ b/internal/download/annas_download_test.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -245,5 +246,29 @@ func TestDownloadFromAnnasFallsBackToLibgenWhenFastFails(t *testing.T) {
 	}
 	if gotMD5 != md5 {
 		t.Errorf("md5 = %q, want %q", gotMD5, md5)
+	}
+}
+
+func TestFastDownloadNetworkErrorRedactsSecretKey(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("dial tcp: connection refused")
+	})}
+	cfg := exhaustedAnnasConfig(t.TempDir())
+	cfg.AnnasArchiveSecretKey = "vip-key"
+	direct := NewDirectDownloader(cfg, client)
+	direct.validate = nil
+
+	_, _, err := direct.downloadFromAnnasFast("cccccccccccccccccccccccccccccccc", "Redact Book", nil)
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+	// client.Do wraps transport errors in *url.Error, which embeds the full
+	// request URL including key=… — the secret must not survive into the
+	// error text that DownloadFromAnnas logs.
+	if strings.Contains(err.Error(), "vip-key") {
+		t.Fatalf("secret key leaked into error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "REDACTED") {
+		t.Fatalf("expected redaction marker in error: %v", err)
 	}
 }

--- a/internal/download/annas_download_test.go
+++ b/internal/download/annas_download_test.go
@@ -156,3 +156,94 @@ func TestAnnasTransientExhaustionUsesConfiguredRetries(t *testing.T) {
 		t.Errorf("detail = %q", job.Detail)
 	}
 }
+
+func TestParseAnnasFastDownloadURLAbsoluteAndRelative(t *testing.T) {
+	api := "https://annas.test/dyn/api/fast_download.json?md5=abc&key=k"
+	got, err := parseAnnasFastDownloadURL(api, []byte(`{"download_url":"https://cdn.test/file.epub"}`))
+	if err != nil || got != "https://cdn.test/file.epub" {
+		t.Fatalf("absolute: got %q err %v", got, err)
+	}
+	got, err = parseAnnasFastDownloadURL(api, []byte(`{"download_url":"/get.php?md5=abc"}`))
+	if err != nil || got != "https://annas.test/get.php?md5=abc" {
+		t.Fatalf("relative: got %q err %v", got, err)
+	}
+	if _, err := parseAnnasFastDownloadURL(api, []byte(`{"error":"not a member"}`)); err == nil || !strings.Contains(err.Error(), "not a member") {
+		t.Fatalf("expected membership error, got %v", err)
+	}
+}
+
+func TestDownloadFromAnnasUsesFastDownloadWhenKeyConfigured(t *testing.T) {
+	const md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	epub := append([]byte("PK"), bytes.Repeat([]byte{'z'}, 2000)...)
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		switch {
+		case req.URL.Host == "annas.test" && req.URL.Path == "/dyn/api/fast_download.json":
+			if req.URL.Query().Get("key") != "vip-key" || req.URL.Query().Get("md5") != md5 {
+				t.Fatalf("unexpected fast_download query: %s", req.URL.RawQuery)
+			}
+			body := []byte(`{"download_url":"https://cdn.test/book.epub"}`)
+			return &http.Response{StatusCode: 200, Header: header, Body: io.NopCloser(bytes.NewReader(body)), Request: req}, nil
+		case req.URL.Host == "cdn.test" && req.URL.Path == "/book.epub":
+			header.Set("Content-Type", "application/epub+zip")
+			return &http.Response{StatusCode: 200, Header: header, Body: io.NopCloser(bytes.NewReader(epub)), Request: req}, nil
+		case req.URL.Host == "mirror.test":
+			t.Fatalf("should not fall back to LibGen when fast download succeeds: %s", req.URL)
+		default:
+			t.Fatalf("unexpected request: %s", req.URL)
+		}
+		return nil, nil
+	})}
+	cfg := exhaustedAnnasConfig(t.TempDir())
+	cfg.AnnasArchiveSecretKey = "vip-key"
+	direct := NewDirectDownloader(cfg, client)
+	direct.validate = nil
+
+	path, size, gotMD5, err := direct.DownloadFromAnnas(md5, "VIP Book", nil)
+	if err != nil {
+		t.Fatalf("fast download: %v", err)
+	}
+	if gotMD5 != md5 {
+		t.Errorf("md5 = %q, want %q", gotMD5, md5)
+	}
+	if size < 1000 {
+		t.Errorf("size = %d, want larger file", size)
+	}
+	if path == "" {
+		t.Fatal("expected local path")
+	}
+}
+
+func TestDownloadFromAnnasFallsBackToLibgenWhenFastFails(t *testing.T) {
+	const md5 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	epub := append([]byte("PK"), bytes.Repeat([]byte{'y'}, 2000)...)
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		switch {
+		case req.URL.Host == "annas.test" && req.URL.Path == "/dyn/api/fast_download.json":
+			body := []byte(`{"error":"quota exceeded"}`)
+			return &http.Response{StatusCode: 200, Header: header, Body: io.NopCloser(bytes.NewReader(body)), Request: req}, nil
+		case req.URL.Host == "mirror.test" && req.URL.Path == "/ads.php":
+			body := `<a href="get.php?md5=` + md5 + `&amp;key=test">GET</a>`
+			return &http.Response{StatusCode: 200, Header: header, Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+		case req.URL.Host == "mirror.test" && req.URL.Path == "/get.php":
+			header.Set("Content-Type", "application/epub+zip")
+			return &http.Response{StatusCode: 200, Header: header, Body: io.NopCloser(bytes.NewReader(epub)), Request: req}, nil
+		default:
+			t.Fatalf("unexpected request: %s", req.URL)
+		}
+		return nil, nil
+	})}
+	cfg := exhaustedAnnasConfig(t.TempDir())
+	cfg.AnnasArchiveSecretKey = "vip-key"
+	direct := NewDirectDownloader(cfg, client)
+	direct.validate = nil
+
+	_, _, gotMD5, err := direct.DownloadFromAnnas(md5, "Fallback Book", nil)
+	if err != nil {
+		t.Fatalf("libgen fallback: %v", err)
+	}
+	if gotMD5 != md5 {
+		t.Errorf("md5 = %q, want %q", gotMD5, md5)
+	}
+}

--- a/internal/download/direct.go
+++ b/internal/download/direct.go
@@ -67,10 +67,23 @@ func (d *DirectDownloader) mirrors() []string {
 	return d.cfg.Sources.LibgenMirrors
 }
 
-// DownloadFromAnnas downloads a file from Anna's Archive via libgen.
-// Returns the local file path and size, or an error.
+// DownloadFromAnnas downloads a file from Anna's Archive.
+// When a membership/donator secret key is configured, tries the VIP
+// fast_download API first, then falls back to public LibGen mirrors.
 func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(string)) (string, int64, string, error) {
-	if progressFn != nil {
+	if strings.TrimSpace(d.cfg.AnnasArchiveSecretKey) != "" {
+		if progressFn != nil {
+			progressFn("Trying Anna's Archive fast download...")
+		}
+		filePath, fileSize, err := d.downloadFromAnnasFast(md5, title, progressFn)
+		if err == nil {
+			return filePath, fileSize, md5, nil
+		}
+		slog.Warn("annas fast download failed; falling back to LibGen", "md5", md5, "error", err)
+		if progressFn != nil {
+			progressFn("Fast download unavailable, trying LibGen mirrors...")
+		}
+	} else if progressFn != nil {
 		progressFn("Fetching download link from Anna's Archive...")
 	}
 
@@ -114,6 +127,108 @@ func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(
 		lastErr = errLibgenNoMatch
 	}
 	return "", 0, "", fmt.Errorf("all matching LibGen candidates exhausted: %w", lastErr)
+}
+
+// downloadFromAnnasFast resolves VIP fast_download.json and downloads the file.
+func (d *DirectDownloader) downloadFromAnnasFast(md5, title string, progressFn func(string)) (string, int64, error) {
+	downloadURL, err := d.fetchAnnasFastDownloadURL(md5)
+	if err != nil {
+		return "", 0, err
+	}
+	if progressFn != nil {
+		progressFn("Downloading via Anna's Archive fast download...")
+	}
+	slog.Info("found annas fast download link", "title", title, "md5", md5)
+	return d.downloadFile(downloadURL, title, progressFn)
+}
+
+// fetchAnnasFastDownloadURL calls AA membership fast_download API for one MD5.
+func (d *DirectDownloader) fetchAnnasFastDownloadURL(md5 string) (string, error) {
+	domain := strings.TrimSpace(d.cfg.AnnasArchiveDomain)
+	key := strings.TrimSpace(d.cfg.AnnasArchiveSecretKey)
+	if domain == "" || key == "" {
+		return "", fmt.Errorf("annas fast download requires domain and secret key")
+	}
+	apiURL := fmt.Sprintf(
+		"https://%s/dyn/api/fast_download.json?md5=%s&key=%s",
+		domain,
+		url.QueryEscape(md5),
+		url.QueryEscape(key),
+	)
+	if err := d.checkURL(apiURL); err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", d.cfg.UserAgent)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("annas fast download request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return "", fmt.Errorf("annas fast download read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("annas fast download HTTP %d: %s", resp.StatusCode, truncateForErr(string(body), 200))
+	}
+
+	downloadURL, err := parseAnnasFastDownloadURL(apiURL, body)
+	if err != nil {
+		return "", err
+	}
+	if err := d.checkURL(downloadURL); err != nil {
+		return "", err
+	}
+	return downloadURL, nil
+}
+
+// parseAnnasFastDownloadURL extracts download_url from AA fast_download JSON.
+func parseAnnasFastDownloadURL(apiURL string, body []byte) (string, error) {
+	var payload struct {
+		DownloadURL string `json:"download_url"`
+		Error       string `json:"error"`
+		Message     string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", fmt.Errorf("annas fast download JSON: %w", err)
+	}
+	if payload.Error != "" {
+		return "", fmt.Errorf("annas fast download: %s", payload.Error)
+	}
+	if payload.Message != "" && payload.DownloadURL == "" {
+		return "", fmt.Errorf("annas fast download: %s", payload.Message)
+	}
+	downloadURL := strings.TrimSpace(payload.DownloadURL)
+	if downloadURL == "" {
+		return "", fmt.Errorf("annas fast download: empty download_url")
+	}
+	if strings.HasPrefix(downloadURL, "http://") || strings.HasPrefix(downloadURL, "https://") {
+		return downloadURL, nil
+	}
+	base, err := url.Parse(apiURL)
+	if err != nil {
+		return "", fmt.Errorf("annas fast download base URL: %w", err)
+	}
+	ref, err := url.Parse(downloadURL)
+	if err != nil {
+		return "", fmt.Errorf("annas fast download relative URL: %w", err)
+	}
+	return base.ResolveReference(ref).String(), nil
+}
+
+func truncateForErr(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
 }
 
 // downloadFromLibgenMirrors resolves and downloads one MD5 from each mirror.

--- a/internal/download/direct.go
+++ b/internal/download/direct.go
@@ -133,7 +133,7 @@ func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(
 func (d *DirectDownloader) downloadFromAnnasFast(md5, title string, progressFn func(string)) (string, int64, error) {
 	downloadURL, err := d.fetchAnnasFastDownloadURL(md5)
 	if err != nil {
-		return "", 0, err
+		return "", 0, redactSecret(err, d.cfg.AnnasArchiveSecretKey)
 	}
 	if progressFn != nil {
 		progressFn("Downloading via Anna's Archive fast download...")
@@ -221,6 +221,21 @@ func parseAnnasFastDownloadURL(apiURL string, body []byte) (string, error) {
 		return "", fmt.Errorf("annas fast download relative URL: %w", err)
 	}
 	return base.ResolveReference(ref).String(), nil
+}
+
+// redactSecret scrubs the account secret key from an error's text. A
+// network-level failure surfaces as *url.Error, whose message embeds the
+// full request URL — including the key query parameter — and the fast-path
+// failure is logged, so without this the key would leak into logs.
+func redactSecret(err error, secret string) error {
+	if err == nil || secret == "" {
+		return err
+	}
+	msg := err.Error()
+	for _, needle := range []string{url.QueryEscape(secret), secret} {
+		msg = strings.ReplaceAll(msg, needle, "REDACTED")
+	}
+	return errors.New(msg)
 }
 
 func truncateForErr(s string, max int) string {

--- a/internal/download/direct.go
+++ b/internal/download/direct.go
@@ -68,7 +68,7 @@ func (d *DirectDownloader) mirrors() []string {
 }
 
 // DownloadFromAnnas downloads a file from Anna's Archive.
-// When a membership/donator secret key is configured, tries the VIP
+// When an account secret key is configured, tries the membership
 // fast_download API first, then falls back to public LibGen mirrors.
 func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(string)) (string, int64, string, error) {
 	if strings.TrimSpace(d.cfg.AnnasArchiveSecretKey) != "" {
@@ -129,7 +129,7 @@ func (d *DirectDownloader) DownloadFromAnnas(md5, title string, progressFn func(
 	return "", 0, "", fmt.Errorf("all matching LibGen candidates exhausted: %w", lastErr)
 }
 
-// downloadFromAnnasFast resolves VIP fast_download.json and downloads the file.
+// downloadFromAnnasFast resolves membership fast_download.json and downloads the file.
 func (d *DirectDownloader) downloadFromAnnasFast(md5, title string, progressFn func(string)) (string, int64, error) {
 	downloadURL, err := d.fetchAnnasFastDownloadURL(md5)
 	if err != nil {
@@ -142,7 +142,7 @@ func (d *DirectDownloader) downloadFromAnnasFast(md5, title string, progressFn f
 	return d.downloadFile(downloadURL, title, progressFn)
 }
 
-// fetchAnnasFastDownloadURL calls AA membership fast_download API for one MD5.
+// fetchAnnasFastDownloadURL calls AA fast_download API for one MD5 using the account secret key.
 func (d *DirectDownloader) fetchAnnasFastDownloadURL(md5 string) (string, error) {
 	domain := strings.TrimSpace(d.cfg.AnnasArchiveDomain)
 	key := strings.TrimSpace(d.cfg.AnnasArchiveSecretKey)

--- a/web/index.html
+++ b/web/index.html
@@ -328,6 +328,25 @@
         </div>
         <div class="space-y-4">
 
+          <!-- Anna's Archive -->
+          <div class="bg-slate-800/40 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <h4 class="text-sm font-medium text-slate-200">Anna's Archive</h4>
+              <button data-action="saveIntegration" data-arg="annas" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
+            </div>
+            <p class="text-xs text-slate-500 mb-3">Membership secret key enables VIP fast downloads via <code class="text-slate-400">/dyn/api/fast_download.json</code>. Without it, Librarr uses public LibGen mirrors.</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Domain</label>
+                <input type="text" id="setting-annas_archive_domain" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="annas-archive.gl">
+              </div>
+              <div>
+                <label class="block text-xs text-slate-500 mb-1">Secret key (donator / VIP)</label>
+                <input type="password" id="setting-annas_archive_secret_key" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
+              </div>
+            </div>
+          </div>
+
           <!-- Prowlarr -->
           <div class="bg-slate-800/40 rounded-lg p-4">
             <div class="flex items-center justify-between mb-3">

--- a/web/index.html
+++ b/web/index.html
@@ -334,14 +334,14 @@
               <h4 class="text-sm font-medium text-slate-200">Anna's Archive</h4>
               <button data-action="saveIntegration" data-arg="annas" class="px-3 py-1.5 text-xs bg-indigo-600 hover:bg-indigo-500 text-white rounded-md transition-colors">Save</button>
             </div>
-            <p class="text-xs text-slate-500 mb-3">Membership secret key enables VIP fast downloads via <code class="text-slate-400">/dyn/api/fast_download.json</code>. Without it, Librarr uses public LibGen mirrors.</p>
+            <p class="text-xs text-slate-500 mb-3">Your Anna's Archive account <strong class="font-medium text-slate-400">secret key</strong> (login key; also called a donator key in some tools) enables membership fast downloads via <code class="text-slate-400">/dyn/api/fast_download.json</code>. Without it, Librarr uses public LibGen mirrors. Fast downloads also require an active membership on that account.</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
               <div>
                 <label class="block text-xs text-slate-500 mb-1">Domain</label>
                 <input type="text" id="setting-annas_archive_domain" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="annas-archive.gl">
               </div>
               <div>
-                <label class="block text-xs text-slate-500 mb-1">Secret key (donator / VIP)</label>
+                <label class="block text-xs text-slate-500 mb-1">Secret key</label>
                 <input type="password" id="setting-annas_archive_secret_key" autocomplete="off" data-1p-ignore data-lpignore="true" class="w-full bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 placeholder-slate-600" placeholder="">
               </div>
             </div>

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2034,6 +2034,7 @@ document.getElementById('change-password-form')?.addEventListener('submit', asyn
 // Settings keys backed by an input in the Integrations section, grouped by the
 // integration name passed to saveIntegration().
 const INTEGRATION_FIELDS = {
+  annas:          ['annas_archive_domain', 'annas_archive_secret_key'],
   prowlarr:       ['prowlarr_url', 'prowlarr_api_key'],
   qbittorrent:    ['qb_url', 'qb_user', 'qb_pass'],
   transmission:   ['transmission_url', 'transmission_user', 'transmission_pass', 'torrent_client'],


### PR DESCRIPTION
## Summary

- Prefer Anna's Archive membership fast downloads when an account **secret key** is configured: `GET /dyn/api/fast_download.json?md5=…&key=…`
- Fall back to the existing public LibGen mirror path on VIP/API failure, missing membership, or no key
- Config: `ANNAS_ARCHIVE_SECRET_KEY` (env alias `AA_DONATOR_KEY` still accepted for tools that use that name)
- Settings UI: Integrations → Anna's Archive (domain + secret key); key is masked on GET and applied at runtime on save
- Docs: README + `.env.example`

## Motivation

Librarr already searches Anna's Archive and downloads via LibGen mirrors, but never used the account secret key from the AA login page. That key (sometimes called a "donator key" elsewhere) authenticates the official membership fast-download API when the account has an active membership. This wires that path in while keeping LibGen as a reliable fallback.

## Test plan

- [x] `go test ./internal/download/ ./internal/config/`
- [x] Unit coverage: parse absolute/relative `download_url`; fast path skips LibGen; fast-path error falls back to LibGen
- [ ] Manual: set secret key + active membership, download a single-file AA hit, confirm fast-download progress/log
- [ ] Manual: expired/inactive membership or bad key 