### PR TITLE
Fix remote qBittorrent downloads and idempotent imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ which requires Transmission 3.0+).
 | `QB_URL` | | qBittorrent Web UI URL |
 | `QB_USER` | `admin` | qBittorrent username |
 | `QB_PASS` | | qBittorrent password |
-| `QB_SAVE_PATH` | `/downloads` | Ebook download path (inside qBit container) |
+| `QB_SAVE_PATH` | `/downloads` | Ebook download path as seen by qBittorrent (the remote/client-side path) |
 | `QB_CATEGORY` | `librarr` | Torrent category for ebooks |
 | `QB_AUDIOBOOK_SAVE_PATH` | `/audiobooks-incoming` | Audiobook download path |
 | `QB_AUDIOBOOK_CATEGORY` | `audiobooks` | Torrent category for audiobooks |
@@ -288,7 +288,7 @@ which requires Transmission 3.0+).
 | `EBOOK_DIR` | `/books/ebooks` | Organized ebook destination |
 | `AUDIOBOOK_DIR` | `/books/audiobooks` | Organized audiobook destination |
 | `MANGA_DIR` | `/books/manga` | Organized manga destination |
-| `INCOMING_DIR` | `/data/incoming` | Incoming file staging directory |
+| `INCOMING_DIR` | `/data/incoming` | Incoming file staging directory as seen by Librarr; qBittorrent paths beneath `QB_SAVE_PATH` are translated here before import |
 | `MANGA_INCOMING_DIR` | `/data/manga-incoming` | Manga incoming staging directory |
 
 ### Sources Registry

--- a/cmd/librarr/main.go
+++ b/cmd/librarr/main.go
@@ -110,6 +110,14 @@ func main() {
 		},
 	})
 	organizer := organize.NewOrganizer(cfg)
+	if updated, err := database.BackfillLibraryMetadata(func(path string) (string, string) {
+		meta := organize.ExtractEbookMetadata(path)
+		return meta.Title, meta.Author
+	}); err != nil {
+		slog.Warn("ebook metadata backfill failed", "error", err)
+	} else if updated > 0 {
+		slog.Info("ebook metadata backfill complete", "updated", updated)
+	}
 	targets := organize.NewLibraryTargets(cfg)
 	downloadMgr := download.NewManager(cfg, database, torrentClient, sab, directDL, organizer, targets, health)
 

--- a/docs/library-duplicate-report.md
+++ b/docs/library-duplicate-report.md
@@ -1,0 +1,69 @@
+# Library duplicate report
+
+These commands are read-only. Run them against a copy or the live database
+after stopping nothing and without opening it for writes:
+
+```sh
+DB=/opt/docker/data/librarr/librarr.db
+
+# Rows pointing at the same normalized destination path.
+sqlite3 -header -column "$DB" <<'SQL'
+SELECT lower(replace(replace(trim(file_path), char(92), '/'), '//', '/')) AS normalized_path,
+       COUNT(*) AS count,
+       group_concat(id) AS ids,
+       group_concat(title, ' | ') AS titles
+FROM library_items
+GROUP BY normalized_path
+HAVING COUNT(*) > 1
+ORDER BY count DESC;
+SQL
+
+# Same torrent/source identifier. This is diagnostic only: one torrent may
+# legitimately contain multiple files and must not be deduplicated by source_id alone.
+sqlite3 -header -column "$DB" <<'SQL'
+SELECT source_id, COUNT(*) AS count, group_concat(id) AS ids,
+       group_concat(title, ' | ') AS titles
+FROM library_items
+WHERE source_id <> ''
+GROUP BY source_id
+HAVING COUNT(*) > 1
+ORDER BY count DESC;
+SQL
+
+# After the content_hash migration is present, identify repeated content by
+# media type and format. EPUB and MOBI remain separate groups.
+sqlite3 -header -column "$DB" <<'SQL'
+SELECT content_hash, media_type, file_format, COUNT(*) AS count,
+       group_concat(id) AS ids, group_concat(file_path, ' | ') AS paths
+FROM library_items
+WHERE content_hash <> ''
+GROUP BY content_hash, media_type, file_format
+HAVING COUNT(*) > 1
+ORDER BY count DESC;
+SQL
+```
+
+Same title/author/format is only a review group; it is not proof of a
+duplicate file:
+
+```sh
+sqlite3 -header -column "$DB" <<'SQL'
+SELECT lower(trim(title)) AS title, lower(trim(author)) AS author,
+       media_type, lower(trim(file_format)) AS format,
+       COUNT(*) AS count, group_concat(id) AS ids
+FROM library_items
+GROUP BY title, author, media_type, format
+HAVING COUNT(*) > 1
+ORDER BY count DESC;
+SQL
+```
+
+For files not yet represented by `content_hash`, a read-only filesystem scan
+can be compared with the database paths:
+
+```sh
+find /mnt/media/books/ebooks -type f -print0 | xargs -0 sha256sum | sort
+```
+
+Do not delete or merge rows automatically. Review exact path/content matches
+separately from same-title or same-source groups.

--- a/internal/api/csv.go
+++ b/internal/api/csv.go
@@ -133,7 +133,7 @@ func (s *Server) handleCSVImport(w http.ResponseWriter, r *http.Request) {
 				if url == "" {
 					url = "magnet:?xt=urn:btih:" + best.InfoHash
 				}
-				s.downloadMgr.StartTorrentDownload(url, title, "", "")
+				s.downloadMgr.StartTorrentDownload(url, title, "", "", best.InfoHash)
 			} else {
 				slog.Warn("CSV import: no downloadable result", "title", title)
 			}

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/JeremiahM37/librarr/internal/download"
 	"github.com/JeremiahM37/librarr/internal/models"
 	"github.com/JeremiahM37/librarr/internal/netutil"
 	"github.com/JeremiahM37/librarr/internal/search"
@@ -119,7 +121,17 @@ func (s *Server) handleTorrentDownload(w http.ResponseWriter, r *http.Request, r
 		category = s.cfg.QBMangaCategory
 	}
 
-	err = s.downloadMgr.StartTorrentDownload(url, req.Title, savePath, category)
+	err = s.downloadMgr.StartTorrentDownload(url, req.Title, savePath, category, req.InfoHash)
+	var verificationWarning *download.TorrentVerificationWarning
+	if errors.As(err, &verificationWarning) {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"success": true,
+			"title":   req.Title,
+			"error":   "",
+			"warning": errString(err),
+		})
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"success": err == nil,
 		"title":   req.Title,
@@ -416,7 +428,7 @@ func errString(err error) string {
 	if err == nil {
 		return ""
 	}
-	return "Download failed"
+	return netutil.SanitizeSensitiveText(err.Error())
 }
 
 // isNZBResult checks if a download request should be routed to SABnzbd.

--- a/internal/api/download_warning_test.go
+++ b/internal/api/download_warning_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/download"
+	"github.com/JeremiahM37/librarr/internal/models"
+	"github.com/JeremiahM37/librarr/internal/search"
+)
+
+type downloadWarningTorrentClient struct {
+	err error
+}
+
+func (c downloadWarningTorrentClient) AddTorrent(string, string, string, string, string) error {
+	return c.err
+}
+
+func (downloadWarningTorrentClient) GetTorrents(string) ([]download.TorrentInfo, error) {
+	return nil, nil
+}
+
+func (downloadWarningTorrentClient) GetTorrentFiles(string) ([]download.TorrentFile, error) {
+	return nil, nil
+}
+
+func (downloadWarningTorrentClient) DeleteTorrent(string, bool) error { return nil }
+
+func (downloadWarningTorrentClient) Diagnose() map[string]interface{} { return nil }
+
+func (downloadWarningTorrentClient) Name() string { return "test" }
+
+func newDownloadWarningTestServer(t *testing.T, client download.TorrentClient) *Server {
+	t.Helper()
+	database, err := db.New(filepath.Join(t.TempDir(), "library.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	cfg := &config.Config{QBUrl: "http://qbit.test"}
+	manager := download.NewManager(cfg, database, client, nil, nil, nil, nil, search.NewHealthTracker(3, 300))
+	return &Server{cfg: cfg, db: database, downloadMgr: manager}
+}
+
+func TestHandleTorrentDownloadReturnsWarningAsAccepted(t *testing.T) {
+	warning := &download.TorrentVerificationWarning{Err: errors.New("verification timeout")}
+	server := newDownloadWarningTestServer(t, downloadWarningTorrentClient{err: warning})
+	req := models.DownloadRequest{Title: "Test Book", Source: "torrent", DownloadURL: "magnet:?xt=urn:btih:abc"}
+	r := httptest.NewRequest("POST", "/api/download", nil)
+	rr := httptest.NewRecorder()
+
+	server.handleTorrentDownload(rr, r, req)
+	var response map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["success"] != true {
+		t.Fatalf("success = %v, want true: %s", response["success"], rr.Body.String())
+	}
+	if response["warning"] == "" || response["error"] != "" {
+		t.Fatalf("response = %s, want warning and empty error", rr.Body.String())
+	}
+}
+
+func TestHandleTorrentDownloadKeepsQBitFailureAsFailure(t *testing.T) {
+	server := newDownloadWarningTestServer(t, downloadWarningTorrentClient{err: errors.New("qBittorrent API failure")})
+	req := models.DownloadRequest{Title: "Test Book", Source: "torrent", DownloadURL: "magnet:?xt=urn:btih:abc"}
+	r := httptest.NewRequest("POST", "/api/download", nil)
+	rr := httptest.NewRecorder()
+
+	server.handleTorrentDownload(rr, r, req)
+	var response map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["success"] != false || response["error"] != "qBittorrent API failure" {
+		t.Fatalf("response = %s, want hard failure", rr.Body.String())
+	}
+}

--- a/internal/api/requests.go
+++ b/internal/api/requests.go
@@ -5,12 +5,14 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/JeremiahM37/librarr/internal/download"
 	"github.com/JeremiahM37/librarr/internal/models"
 )
 
@@ -539,9 +541,14 @@ func (s *Server) processApprovedRequest(req *models.Request) {
 		}
 
 		savePath, category := s.resolveSavePathAndCategory(req.BookType)
-		if err := s.downloadMgr.StartTorrentDownload(url, chosen.Title, savePath, category); err != nil {
-			s.failRequest(req, fmt.Sprintf("Torrent download failed: %v", err))
-			return
+		if err := s.downloadMgr.StartTorrentDownload(url, chosen.Title, savePath, category, chosen.InfoHash); err != nil {
+			var verificationWarning *download.TorrentVerificationWarning
+			if errors.As(err, &verificationWarning) {
+				slog.Warn("torrent accepted; verification pending", "title", chosen.Title, "warning", err.Error())
+			} else {
+				s.failRequest(req, fmt.Sprintf("Torrent download failed: %v", err))
+				return
+			}
 		}
 		req.Status = "processing"
 		req.UpdatedAt = time.Now()

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	_ "modernc.org/sqlite"
@@ -61,6 +62,7 @@ func (d *DB) migrate() error {
 			source TEXT NOT NULL DEFAULT '',
 			source_id TEXT NOT NULL DEFAULT '',
 			metadata TEXT NOT NULL DEFAULT '{}',
+			content_hash TEXT NOT NULL DEFAULT '',
 			added_at REAL NOT NULL DEFAULT (strftime('%s','now'))
 		)`,
 		`CREATE TABLE IF NOT EXISTS activity_log (
@@ -295,13 +297,22 @@ func (d *DB) migrate() error {
 	// fails. Duplicate-column errors are expected on already-upgraded DBs
 	// and are ignored.
 	addColumns := []string{
+		`ALTER TABLE library_items ADD COLUMN content_hash TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE download_jobs ADD COLUMN status_history TEXT NOT NULL DEFAULT '[]'`,
 		`ALTER TABLE download_jobs ADD COLUMN source_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE activity_log ADD COLUMN user TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE reading_history ADD COLUMN status TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range addColumns {
-		d.db.Exec(stmt)
+		if _, err := d.db.Exec(stmt); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
+			return fmt.Errorf("additive migration failed: %w\nSQL: %s", err, stmt)
+		}
+	}
+	if _, err := d.db.Exec(`CREATE INDEX IF NOT EXISTS idx_library_items_content_hash ON library_items(content_hash)`); err != nil {
+		return fmt.Errorf("create library content hash index: %w", err)
+	}
+	if err := d.backfillLibraryContentHashes(); err != nil {
+		return fmt.Errorf("backfill library content hashes: %w", err)
 	}
 
 	return nil

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -153,6 +154,144 @@ func TestLibraryItems_CRUD(t *testing.T) {
 			t.Error("expected error deleting nonexistent item")
 		}
 	})
+}
+
+func TestAddItemIsIdempotentByEquivalentPathAndContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "book.epub")
+	if err := os.WriteFile(path, []byte("ebook bytes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	d := newTestDB(t)
+
+	first := &models.LibraryItem{Title: "First title", Author: "First author", FilePath: path, FileFormat: "epub", MediaType: "ebook"}
+	firstOutcome, err := d.AddItemWithOutcome(first)
+	if err != nil || !firstOutcome.Inserted {
+		t.Fatalf("first AddItemWithOutcome = %+v, %v", firstOutcome, err)
+	}
+
+	equivalentPath := filepath.Join(dir, "nested", "..", "book.epub")
+	second := &models.LibraryItem{Title: "Different metadata", Author: "Different author", FilePath: equivalentPath, FileFormat: "epub", MediaType: "ebook"}
+	secondOutcome, err := d.AddItemWithOutcome(second)
+	if err != nil {
+		t.Fatalf("second AddItemWithOutcome: %v", err)
+	}
+	if secondOutcome.Inserted || secondOutcome.ID != firstOutcome.ID || secondOutcome.Reason != "duplicate_destination_path" {
+		t.Fatalf("second outcome = %+v, want reuse of first row", secondOutcome)
+	}
+
+	items, err := d.GetItems("ebook", 10, 0)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("GetItems = %d, %v; want one row", len(items), err)
+	}
+}
+
+func TestAddItemRemainsIdempotentAfterDatabaseReopen(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "library.db")
+	filePath := filepath.Join(dir, "book.epub")
+	if err := os.WriteFile(filePath, []byte("persistent ebook"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := New(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID, err := d.AddItem(&models.LibraryItem{FilePath: filePath, FileFormat: "epub", MediaType: "ebook"})
+	if err != nil {
+		d.Close()
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err = New(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	secondID, err := d.AddItem(&models.LibraryItem{FilePath: filePath, FileFormat: "epub", MediaType: "ebook"})
+	if err != nil || secondID != firstID {
+		t.Fatalf("reopened AddItem = id %d, err %v; want existing id %d", secondID, err, firstID)
+	}
+}
+
+func TestAddItemDoesNotMergeDifferentFormatsOrFilesByMetadata(t *testing.T) {
+	d := newTestDB(t)
+	dir := t.TempDir()
+	epubPath := filepath.Join(dir, "book.epub")
+	mobiPath := filepath.Join(dir, "book.mobi")
+	otherPath := filepath.Join(dir, "other.epub")
+	for path, body := range map[string]string{epubPath: "same bytes", mobiPath: "same bytes", otherPath: "other epub bytes"} {
+		if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	items := []*models.LibraryItem{
+		{Title: "Same Book", Author: "Same Author", FilePath: epubPath, FileFormat: "epub", MediaType: "ebook"},
+		{Title: "Same Book", Author: "Same Author", FilePath: mobiPath, FileFormat: "mobi", MediaType: "ebook"},
+		{Title: "Same Book", Author: "Same Author", FilePath: otherPath, FileFormat: "epub", MediaType: "ebook"},
+	}
+	ids := make(map[int64]bool)
+	for _, item := range items {
+		id, err := d.AddItem(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids[id] = true
+	}
+	if len(ids) != len(items) {
+		t.Fatalf("metadata-similar files produced %d IDs, want %d", len(ids), len(items))
+	}
+}
+
+func TestAddItemConcurrentDuplicateImportsCreateOneRow(t *testing.T) {
+	d := newTestDB(t)
+	filePath := filepath.Join(t.TempDir(), "book.epub")
+	if err := os.WriteFile(filePath, []byte("concurrent ebook"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	const attempts = 8
+	ids := make(chan int64, attempts)
+	errs := make(chan error, attempts)
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id, err := d.AddItem(&models.LibraryItem{FilePath: filePath, FileFormat: "epub", MediaType: "ebook"})
+			ids <- id
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(ids)
+	close(errs)
+
+	var wantID int64
+	for id := range ids {
+		if id == 0 {
+			t.Fatal("concurrent AddItem returned zero ID")
+		}
+		if wantID == 0 {
+			wantID = id
+		} else if id != wantID {
+			t.Fatalf("concurrent AddItem IDs differ: got %d and %d", id, wantID)
+		}
+	}
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent AddItem error: %v", err)
+		}
+	}
+	count, err := d.CountItems("ebook")
+	if err != nil || count != 1 {
+		t.Fatalf("CountItems = %d, %v; want one row", count, err)
+	}
 }
 
 func TestDownloadJobs_CRUD(t *testing.T) {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -156,6 +156,69 @@ func TestLibraryItems_CRUD(t *testing.T) {
 	})
 }
 
+func TestBackfillLibraryMetadata(t *testing.T) {
+	dir := t.TempDir()
+	database, err := New(filepath.Join(dir, "library.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	metadataFile := filepath.Join(dir, "library", "Torrent Name", "book.epub")
+	if err := os.MkdirAll(filepath.Dir(metadataFile), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(metadataFile, []byte("ebook"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	missingFile := filepath.Join(dir, "library", "Missing", "book.epub")
+	userEditedFile := filepath.Join(dir, "library", "Torrent Name", "edited.epub")
+	if err := os.WriteFile(userEditedFile, []byte("edited"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, item := range []*models.LibraryItem{
+		{Title: "Torrent Name", Author: "", FilePath: metadataFile, OriginalPath: "/incoming/Torrent Name/book.epub", MediaType: "ebook"},
+		{Title: "Missing", Author: "", FilePath: missingFile, OriginalPath: "/incoming/Missing/book.epub", MediaType: "ebook"},
+		{Title: "User Edited", Author: "Someone", FilePath: userEditedFile, OriginalPath: "/incoming/Torrent Name/edited.epub", MediaType: "ebook"},
+	} {
+		if _, err := database.AddItem(item); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	updated, err := database.BackfillLibraryMetadata(func(path string) (string, string) {
+		if path == metadataFile {
+			return "The Guardian's Path", "Jane Doe"
+		}
+		return "", ""
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != 1 {
+		t.Fatalf("BackfillLibraryMetadata updated %d rows, want 1", updated)
+	}
+
+	items, err := database.GetItems("ebook", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPath := make(map[string]models.LibraryItem)
+	for _, item := range items {
+		byPath[item.FilePath] = item
+	}
+	if got := byPath[metadataFile]; got.Title != "The Guardian's Path" || got.Author != "Jane Doe" || got.FileFormat != "epub" {
+		t.Fatalf("metadata row = %+v, want corrected metadata and format", got)
+	}
+	if got := byPath[userEditedFile]; got.Title != "User Edited" || got.Author != "Someone" {
+		t.Fatalf("user-edited row changed: %+v", got)
+	}
+	if got := byPath[missingFile]; got.Title != "Missing" {
+		t.Fatalf("missing-file row changed: %+v", got)
+	}
+}
+
 func TestAddItemIsIdempotentByEquivalentPathAndContent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "book.epub")

--- a/internal/db/library.go
+++ b/internal/db/library.go
@@ -1,9 +1,15 @@
 package db
 
 import (
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/JeremiahM37/librarr/internal/models"
@@ -11,10 +17,62 @@ import (
 
 // --- Library Items ---
 
+const libraryItemColumns = `id, title, author, file_path, original_path, file_size,
+	file_format, media_type, source, source_id, metadata, content_hash, added_at`
+
+// AddItemOutcome describes whether AddItem inserted a new row or reused an
+// existing file-level identity.
+type AddItemOutcome struct {
+	ID             int64
+	Inserted       bool
+	Reason         string
+	ContentHash    string
+	NormalizedPath string
+	ExistingID     int64
+}
+
 // AddItem records a successfully processed book.
 func (d *DB) AddItem(item *models.LibraryItem) (int64, error) {
+	outcome, err := d.AddItemWithOutcome(item)
+	return outcome.ID, err
+}
+
+// AddItemWithOutcome inserts a library item idempotently. Exact canonical
+// destination paths are always unique. Content hashes are also unique within
+// the same media type and file format, which prevents a moved or re-imported
+// file from creating a second row without merging EPUB and MOBI records.
+// The DB mutex serializes the identity check and insert, so concurrent imports
+// within Librarr cannot race between those operations.
+func (d *DB) AddItemWithOutcome(item *models.LibraryItem) (AddItemOutcome, error) {
+	if item == nil {
+		return AddItemOutcome{}, fmt.Errorf("library item is nil")
+	}
+
+	normalizedPath := NormalizeLibraryPath(item.FilePath)
+	contentHash := strings.ToLower(strings.TrimSpace(item.ContentHash))
+	if contentHash == "" {
+		contentHash = hashLibraryFile(item.FilePath)
+	}
+	item.ContentHash = contentHash
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
+	existing, err := d.findDuplicateLibraryItemLocked(item, normalizedPath, contentHash)
+	if err != nil {
+		return AddItemOutcome{}, err
+	}
+	if existing.ID != 0 {
+		slog.Info("library import skipped", "reason", existing.Reason, "existing_record_id", existing.ID, "destination_path", item.FilePath, "content_hash", contentHash)
+		return AddItemOutcome{
+			ID:             existing.ID,
+			Inserted:       false,
+			Reason:         existing.Reason,
+			ContentHash:    contentHash,
+			NormalizedPath: normalizedPath,
+			ExistingID:     existing.ID,
+		}, nil
+	}
 
 	metadata := item.Metadata
 	if metadata == "" {
@@ -22,16 +80,146 @@ func (d *DB) AddItem(item *models.LibraryItem) (int64, error) {
 	}
 
 	result, err := d.db.Exec(
-		`INSERT INTO library_items (title, author, file_path, original_path, file_size, file_format, media_type, source, source_id, metadata)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO library_items (title, author, file_path, original_path, file_size, file_format, media_type, source, source_id, metadata, content_hash)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		item.Title, item.Author, item.FilePath, item.OriginalPath,
 		item.FileSize, item.FileFormat, item.MediaType,
-		item.Source, item.SourceID, metadata,
+		item.Source, item.SourceID, metadata, contentHash,
 	)
 	if err != nil {
-		return 0, err
+		return AddItemOutcome{}, err
 	}
-	return result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return AddItemOutcome{}, err
+	}
+	return AddItemOutcome{
+		ID:             id,
+		Inserted:       true,
+		Reason:         "new_library_item",
+		ContentHash:    contentHash,
+		NormalizedPath: normalizedPath,
+	}, nil
+}
+
+type duplicateLibraryItem struct {
+	ID     int64
+	Reason string
+}
+
+func (d *DB) findDuplicateLibraryItemLocked(item *models.LibraryItem, normalizedPath, contentHash string) (duplicateLibraryItem, error) {
+	rows, err := d.db.Query("SELECT id, file_path, content_hash, file_format, media_type FROM library_items")
+	if err != nil {
+		return duplicateLibraryItem{}, err
+	}
+	defer rows.Close()
+
+	candidateFormat := effectiveLibraryFormat(item.FileFormat, item.FilePath)
+	for rows.Next() {
+		var id int64
+		var filePath, existingHash, fileFormat, mediaType string
+		if err := rows.Scan(&id, &filePath, &existingHash, &fileFormat, &mediaType); err != nil {
+			return duplicateLibraryItem{}, err
+		}
+		if normalizedPath != "" && normalizedPath == NormalizeLibraryPath(filePath) {
+			return duplicateLibraryItem{ID: id, Reason: "duplicate_destination_path"}, nil
+		}
+
+		if contentHash == "" || mediaType != item.MediaType {
+			continue
+		}
+		if existingHash == "" {
+			existingHash = hashLibraryFile(filePath)
+		}
+		if existingHash == contentHash && effectiveLibraryFormat(fileFormat, filePath) == candidateFormat {
+			return duplicateLibraryItem{ID: id, Reason: "duplicate_content_hash"}, nil
+		}
+	}
+	return duplicateLibraryItem{}, rows.Err()
+}
+
+// NormalizeLibraryPath returns a stable absolute path for identity checks.
+// Symlinks are resolved when the target exists; case is intentionally not
+// folded because Linux library filesystems are case-sensitive.
+func NormalizeLibraryPath(filePath string) string {
+	filePath = strings.TrimSpace(filePath)
+	if filePath == "" {
+		return ""
+	}
+	cleaned, err := filepath.Abs(filepath.Clean(filePath))
+	if err != nil {
+		cleaned = filepath.Clean(filePath)
+	}
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(cleaned)
+}
+
+func hashLibraryFile(filePath string) string {
+	if filePath == "" {
+		return ""
+	}
+	info, err := os.Stat(filePath)
+	if err != nil || !info.Mode().IsRegular() {
+		return ""
+	}
+	f, err := os.Open(filePath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func (d *DB) backfillLibraryContentHashes() error {
+	rows, err := d.db.Query("SELECT id, file_path, content_hash FROM library_items WHERE content_hash = ''")
+	if err != nil {
+		return err
+	}
+
+	type libraryFile struct {
+		id   int64
+		path string
+	}
+	var files []libraryFile
+	for rows.Next() {
+		var file libraryFile
+		var contentHash string
+		if err := rows.Scan(&file.id, &file.path, &contentHash); err != nil {
+			return err
+		}
+		files = append(files, file)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		hash := hashLibraryFile(file.path)
+		if hash == "" {
+			continue
+		}
+		if _, err := d.db.Exec("UPDATE library_items SET content_hash = ? WHERE id = ? AND content_hash = ''", hash, file.id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func effectiveLibraryFormat(fileFormat, filePath string) string {
+	if format := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(fileFormat)), "."); format != "" {
+		return format
+	}
+	return strings.TrimPrefix(strings.ToLower(filepath.Ext(filePath)), ".")
 }
 
 // HasSourceID checks if a source_id already exists.
@@ -48,7 +236,7 @@ func (d *DB) HasSourceID(sourceID string) bool {
 
 // FindByTitle performs a case-insensitive title lookup.
 func (d *DB) FindByTitle(title string) ([]models.LibraryItem, error) {
-	rows, err := d.db.Query("SELECT * FROM library_items WHERE title = ? COLLATE NOCASE", title)
+	rows, err := d.db.Query("SELECT "+libraryItemColumns+" FROM library_items WHERE title = ? COLLATE NOCASE", title)
 	if err != nil {
 		return nil, err
 	}
@@ -62,12 +250,12 @@ func (d *DB) GetItems(mediaType string, limit, offset int) ([]models.LibraryItem
 	var err error
 	if mediaType != "" {
 		rows, err = d.db.Query(
-			"SELECT * FROM library_items WHERE media_type = ? ORDER BY added_at DESC LIMIT ? OFFSET ?",
+			"SELECT "+libraryItemColumns+" FROM library_items WHERE media_type = ? ORDER BY added_at DESC LIMIT ? OFFSET ?",
 			mediaType, limit, offset,
 		)
 	} else {
 		rows, err = d.db.Query(
-			"SELECT * FROM library_items ORDER BY added_at DESC LIMIT ? OFFSET ?",
+			"SELECT "+libraryItemColumns+" FROM library_items ORDER BY added_at DESC LIMIT ? OFFSET ?",
 			limit, offset,
 		)
 	}
@@ -140,9 +328,9 @@ func scanLibraryItems(rows *sql.Rows) ([]models.LibraryItem, error) {
 			&item.ID, &item.Title, &item.Author, &item.FilePath,
 			&item.OriginalPath, &item.FileSize, &item.FileFormat,
 			&item.MediaType, &item.Source, &item.SourceID,
-			&metadataStr, &ts,
+			&metadataStr, &item.ContentHash, &ts,
 		); err != nil {
-			continue
+			return nil, err
 		}
 		item.AddedAt = time.Unix(int64(ts), 0)
 		item.Metadata = metadataStr

--- a/internal/db/library.go
+++ b/internal/db/library.go
@@ -215,6 +215,88 @@ func (d *DB) backfillLibraryContentHashes() error {
 	return nil
 }
 
+// BackfillLibraryMetadata updates rows whose title still matches the
+// torrent-derived directory name. It deliberately leaves user-renamed rows
+// alone and skips files that are no longer present.
+func (d *DB) BackfillLibraryMetadata(extract func(string) (title, author string)) (int, error) {
+	if extract == nil {
+		return 0, fmt.Errorf("library metadata extractor is nil")
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	rows, err := d.db.Query(`SELECT id, title, author, file_path, original_path, file_format
+		FROM library_items WHERE media_type = 'ebook'`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	type candidate struct {
+		id                                                int64
+		title, author, filePath, originalPath, fileFormat string
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var item candidate
+		if err := rows.Scan(&item.id, &item.title, &item.author, &item.filePath, &item.originalPath, &item.fileFormat); err != nil {
+			return 0, err
+		}
+		if _, err := os.Stat(item.filePath); err != nil {
+			continue
+		}
+		if !matchesTorrentDerivedTitle(item.title, item.filePath, item.originalPath) {
+			continue
+		}
+		candidates = append(candidates, item)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+
+	updated := 0
+	for _, item := range candidates {
+		title, author := extract(item.filePath)
+		format := item.fileFormat
+		if format == "" {
+			format = effectiveLibraryFormat("", item.filePath)
+		}
+		if title == "" && author == "" && format == item.fileFormat {
+			continue
+		}
+		if title == "" {
+			title = item.title
+		}
+		if author == "" {
+			author = item.author
+		}
+		if _, err := d.db.Exec(`UPDATE library_items SET title = ?, author = ?, file_format = ? WHERE id = ?`, title, author, format, item.id); err != nil {
+			return updated, err
+		}
+		updated++
+	}
+	return updated, nil
+}
+
+func matchesTorrentDerivedTitle(title, filePath, originalPath string) bool {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return false
+	}
+	for _, path := range []string{filePath, originalPath} {
+		if path == "" {
+			continue
+		}
+		if strings.EqualFold(title, filepath.Base(filepath.Dir(path))) {
+			return true
+		}
+	}
+	return false
+}
+
 func effectiveLibraryFormat(fileFormat, filePath string) string {
 	if format := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(fileFormat)), "."); format != "" {
 		return format

--- a/internal/db/library.go
+++ b/internal/db/library.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/JeremiahM37/librarr/internal/models"
+	"github.com/JeremiahM37/librarr/internal/netutil"
 )
 
 // --- Library Items ---
@@ -63,7 +64,7 @@ func (d *DB) AddItemWithOutcome(item *models.LibraryItem) (AddItemOutcome, error
 		return AddItemOutcome{}, err
 	}
 	if existing.ID != 0 {
-		slog.Info("library import skipped", "reason", existing.Reason, "existing_record_id", existing.ID, "destination_path", item.FilePath, "content_hash", contentHash)
+		slog.Info("library import skipped", "reason", existing.Reason, "existing_record_id", existing.ID, "destination_path", netutil.SanitizeLogValue(item.FilePath), "content_hash", netutil.SanitizeLogValue(contentHash))
 		return AddItemOutcome{
 			ID:             existing.ID,
 			Inserted:       false,
@@ -157,7 +158,8 @@ func NormalizeLibraryPath(filePath string) string {
 }
 
 func hashLibraryFile(filePath string) string {
-	if filePath == "" {
+	filePath = filepath.Clean(strings.TrimSpace(filePath))
+	if filePath == "" || filePath == "." || strings.Contains(filePath, "..") {
 		return ""
 	}
 	info, err := os.Stat(filePath)

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -95,7 +95,7 @@ func (d *DB) GetItemTags(itemID int64) ([]Tag, error) {
 func (d *DB) GetItemsByTag(tagID int64, limit, offset int) ([]models.LibraryItem, error) {
 	rows, err := d.db.Query(
 		`SELECT li.id, li.title, li.author, li.file_path, li.original_path, li.file_size, li.file_format,
-		        li.media_type, li.source, li.source_id, li.metadata, li.added_at
+		        li.media_type, li.source, li.source_id, li.metadata, li.content_hash, li.added_at
 		 FROM library_items li JOIN item_tags it ON li.id = it.item_id
 		 WHERE it.tag_id = ? ORDER BY li.added_at DESC LIMIT ? OFFSET ?`,
 		tagID, limit, offset,

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -95,11 +95,11 @@ func (m *Manager) StartAnnasDownload(md5, title string) (*models.DownloadJob, er
 }
 
 // StartTorrentDownload adds a torrent to the active torrent client.
-func (m *Manager) StartTorrentDownload(torrentURL, title, savePath, category string) error {
+func (m *Manager) StartTorrentDownload(torrentURL, title, savePath, category, expectedInfoHash string) error {
 	if m.torrent == nil {
 		return fmt.Errorf("no torrent download client configured")
 	}
-	return m.torrent.AddTorrent(torrentURL, title, savePath, category)
+	return m.torrent.AddTorrent(torrentURL, title, savePath, category, expectedInfoHash)
 }
 
 // StartNZBDownload sends an NZB URL to SABnzbd.

--- a/internal/download/qbittorrent.go
+++ b/internal/download/qbittorrent.go
@@ -239,35 +239,37 @@ func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category, ex
 	}
 
 	expectedInfoHash = firstNonEmptyHash(expectedInfoHash, infoHashFromMagnet(torrentURL))
+	logTitle := netutil.SanitizeLogValue(title)
+	logCategory := netutil.SanitizeLogValue(category)
 	var ids []string
 	var err error
 	if isMagnetURL(torrentURL) {
-		slog.Info("submitting magnet to qBittorrent", "title", title, "category", category)
+		slog.Info("submitting magnet to qBittorrent", "title", logTitle, "category", logCategory)
 		ids, err = q.addTorrentURL(torrentURL, savePath, category)
 	} else if isHTTPURL(torrentURL) && q.isProwlarrTorrentURL(torrentURL) {
-		slog.Info("fetching torrent before qBittorrent upload", "title", title, "category", category)
+		slog.Info("fetching torrent before qBittorrent upload", "title", logTitle, "category", logCategory)
 		var fetched fetchedTorrent
 		fetched, err = q.fetchTorrent(torrentURL)
 		if err == nil {
 			if supplied := firstNonEmptyHash(expectedInfoHash); supplied != "" && supplied != fetched.infoHash {
-				slog.Warn("torrent info hash differs from search result", "title", title, "expected_hash", supplied, "fetched_hash", fetched.infoHash)
+				slog.Warn("torrent info hash differs from search result", "title", logTitle, "expected_hash", netutil.SanitizeLogValue(supplied), "fetched_hash", netutil.SanitizeLogValue(fetched.infoHash))
 			}
 			// The hash of the fetched bytes is authoritative for verification.
 			expectedInfoHash = fetched.infoHash
-			slog.Info("uploading torrent bytes to qBittorrent", "title", title, "category", category, "filename", fetched.filename, "bytes", len(fetched.body))
+			slog.Info("uploading torrent bytes to qBittorrent", "title", logTitle, "category", logCategory, "filename", netutil.SanitizeLogValue(fetched.filename), "bytes", len(fetched.body))
 			ids, err = q.addTorrentFile(fetched, savePath, category)
 		}
 	} else {
-		slog.Info("submitting torrent URL to qBittorrent", "title", title, "category", category)
+		slog.Info("submitting torrent URL to qBittorrent", "title", logTitle, "category", logCategory)
 		ids, err = q.addTorrentURL(torrentURL, savePath, category)
 	}
 	if err != nil {
-		slog.Warn("qBittorrent torrent submission failed", "title", title, "category", category, "error", netutil.SanitizeSensitiveText(err.Error()))
+		slog.Warn("qBittorrent torrent submission failed", "title", logTitle, "category", logCategory, "error", netutil.SanitizeSensitiveText(err.Error()))
 		return err
 	}
 
 	if err := q.verifyTorrentAdded(expectedInfoHash, ids, title, category); err != nil {
-		slog.Warn("qBittorrent torrent verification failed", "title", title, "category", category, "error", netutil.SanitizeSensitiveText(err.Error()))
+		slog.Warn("qBittorrent torrent verification failed", "title", logTitle, "category", logCategory, "error", netutil.SanitizeSensitiveText(err.Error()))
 		var timeoutErr torrentVerificationTimeoutError
 		if errors.As(err, &timeoutErr) {
 			return &TorrentVerificationWarning{Err: err}
@@ -275,7 +277,7 @@ func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category, ex
 		return err
 	}
 
-	slog.Info("torrent added to qBittorrent", "title", title, "category", category)
+	slog.Info("torrent added to qBittorrent", "title", logTitle, "category", logCategory)
 	return nil
 }
 
@@ -445,9 +447,17 @@ func (q *QBittorrentClient) fetchTorrent(rawURL string) (fetchedTorrent, error) 
 	if q.cfg == nil || q.cfg.ProwlarrURL == "" {
 		return fetchedTorrent{}, fmt.Errorf("Prowlarr URL is not configured")
 	}
-	if _, err := netutil.ValidateSameOriginHTTPURL(rawURL, q.cfg.ProwlarrURL); err != nil {
+	u, err := netutil.ValidateSameOriginHTTPURL(rawURL, q.cfg.ProwlarrURL)
+	if err != nil {
 		return fetchedTorrent{}, fmt.Errorf("torrent URL rejected: %w", err)
 	}
+	base, err := netutil.ValidateSameOriginHTTPURL(q.cfg.ProwlarrURL, q.cfg.ProwlarrURL)
+	if err != nil {
+		return fetchedTorrent{}, fmt.Errorf("configured Prowlarr URL invalid: %w", err)
+	}
+	// Build the request from the configured Prowlarr origin plus the validated
+	// path and query, so the fetched host and port always come from config.
+	requestURL := base.Scheme + "://" + base.Host + u.RequestURI()
 
 	client := &http.Client{
 		Timeout:   30 * time.Second,
@@ -465,7 +475,7 @@ func (q *QBittorrentClient) fetchTorrent(rawURL string) (fetchedTorrent, error) 
 		},
 	}
 
-	req, err := http.NewRequest("GET", rawURL, nil)
+	req, err := http.NewRequest("GET", requestURL, nil)
 	if err != nil {
 		return fetchedTorrent{}, fmt.Errorf("torrent URL request: %w", err)
 	}
@@ -791,7 +801,7 @@ func (q *QBittorrentClient) verifyTorrentAddedContext(ctx context.Context, expec
 				lastErr = err
 			}
 		} else {
-			slog.Debug("qBittorrent verification poll", "expected_hash", expected, "added_ids", addedIDs, "expected_category", category, "expected_title", title, "candidate_count", len(torrents))
+			slog.Debug("qBittorrent verification poll", "expected_hash", netutil.SanitizeLogValue(expected), "added_ids", netutil.SanitizeLogValue(strings.Join(addedIDs, ",")), "expected_category", netutil.SanitizeLogValue(category), "expected_title", netutil.SanitizeLogValue(title), "candidate_count", len(torrents))
 			if torrentListContains(torrents, expected, addedIDs, title, category) {
 				return nil
 			}
@@ -824,18 +834,18 @@ func torrentListContains(torrents []TorrentInfo, expectedInfoHash string, addedI
 	for _, t := range torrents {
 		hash := normalizeInfoHash(t.Hash)
 		if expectedInfoHash != "" && hash == expectedInfoHash {
-			slog.Debug("qBittorrent verification candidate accepted", "hash", hash, "name", t.Name, "category", t.Category, "save_path", t.SavePath, "reason", "matching info hash", "expected_category", expectedCategory)
+			slog.Debug("qBittorrent verification candidate accepted", "hash", netutil.SanitizeLogValue(hash), "name", netutil.SanitizeLogValue(t.Name), "category", netutil.SanitizeLogValue(t.Category), "save_path", netutil.SanitizeLogValue(t.SavePath), "reason", "matching info hash", "expected_category", netutil.SanitizeLogValue(expectedCategory))
 			return true
 		}
 		if added[hash] {
-			slog.Debug("qBittorrent verification candidate accepted", "hash", hash, "name", t.Name, "category", t.Category, "save_path", t.SavePath, "reason", "matching add response id", "expected_category", expectedCategory)
+			slog.Debug("qBittorrent verification candidate accepted", "hash", netutil.SanitizeLogValue(hash), "name", netutil.SanitizeLogValue(t.Name), "category", netutil.SanitizeLogValue(t.Category), "save_path", netutil.SanitizeLogValue(t.SavePath), "reason", "matching add response id", "expected_category", netutil.SanitizeLogValue(expectedCategory))
 			return true
 		}
 		if expectedInfoHash == "" && len(added) == 0 && title != "" && strings.EqualFold(strings.TrimSpace(t.Name), title) {
-			slog.Debug("qBittorrent verification candidate accepted", "hash", hash, "name", t.Name, "category", t.Category, "save_path", t.SavePath, "reason", "exact title fallback", "expected_category", expectedCategory)
+			slog.Debug("qBittorrent verification candidate accepted", "hash", netutil.SanitizeLogValue(hash), "name", netutil.SanitizeLogValue(t.Name), "category", netutil.SanitizeLogValue(t.Category), "save_path", netutil.SanitizeLogValue(t.SavePath), "reason", "exact title fallback", "expected_category", netutil.SanitizeLogValue(expectedCategory))
 			return true
 		}
-		slog.Debug("qBittorrent verification candidate rejected", "hash", hash, "name", t.Name, "category", t.Category, "save_path", t.SavePath, "reason", verificationRejectReason(expectedInfoHash, added, title), "expected_category", expectedCategory)
+		slog.Debug("qBittorrent verification candidate rejected", "hash", netutil.SanitizeLogValue(hash), "name", netutil.SanitizeLogValue(t.Name), "category", netutil.SanitizeLogValue(t.Category), "save_path", netutil.SanitizeLogValue(t.SavePath), "reason", verificationRejectReason(expectedInfoHash, added, title), "expected_category", netutil.SanitizeLogValue(expectedCategory))
 	}
 	return false
 }

--- a/internal/download/qbittorrent.go
+++ b/internal/download/qbittorrent.go
@@ -244,7 +244,7 @@ func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category, ex
 	if isMagnetURL(torrentURL) {
 		slog.Info("submitting magnet to qBittorrent", "title", title, "category", category)
 		ids, err = q.addTorrentURL(torrentURL, savePath, category)
-	} else if isHTTPURL(torrentURL) {
+	} else if isHTTPURL(torrentURL) && q.isProwlarrTorrentURL(torrentURL) {
 		slog.Info("fetching torrent before qBittorrent upload", "title", title, "category", category)
 		var fetched fetchedTorrent
 		fetched, err = q.fetchTorrent(torrentURL)
@@ -426,6 +426,19 @@ type fetchedTorrent struct {
 	filename string
 	body     []byte
 	infoHash string
+}
+
+// isProwlarrTorrentURL reports whether the URL belongs to the configured
+// Prowlarr origin. Only those URLs are fetched by Librarr and re-uploaded as
+// torrent bytes: a remote qBittorrent cannot reach a locally hosted Prowlarr,
+// but it can fetch public tracker URLs (e.g. Nyaa) itself, so those are passed
+// through unchanged and never receive the Prowlarr API key.
+func (q *QBittorrentClient) isProwlarrTorrentURL(rawURL string) bool {
+	if q.cfg == nil || q.cfg.ProwlarrURL == "" {
+		return false
+	}
+	_, err := netutil.ValidateSameOriginHTTPURL(rawURL, q.cfg.ProwlarrURL)
+	return err == nil
 }
 
 func (q *QBittorrentClient) fetchTorrent(rawURL string) (fetchedTorrent, error) {

--- a/internal/download/qbittorrent.go
+++ b/internal/download/qbittorrent.go
@@ -1,31 +1,61 @@
 package download
 
 import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/base32"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/netutil"
 )
 
 // QBittorrentClient wraps the qBittorrent Web API.
 type QBittorrentClient struct {
-	cfg           *config.Config
-	client        *http.Client
-	mu            sync.Mutex
-	authenticated bool
-	cookies       []*http.Cookie
-	banUntil      time.Time
-	nextLogin     time.Time
-	backoffSec    int
-	lastError     string
+	cfg            *config.Config
+	client         *http.Client
+	mu             sync.Mutex
+	authenticated  bool
+	cookies        []*http.Cookie
+	banUntil       time.Time
+	nextLogin      time.Time
+	backoffSec     int
+	lastError      string
+	verifyTimeout  time.Duration
+	verifyInterval time.Duration
+}
+
+// TorrentVerificationWarning indicates that qBittorrent accepted the add
+// request but the torrent was not visible before the verification deadline.
+// The submission remains accepted; callers may surface this as a warning.
+type TorrentVerificationWarning struct {
+	Err error
+}
+
+func (e *TorrentVerificationWarning) Error() string {
+	return fmt.Sprintf("torrent accepted but verification incomplete: %v", e.Err)
+}
+
+func (e *TorrentVerificationWarning) Unwrap() error { return e.Err }
+
+type torrentVerificationTimeoutError struct{}
+
+func (torrentVerificationTimeoutError) Error() string {
+	return "timed out waiting for torrent to appear in qBittorrent"
 }
 
 // Name identifies this client in logs and the TorrentClient interface.
@@ -42,7 +72,9 @@ func NewQBittorrentClient(cfg *config.Config) *QBittorrentClient {
 				return http.ErrUseLastResponse
 			},
 		},
-		backoffSec: 3,
+		backoffSec:     3,
+		verifyTimeout:  25 * time.Second,
+		verifyInterval: 250 * time.Millisecond,
 	}
 }
 
@@ -75,7 +107,11 @@ func (q *QBittorrentClient) login() error {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		q.scheduleBackoff()
+		return fmt.Errorf("read qBittorrent login response: %w", err)
+	}
 	bodyStr := string(body)
 
 	if strings.Contains(strings.ToLower(bodyStr), "banned") {
@@ -134,6 +170,13 @@ func (q *QBittorrentClient) ensureAuth() error {
 }
 
 func (q *QBittorrentClient) doRequest(method, path string, data url.Values) (*http.Response, error) {
+	return q.doRequestContext(context.Background(), method, path, data)
+}
+
+func (q *QBittorrentClient) doRequestContext(ctx context.Context, method, path string, data url.Values) (*http.Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -161,6 +204,7 @@ func (q *QBittorrentClient) doRequest(method, path string, data url.Values) (*ht
 				req.URL.RawQuery = data.Encode()
 			}
 		}
+		req = req.WithContext(ctx)
 
 		for _, c := range q.cookies {
 			req.AddCookie(c)
@@ -186,7 +230,7 @@ func (q *QBittorrentClient) doRequest(method, path string, data url.Values) (*ht
 }
 
 // AddTorrent adds a torrent to qBittorrent.
-func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category string) error {
+func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category, expectedInfoHash string) error {
 	if savePath == "" {
 		savePath = q.cfg.QBSavePath
 	}
@@ -194,6 +238,48 @@ func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category str
 		category = q.cfg.QBCategory
 	}
 
+	expectedInfoHash = firstNonEmptyHash(expectedInfoHash, infoHashFromMagnet(torrentURL))
+	var ids []string
+	var err error
+	if isMagnetURL(torrentURL) {
+		slog.Info("submitting magnet to qBittorrent", "title", title, "category", category)
+		ids, err = q.addTorrentURL(torrentURL, savePath, category)
+	} else if isHTTPURL(torrentURL) {
+		slog.Info("fetching torrent before qBittorrent upload", "title", title, "category", category)
+		var fetched fetchedTorrent
+		fetched, err = q.fetchTorrent(torrentURL)
+		if err == nil {
+			if supplied := firstNonEmptyHash(expectedInfoHash); supplied != "" && supplied != fetched.infoHash {
+				slog.Warn("torrent info hash differs from search result", "title", title, "expected_hash", supplied, "fetched_hash", fetched.infoHash)
+			}
+			// The hash of the fetched bytes is authoritative for verification.
+			expectedInfoHash = fetched.infoHash
+			slog.Info("uploading torrent bytes to qBittorrent", "title", title, "category", category, "filename", fetched.filename, "bytes", len(fetched.body))
+			ids, err = q.addTorrentFile(fetched, savePath, category)
+		}
+	} else {
+		slog.Info("submitting torrent URL to qBittorrent", "title", title, "category", category)
+		ids, err = q.addTorrentURL(torrentURL, savePath, category)
+	}
+	if err != nil {
+		slog.Warn("qBittorrent torrent submission failed", "title", title, "category", category, "error", netutil.SanitizeSensitiveText(err.Error()))
+		return err
+	}
+
+	if err := q.verifyTorrentAdded(expectedInfoHash, ids, title, category); err != nil {
+		slog.Warn("qBittorrent torrent verification failed", "title", title, "category", category, "error", netutil.SanitizeSensitiveText(err.Error()))
+		var timeoutErr torrentVerificationTimeoutError
+		if errors.As(err, &timeoutErr) {
+			return &TorrentVerificationWarning{Err: err}
+		}
+		return err
+	}
+
+	slog.Info("torrent added to qBittorrent", "title", title, "category", category)
+	return nil
+}
+
+func (q *QBittorrentClient) addTorrentURL(torrentURL, savePath, category string) ([]string, error) {
 	data := url.Values{
 		"urls":     {torrentURL},
 		"savepath": {savePath},
@@ -202,21 +288,106 @@ func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category str
 
 	resp, err := q.doRequest("POST", "/api/v2/torrents/add", data)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read add torrent response: %w", err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("add torrent HTTP %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("add torrent HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
-	if err := parseQBittorrentAddTorrentResponse(body); err != nil {
-		return fmt.Errorf("add torrent failed: %w", err)
+	parsed, err := parseQBittorrentAddTorrentResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("add torrent failed: %w", err)
 	}
 
-	slog.Info("torrent added to qBittorrent", "title", title)
-	return nil
+	return parsed.AddedTorrentIDs, nil
+}
+
+func (q *QBittorrentClient) addTorrentFile(torrent fetchedTorrent, savePath, category string) ([]string, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("torrents", torrent.filename)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := part.Write(torrent.body); err != nil {
+		return nil, err
+	}
+	if savePath != "" {
+		if err := writer.WriteField("savepath", savePath); err != nil {
+			return nil, fmt.Errorf("write torrent save path: %w", err)
+		}
+	}
+	if category != "" {
+		if err := writer.WriteField("category", category); err != nil {
+			return nil, fmt.Errorf("write torrent category: %w", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	resp, err := q.doMultipartRequest("/api/v2/torrents/add", writer.FormDataContentType(), buf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read add torrent response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("add torrent HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	parsed, err := parseQBittorrentAddTorrentResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("add torrent failed: %w", err)
+	}
+	return parsed.AddedTorrentIDs, nil
+}
+
+func (q *QBittorrentClient) doMultipartRequest(path, contentType string, body []byte) (*http.Response, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if err := q.ensureAuth(); err != nil {
+		return nil, err
+	}
+
+	var resp *http.Response
+	var err error
+	for attempt := 0; attempt < 2; attempt++ {
+		req, reqErr := http.NewRequest("POST", q.cfg.QBUrl+path, bytes.NewReader(body))
+		if reqErr != nil {
+			return nil, reqErr
+		}
+		req.Header.Set("Content-Type", contentType)
+		for _, c := range q.cookies {
+			req.AddCookie(c)
+		}
+
+		resp, err = q.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == 403 && attempt == 0 {
+			resp.Body.Close()
+			q.authenticated = false
+			if err := q.login(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		break
+	}
+	return resp, nil
 }
 
 type qbittorrentAddTorrentResponse struct {
@@ -227,26 +398,446 @@ type qbittorrentAddTorrentResponse struct {
 	Error           string   `json:"error"`
 }
 
-func parseQBittorrentAddTorrentResponse(body []byte) error {
+func parseQBittorrentAddTorrentResponse(body []byte) (qbittorrentAddTorrentResponse, error) {
 	trimmed := strings.TrimSpace(string(body))
 	if trimmed == "" || trimmed == "Ok." {
-		return nil
+		return qbittorrentAddTorrentResponse{}, nil
 	}
 
 	var parsed qbittorrentAddTorrentResponse
 	if err := json.Unmarshal(body, &parsed); err == nil {
 		if parsed.Error != "" {
-			return errors.New(parsed.Error)
+			return parsed, errors.New(parsed.Error)
 		}
 		if parsed.FailureCount > 0 {
-			return fmt.Errorf("success_count=%d failure_count=%d pending_count=%d", parsed.SuccessCount, parsed.FailureCount, parsed.PendingCount)
+			return parsed, fmt.Errorf("success_count=%d failure_count=%d pending_count=%d", parsed.SuccessCount, parsed.FailureCount, parsed.PendingCount)
 		}
 		if parsed.SuccessCount > 0 || parsed.PendingCount > 0 || len(parsed.AddedTorrentIDs) > 0 {
-			return nil
+			return parsed, nil
 		}
 	}
 
-	return errors.New(trimmed)
+	return parsed, errors.New(trimmed)
+}
+
+const maxTorrentFetchBytes = 50 << 20
+
+type fetchedTorrent struct {
+	filename string
+	body     []byte
+	infoHash string
+}
+
+func (q *QBittorrentClient) fetchTorrent(rawURL string) (fetchedTorrent, error) {
+	if q.cfg == nil || q.cfg.ProwlarrURL == "" {
+		return fetchedTorrent{}, fmt.Errorf("Prowlarr URL is not configured")
+	}
+	if _, err := netutil.ValidateSameOriginHTTPURL(rawURL, q.cfg.ProwlarrURL); err != nil {
+		return fetchedTorrent{}, fmt.Errorf("torrent URL rejected: %w", err)
+	}
+
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: q.client.Transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("stopped after 5 redirects")
+			}
+			if _, err := netutil.ValidateSameOriginHTTPURL(req.URL.String(), q.cfg.ProwlarrURL); err != nil {
+				req.Header.Del("X-Api-Key")
+				return fmt.Errorf("torrent redirect rejected: %w", err)
+			}
+			q.applyProwlarrAuth(req)
+			return nil
+		},
+	}
+
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return fetchedTorrent{}, fmt.Errorf("torrent URL request: %w", err)
+	}
+	q.applyProwlarrAuth(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fetchedTorrent{}, fmt.Errorf("fetch torrent: %s", netutil.SanitizeSensitiveText(err.Error()))
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTorrentFetchBytes+1))
+	if err != nil {
+		return fetchedTorrent{}, fmt.Errorf("read torrent response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fetchedTorrent{}, fmt.Errorf("fetch torrent HTTP %d: %s", resp.StatusCode, summarizeHTTPBody(body))
+	}
+	if len(body) > maxTorrentFetchBytes {
+		return fetchedTorrent{}, fmt.Errorf("torrent response too large")
+	}
+	infoHash, err := validateTorrentBytes(resp.Header.Get("Content-Type"), body)
+	if err != nil {
+		return fetchedTorrent{}, err
+	}
+
+	return fetchedTorrent{
+		filename: torrentFilename(resp, rawURL),
+		body:     body,
+		infoHash: infoHash,
+	}, nil
+}
+
+func (q *QBittorrentClient) applyProwlarrAuth(req *http.Request) {
+	if q.cfg == nil || q.cfg.ProwlarrAPIKey == "" {
+		req.Header.Del("X-Api-Key")
+		return
+	}
+	if _, err := netutil.ValidateSameOriginHTTPURL(req.URL.String(), q.cfg.ProwlarrURL); err != nil {
+		req.Header.Del("X-Api-Key")
+		return
+	}
+	req.Header.Set("X-Api-Key", q.cfg.ProwlarrAPIKey)
+}
+
+func validateTorrentBytes(contentType string, body []byte) (string, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return "", fmt.Errorf("torrent response was empty")
+	}
+
+	ct := strings.ToLower(contentType)
+	switch {
+	case strings.Contains(ct, "text/html"):
+		return "", fmt.Errorf("torrent response was HTML, not a .torrent file")
+	case strings.Contains(ct, "application/json"):
+		return "", fmt.Errorf("torrent response was JSON, not a .torrent file: %s", summarizeHTTPBody(body))
+	}
+
+	if trimmed[0] == '<' {
+		return "", fmt.Errorf("torrent response was HTML, not a .torrent file")
+	}
+	if trimmed[0] == '{' || trimmed[0] == '[' {
+		return "", fmt.Errorf("torrent response was JSON, not a .torrent file: %s", summarizeHTTPBody(body))
+	}
+	infoHash, err := torrentInfoHash(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("torrent response did not contain valid bencode: %w", err)
+	}
+	return infoHash, nil
+}
+
+// torrentInfoHash computes the BitTorrent v1 info hash from the exact raw
+// bencoded info dictionary bytes. Re-encoding the dictionary could change its
+// byte ordering and therefore produce a different hash.
+func torrentInfoHash(body []byte) (string, error) {
+	pos := 0
+	if len(body) == 0 || body[pos] != 'd' {
+		return "", fmt.Errorf("torrent metadata is not a dictionary")
+	}
+	pos++
+	var info []byte
+	for pos < len(body) && body[pos] != 'e' {
+		key, err := parseBencodeStringAt(body, &pos)
+		if err != nil {
+			return "", err
+		}
+		start := pos
+		end, err := skipBencodeValue(body, pos, 0)
+		if err != nil {
+			return "", err
+		}
+		if string(key) == "info" {
+			if body[start] != 'd' {
+				return "", fmt.Errorf("info value is not a dictionary")
+			}
+			info = body[start:end]
+		}
+		pos = end
+	}
+	if pos >= len(body) || body[pos] != 'e' {
+		return "", fmt.Errorf("torrent metadata has an unterminated top-level dictionary")
+	}
+	pos++
+	if pos != len(body) {
+		return "", fmt.Errorf("torrent metadata has trailing data")
+	}
+	if len(info) == 0 {
+		return "", fmt.Errorf("torrent metadata is missing an info dictionary")
+	}
+
+	sum := sha1.Sum(info)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func parseBencodeStringAt(data []byte, pos *int) ([]byte, error) {
+	if *pos >= len(data) || data[*pos] < '0' || data[*pos] > '9' {
+		return nil, fmt.Errorf("invalid bencode string")
+	}
+	length := 0
+	for *pos < len(data) && data[*pos] >= '0' && data[*pos] <= '9' {
+		digit := int(data[*pos] - '0')
+		if length > (len(data)-digit)/10 {
+			return nil, fmt.Errorf("bencode string length is too large")
+		}
+		length = length*10 + digit
+		(*pos)++
+	}
+	if *pos >= len(data) || data[*pos] != ':' {
+		return nil, fmt.Errorf("invalid bencode string length")
+	}
+	(*pos)++
+	if length > len(data)-*pos {
+		return nil, fmt.Errorf("bencode string exceeds response")
+	}
+	start := *pos
+	*pos += length
+	return data[start:*pos], nil
+}
+
+func skipBencodeValue(data []byte, pos, depth int) (int, error) {
+	if depth > 64 || pos >= len(data) {
+		return 0, fmt.Errorf("invalid bencode nesting")
+	}
+	switch data[pos] {
+	case 'i':
+		pos++
+		start := pos
+		if pos < len(data) && data[pos] == '-' {
+			pos++
+		}
+		if pos >= len(data) || data[pos] < '0' || data[pos] > '9' {
+			return 0, fmt.Errorf("invalid bencode integer")
+		}
+		for pos < len(data) && data[pos] >= '0' && data[pos] <= '9' {
+			pos++
+		}
+		if (pos-start > 1 && data[start] == '0') ||
+			(pos-start > 2 && data[start] == '-' && data[start+1] == '0') {
+			return 0, fmt.Errorf("invalid bencode integer")
+		}
+		if pos >= len(data) || data[pos] != 'e' {
+			return 0, fmt.Errorf("unterminated bencode integer")
+		}
+		return pos + 1, nil
+	case 'l':
+		pos++
+		for pos < len(data) && data[pos] != 'e' {
+			var err error
+			pos, err = skipBencodeValue(data, pos, depth+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+		if pos >= len(data) {
+			return 0, fmt.Errorf("unterminated bencode list")
+		}
+		return pos + 1, nil
+	case 'd':
+		pos++
+		for pos < len(data) && data[pos] != 'e' {
+			if _, err := parseBencodeStringAt(data, &pos); err != nil {
+				return 0, err
+			}
+			var err error
+			pos, err = skipBencodeValue(data, pos, depth+1)
+			if err != nil {
+				return 0, err
+			}
+		}
+		if pos >= len(data) {
+			return 0, fmt.Errorf("unterminated bencode dictionary")
+		}
+		return pos + 1, nil
+	default:
+		_, err := parseBencodeStringAt(data, &pos)
+		return pos, err
+	}
+}
+
+func summarizeHTTPBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	s = strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 {
+			return ' '
+		}
+		return r
+	}, s)
+	if len(s) > 160 {
+		return s[:160]
+	}
+	if s == "" {
+		return "empty response"
+	}
+	return s
+}
+
+func torrentFilename(resp *http.Response, rawURL string) string {
+	if cd := resp.Header.Get("Content-Disposition"); cd != "" {
+		if _, params, err := mime.ParseMediaType(cd); err == nil {
+			if filename := cleanTorrentFilename(params["filename"]); filename != "" {
+				return filename
+			}
+			if filename := cleanTorrentFilename(params["filename*"]); filename != "" {
+				return filename
+			}
+		}
+	}
+	if u, err := url.Parse(rawURL); err == nil {
+		if filename := cleanTorrentFilename(path.Base(u.Path)); filename != "" {
+			return filename
+		}
+	}
+	return "download.torrent"
+}
+
+func cleanTorrentFilename(filename string) string {
+	filename = strings.TrimSpace(path.Base(filename))
+	if filename == "." || filename == "/" || filename == "" {
+		return ""
+	}
+	filename = strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 || r == '/' || r == '\\' {
+			return -1
+		}
+		return r
+	}, filename)
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		return ""
+	}
+	if !strings.HasSuffix(strings.ToLower(filename), ".torrent") {
+		filename += ".torrent"
+	}
+	return filename
+}
+
+func isHTTPURL(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
+}
+
+func isMagnetURL(raw string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(raw)), "magnet:")
+}
+
+func infoHashFromMagnet(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || !strings.EqualFold(u.Scheme, "magnet") {
+		return ""
+	}
+	for _, xt := range u.Query()["xt"] {
+		const prefix = "urn:btih:"
+		if strings.HasPrefix(strings.ToLower(xt), prefix) {
+			return normalizeInfoHash(xt[len(prefix):])
+		}
+	}
+	return ""
+}
+
+func firstNonEmptyHash(values ...string) string {
+	for _, v := range values {
+		if h := normalizeInfoHash(v); h != "" {
+			return h
+		}
+	}
+	return ""
+}
+
+func normalizeInfoHash(hash string) string {
+	hash = strings.TrimSpace(hash)
+	hash = strings.TrimPrefix(strings.ToLower(hash), "urn:btih:")
+	if len(hash) == 32 {
+		if decoded, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(strings.ToUpper(hash)); err == nil && len(decoded) == sha1.Size {
+			return hex.EncodeToString([]byte(decoded))
+		}
+	}
+	return hash
+}
+
+func (q *QBittorrentClient) verifyTorrentAdded(expectedInfoHash string, addedIDs []string, title, category string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), q.verifyTimeout)
+	defer cancel()
+	return q.verifyTorrentAddedContext(ctx, expectedInfoHash, addedIDs, title, category)
+}
+
+func (q *QBittorrentClient) verifyTorrentAddedContext(ctx context.Context, expectedInfoHash string, addedIDs []string, title, category string) error {
+	expected := firstNonEmptyHash(expectedInfoHash)
+	for _, id := range addedIDs {
+		if expected == "" {
+			expected = normalizeInfoHash(id)
+			break
+		}
+	}
+
+	var lastErr error
+	ticker := time.NewTicker(q.verifyInterval)
+	defer ticker.Stop()
+	for {
+		torrents, err := q.getTorrentsContext(ctx, "")
+		if err != nil {
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				lastErr = err
+			}
+		} else {
+			slog.Debug("qBittorrent verification poll", "expected_hash", expected, "added_ids", addedIDs, "expected_category", category, "expected_title", title, "candidate_count", len(torrents))
+			if torrentListContains(torrents, expected, addedIDs, title, category) {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				if lastErr != nil {
+					return fmt.Errorf("verify torrent in qBittorrent: %w", lastErr)
+				}
+				return torrentVerificationTimeoutError{}
+			}
+			return fmt.Errorf("verify torrent in qBittorrent: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func torrentListContains(torrents []TorrentInfo, expectedInfoHash string, addedIDs []string, title, expectedCategory string) bool {
+	expectedInfoHash = normalizeInfoHash(expectedInfoHash)
+	added := make(map[string]bool, len(addedIDs))
+	for _, id := range addedIDs {
+		if h := normalizeInfoHash(id); h != "" {
+			added[h] = true
+		}
+	}
+	title = strings.ToLower(strings.TrimSpace(title))
+
+	for _, t := range torrents {
+		hash := normalizeInfoHash(t.Hash)
+		if expectedInfoHash != "" && hash == expectedInfoHash {
+			slog.Debug("qBittorrent verification candidate accepted", "hash", hash, "name", t.Name, "category", t.Category, "save_path", t.SavePath, "reason", "matching info hash", "expected_category", expectedCategory)
+			return true
+		}
+		if added[hash] {
+			slog.Debug("qBittorrent verification candidate accepted", "hash", hash, "name", t.Name, "category", t.Category, "save_path", t.SavePath, "reason", "matching add response id", "expected_category", expectedCategory)
+			return true
+		}
+		if expectedInfoHash == "" && len(added) == 0 && title != "" && strings.EqualFold(strings.TrimSpace(t.Name), title) {
+			slog.Debug("qBittorrent verification candidate accepted", "hash", hash, "name", t.Name, "category", t.Category, "save_path", t.SavePath, "reason", "exact title fallback", "expected_category", expectedCategory)
+			return true
+		}
+		slog.Debug("qBittorrent verification candidate rejected", "hash", hash, "name", t.Name, "category", t.Category, "save_path", t.SavePath, "reason", verificationRejectReason(expectedInfoHash, added, title), "expected_category", expectedCategory)
+	}
+	return false
+}
+
+func verificationRejectReason(expectedHash string, added map[string]bool, title string) string {
+	if expectedHash != "" {
+		return "info hash did not match"
+	}
+	if len(added) > 0 {
+		return "add response id did not match"
+	}
+	if title != "" {
+		return "title did not match"
+	}
+	return "no verification identifier available"
 }
 
 // TorrentInfo represents a torrent from the qBittorrent API.
@@ -283,7 +874,10 @@ func (q *QBittorrentClient) GetTorrentFiles(hash string) ([]TorrentFile, error) 
 	}
 
 	var files []TorrentFile
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read torrent files response: %w", err)
+	}
 	if err := jsonUnmarshal(body, &files); err != nil {
 		return nil, err
 	}
@@ -292,12 +886,16 @@ func (q *QBittorrentClient) GetTorrentFiles(hash string) ([]TorrentFile, error) 
 
 // GetTorrents returns torrents, optionally filtered by category.
 func (q *QBittorrentClient) GetTorrents(category string) ([]TorrentInfo, error) {
+	return q.getTorrentsContext(context.Background(), category)
+}
+
+func (q *QBittorrentClient) getTorrentsContext(ctx context.Context, category string) ([]TorrentInfo, error) {
 	data := url.Values{}
 	if category != "" {
 		data.Set("category", category)
 	}
 
-	resp, err := q.doRequest("GET", "/api/v2/torrents/info", data)
+	resp, err := q.doRequestContext(ctx, "GET", "/api/v2/torrents/info", data)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +906,10 @@ func (q *QBittorrentClient) GetTorrents(category string) ([]TorrentInfo, error) 
 	}
 
 	var torrents []TorrentInfo
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read torrents response: %w", err)
+	}
 	if err := jsonUnmarshal(body, &torrents); err != nil {
 		return nil, err
 	}
@@ -347,7 +948,10 @@ func (q *QBittorrentClient) Diagnose() map[string]interface{} {
 		return map[string]interface{}{"success": false, "error": err.Error()}
 	}
 
-	req, _ := http.NewRequest("GET", q.cfg.QBUrl+"/api/v2/app/version", nil)
+	req, err := http.NewRequest("GET", q.cfg.QBUrl+"/api/v2/app/version", nil)
+	if err != nil {
+		return map[string]interface{}{"success": false, "error": "invalid qBittorrent URL"}
+	}
 	for _, c := range q.cookies {
 		req.AddCookie(c)
 	}
@@ -358,7 +962,10 @@ func (q *QBittorrentClient) Diagnose() map[string]interface{} {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return map[string]interface{}{"success": false, "error": "read qBittorrent version response failed"}
+	}
 	if resp.StatusCode != 200 {
 		return map[string]interface{}{"success": false, "error": fmt.Sprintf("HTTP %d", resp.StatusCode)}
 	}

--- a/internal/download/qbittorrent_test.go
+++ b/internal/download/qbittorrent_test.go
@@ -882,6 +882,69 @@ func TestQBittorrentVerificationAPIError(t *testing.T) {
 	}
 }
 
+func TestQBittorrentPublicTorrentURLPassedThrough(t *testing.T) {
+	const hash = "0123456789abcdef0123456789abcdef01234567"
+	const publicURL = "https://nyaa.example/download/12345.torrent"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123", Path: "/"})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Fatalf("Content-Type = %q, want form urlencoded", got)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("urls"); got != publicURL {
+			t.Fatalf("urls = %q, want the public torrent URL passed through", got)
+		}
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler(hash, "Manga Volume"))
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = "http://prowlarr.internal:9696"
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	if err := q.AddTorrent(publicURL, "Manga Volume", "", "", hash); err != nil {
+		t.Fatalf("AddTorrent returned error for public torrent URL: %v", err)
+	}
+}
+
+func TestQBittorrentHTTPURLWithoutProwlarrPassedThrough(t *testing.T) {
+	const hash = "89abcdef0123456789abcdef0123456789abcdef"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123", Path: "/"})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("urls"); got == "" {
+			t.Fatal("urls form field missing, want URL passthrough when Prowlarr is not configured")
+		}
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler(hash, "Some Book"))
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	if err := q.AddTorrent("https://tracker.example/file.torrent", "Some Book", "", "", hash); err != nil {
+		t.Fatalf("AddTorrent returned error without Prowlarr configured: %v", err)
+	}
+}
+
 func newAddTorrentTestQBClient(serverURL string, client *http.Client) *QBittorrentClient {
 	cfg := &config.Config{
 		QBUrl:      serverURL,

--- a/internal/download/qbittorrent_test.go
+++ b/internal/download/qbittorrent_test.go
@@ -1,10 +1,19 @@
 package download
 
 import (
+	"context"
+	"crypto/sha1"
+	"encoding/base32"
+	"encoding/hex"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/JeremiahM37/librarr/internal/config"
 )
@@ -254,13 +263,14 @@ func TestQBittorrentAddTorrentAcceptsJSONSuccess(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"added_torrent_ids":["e2f71d638953c009f17594d6982c6de68b06d985"],"failure_count":0,"pending_count":0,"success_count":1}`))
 	})
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler("e2f71d638953c009f17594d6982c6de68b06d985", "Test Book"))
 
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
 
-	if err := q.AddTorrent("https://example.com/file.torrent", "Test Book", "", ""); err != nil {
+	if err := q.AddTorrent("magnet:?xt=urn:btih:e2f71d638953c009f17594d6982c6de68b06d985", "Test Book", "", "", ""); err != nil {
 		t.Fatalf("AddTorrent returned error: %v", err)
 	}
 }
@@ -276,13 +286,14 @@ func TestQBittorrentAddTorrentAcceptsOkBody(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("Ok."))
 	})
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler("abc", "Test Book"))
 
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
 
-	if err := q.AddTorrent("https://example.com/file.torrent", "Test Book", "", ""); err != nil {
+	if err := q.AddTorrent("magnet:?xt=urn:btih:abc", "Test Book", "", "", ""); err != nil {
 		t.Fatalf("AddTorrent returned error: %v", err)
 	}
 }
@@ -304,7 +315,7 @@ func TestQBittorrentAddTorrentRejectsHTTPError(t *testing.T) {
 
 	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
 
-	err := q.AddTorrent("https://example.com/file.torrent", "Test Book", "", "")
+	err := q.AddTorrent("magnet:?xt=urn:btih:abc", "Test Book", "", "", "")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -331,7 +342,7 @@ func TestQBittorrentAddTorrentRejectsJSONFailure(t *testing.T) {
 
 	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
 
-	err := q.AddTorrent("https://example.com/file.torrent", "Test Book", "", "")
+	err := q.AddTorrent("magnet:?xt=urn:btih:abc", "Test Book", "", "", "")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -352,13 +363,14 @@ func TestQBittorrentAddTorrentAcceptsJSONPending(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"added_torrent_ids":[],"failure_count":0,"pending_count":1,"success_count":0}`))
 	})
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler("abc", "Test Book"))
 
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
 
-	if err := q.AddTorrent("https://example.com/file.torrent", "Test Book", "", ""); err != nil {
+	if err := q.AddTorrent("magnet:?xt=urn:btih:abc", "Test Book", "", "", ""); err != nil {
 		t.Fatalf("AddTorrent returned error: %v", err)
 	}
 }
@@ -381,12 +393,492 @@ func TestQBittorrentAddTorrentRejectsJSONPartialFailure(t *testing.T) {
 
 	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
 
-	err := q.AddTorrent("https://example.com/file.torrent", "Test Book", "", "")
+	err := q.AddTorrent("magnet:?xt=urn:btih:e2f71d638953c009f17594d6982c6de68b06d985", "Test Book", "", "", "")
 	if err == nil {
 		t.Fatal("expected error")
 	}
 	if got := err.Error(); !strings.Contains(got, "success_count=1 failure_count=1 pending_count=0") {
 		t.Fatalf("error = %q, want partial failure counts", got)
+	}
+}
+
+func TestQBittorrentHTTPURLFetchedAndUploadedAsMultipart(t *testing.T) {
+	hash, err := torrentInfoHash(validTorrentBytes())
+	if err != nil {
+		t.Fatalf("torrentInfoHash: %v", err)
+	}
+	var sawDownload bool
+	var sawMultipart bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/download/book.torrent", func(w http.ResponseWriter, r *http.Request) {
+		sawDownload = true
+		if got := r.Header.Get("X-Api-Key"); got != "prowlarr-key" {
+			t.Fatalf("X-Api-Key = %q, want prowlarr-key", got)
+		}
+		w.Header().Set("Content-Type", "application/x-bittorrent")
+		w.Header().Set("Content-Disposition", `attachment; filename="Useful Name.torrent"`)
+		_, _ = w.Write(validTorrentBytes())
+	})
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123", Path: "/"})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		sawMultipart = true
+		if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+			t.Fatalf("Content-Type = %q, want multipart/form-data", r.Header.Get("Content-Type"))
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		files := r.MultipartForm.File["torrents"]
+		if len(files) != 1 {
+			t.Fatalf("expected one torrents file, got %d", len(files))
+		}
+		if files[0].Filename != "Useful Name.torrent" {
+			t.Fatalf("filename = %q", files[0].Filename)
+		}
+		f, err := files[0].Open()
+		if err != nil {
+			t.Fatalf("open uploaded file: %v", err)
+		}
+		defer f.Close()
+		body, _ := io.ReadAll(f)
+		if string(body) != string(validTorrentBytes()) {
+			t.Fatalf("uploaded body mismatch")
+		}
+		if got := r.MultipartForm.Value["savepath"]; len(got) != 1 || got[0] != "/downloads" {
+			t.Fatalf("savepath = %#v", got)
+		}
+		if got := r.MultipartForm.Value["category"]; len(got) != 1 || got[0] != "librarr" {
+			t.Fatalf("category = %#v", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"added_torrent_ids":["` + hash + `"],"success_count":1}`))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler(hash, "Actual qB Name"))
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = srv.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	if err := q.AddTorrent(srv.URL+"/download/book.torrent", "Search Result Name", "", "", hash); err != nil {
+		t.Fatalf("AddTorrent returned error: %v", err)
+	}
+	if !sawDownload {
+		t.Fatal("expected Librarr to fetch torrent URL")
+	}
+	if !sawMultipart {
+		t.Fatal("expected multipart upload to qBittorrent")
+	}
+}
+
+func TestFetchTorrentAllowsConfiguredProwlarrOrigin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Api-Key"); got != "prowlarr-key" {
+			t.Fatalf("X-Api-Key = %q, want prowlarr-key", got)
+		}
+		w.Header().Set("Content-Type", "application/x-bittorrent")
+		_, _ = w.Write(validTorrentBytes())
+	}))
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = srv.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	if _, err := q.fetchTorrent(srv.URL + "/download.torrent"); err != nil {
+		t.Fatalf("fetchTorrent returned error: %v", err)
+	}
+}
+
+func TestFetchTorrentRejectsDifferentOriginInputs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("rejected URL should not be fetched")
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"different hostname", "http://other.example:9696/download.torrent", "host or port"},
+		{"different port", differentPortURL(t, srv.URL) + "/download.torrent", "host or port"},
+		{"credentials", strings.Replace(srv.URL, "http://", "http://user:pass@", 1) + "/download.torrent", "credentials"},
+		{"unsupported scheme", "ftp://example.com/download.torrent", "http or https"},
+		{"missing host", "http:///download.torrent", "host"},
+	}
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = srv.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := q.fetchTorrent(tt.url)
+			if err == nil {
+				t.Fatal("expected rejection")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchTorrentRejectsCrossOriginRedirects(t *testing.T) {
+	var leakedKey bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != "" {
+			leakedKey = true
+		}
+		_, _ = w.Write(validTorrentBytes())
+	}))
+	defer target.Close()
+
+	prowlarr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/download.torrent", http.StatusFound)
+	}))
+	defer prowlarr.Close()
+
+	q := newAddTorrentTestQBClient(prowlarr.URL, prowlarr.Client())
+	q.cfg.ProwlarrURL = prowlarr.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	_, err := q.fetchTorrent(prowlarr.URL + "/start")
+	if err == nil {
+		t.Fatal("expected redirect rejection")
+	}
+	if !strings.Contains(err.Error(), "redirect rejected") {
+		t.Fatalf("error = %q, want redirect rejected", err.Error())
+	}
+	if leakedKey {
+		t.Fatal("Prowlarr API key leaked to rejected redirect target")
+	}
+}
+
+func TestFetchTorrentRejectsRedirectToDifferentHostname(t *testing.T) {
+	prowlarr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://other.example:9696/download.torrent", http.StatusFound)
+	}))
+	defer prowlarr.Close()
+
+	q := newAddTorrentTestQBClient(prowlarr.URL, prowlarr.Client())
+	q.cfg.ProwlarrURL = prowlarr.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	_, err := q.fetchTorrent(prowlarr.URL + "/start")
+	if err == nil {
+		t.Fatal("expected redirect rejection")
+	}
+	if !strings.Contains(err.Error(), "host or port") {
+		t.Fatalf("error = %q, want host or port", err.Error())
+	}
+}
+
+func TestFetchTorrentRejectsRedirectToDifferentPort(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("rejected redirect should not be fetched")
+	}))
+	defer target.Close()
+
+	prowlarr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/download.torrent", http.StatusFound)
+	}))
+	defer prowlarr.Close()
+
+	q := newAddTorrentTestQBClient(prowlarr.URL, prowlarr.Client())
+	q.cfg.ProwlarrURL = prowlarr.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	_, err := q.fetchTorrent(prowlarr.URL + "/start")
+	if err == nil {
+		t.Fatal("expected redirect rejection")
+	}
+	if !strings.Contains(err.Error(), "host or port") {
+		t.Fatalf("error = %q, want host or port", err.Error())
+	}
+}
+
+func TestFetchTorrentAllowsSameOriginRedirect(t *testing.T) {
+	var downloadSawKey bool
+	prowlarr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			if got := r.Header.Get("X-Api-Key"); got != "prowlarr-key" {
+				t.Fatalf("start X-Api-Key = %q, want prowlarr-key", got)
+			}
+			http.Redirect(w, r, "/download.torrent", http.StatusFound)
+		case "/download.torrent":
+			if got := r.Header.Get("X-Api-Key"); got != "prowlarr-key" {
+				t.Fatalf("download X-Api-Key = %q, want prowlarr-key", got)
+			}
+			downloadSawKey = true
+			w.Header().Set("Content-Type", "application/x-bittorrent")
+			_, _ = w.Write(validTorrentBytes())
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer prowlarr.Close()
+
+	q := newAddTorrentTestQBClient(prowlarr.URL, prowlarr.Client())
+	q.cfg.ProwlarrURL = prowlarr.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	if _, err := q.fetchTorrent(prowlarr.URL + "/start"); err != nil {
+		t.Fatalf("fetchTorrent returned error: %v", err)
+	}
+	if !downloadSawKey {
+		t.Fatal("same-origin redirect target was not fetched")
+	}
+}
+
+func TestQBittorrentMagnetStillUsesURLFormField(t *testing.T) {
+	const hash = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123", Path: "/"})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Fatalf("Content-Type = %q, want form urlencoded", got)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("urls"); got != "magnet:?xt=urn:btih:"+hash {
+			t.Fatalf("urls = %q", got)
+		}
+		if r.MultipartForm != nil {
+			t.Fatal("magnet should not be uploaded as multipart file")
+		}
+		_, _ = w.Write([]byte(`{"added_torrent_ids":["` + hash + `"],"success_count":1}`))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler(hash, "Magnet Book"))
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	if err := q.AddTorrent("magnet:?xt=urn:btih:"+hash, "Magnet Book", "", "", ""); err != nil {
+		t.Fatalf("AddTorrent returned error: %v", err)
+	}
+}
+
+func TestTorrentInfoHashUsesRawInfoDictionaryBytes(t *testing.T) {
+	body := []byte("d4:infod4:zkey1:a4:akey1:bee")
+	got, err := torrentInfoHash(body)
+	if err != nil {
+		t.Fatalf("torrentInfoHash returned error: %v", err)
+	}
+	rawInfo := []byte("d4:zkey1:a4:akey1:be")
+	wantBytes := sha1.Sum(rawInfo)
+	want := hex.EncodeToString(wantBytes[:])
+	if got != want {
+		t.Fatalf("torrentInfoHash = %q, want raw-info hash %q", got, want)
+	}
+}
+
+func TestTorrentVerificationMatchesHashAcrossCategoryAndName(t *testing.T) {
+	const hash = "0123456789abcdef0123456789abcdef01234567"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123"})
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"name":"Actual qB Name","hash":"` + hash + `","category":"other","save_path":"/remote/downloads"}]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	if err := q.AddTorrent("magnet:?xt=urn:btih:"+hash, "Search Result Name", "", "librarr", ""); err != nil {
+		t.Fatalf("AddTorrent returned error: %v", err)
+	}
+}
+
+func TestTorrentVerificationIgnoresUnrelatedTorrents(t *testing.T) {
+	if torrentListContains([]TorrentInfo{{Name: "Other", Hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil, "Target", "librarr") {
+		t.Fatal("unrelated torrent was accepted")
+	}
+}
+
+func TestMagnetInfoHashNormalization(t *testing.T) {
+	hexHash := "0123456789abcdef0123456789abcdef01234567"
+	base32Hash := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte{0, 17, 34, 51, 68, 85, 102, 119, 136, 153, 170, 187, 204, 221, 238, 255, 16, 32, 48, 64})
+	wantBase32 := "00112233445566778899aabbccddeeff10203040"
+	if got := infoHashFromMagnet("magnet:?xt=urn:btih:" + strings.ToUpper(hexHash)); got != hexHash {
+		t.Fatalf("hex magnet hash = %q, want %q", got, hexHash)
+	}
+	if got := infoHashFromMagnet("magnet:?xt=urn:btih:" + base32Hash); got != wantBase32 {
+		t.Fatalf("base32 magnet hash = %q, want %q", got, wantBase32)
+	}
+}
+
+func TestTorrentVerificationContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123"})
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			_, _ = w.Write([]byte("Ok."))
+		}
+	}))
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	err := q.verifyTorrentAddedContext(ctx, "abc", nil, "Target", "librarr")
+	if err == nil || time.Since(start) > time.Second {
+		t.Fatalf("verification cancellation error=%v duration=%s", err, time.Since(start))
+	}
+}
+
+func TestFetchTorrentRejectsInvalidResponses(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		contentType string
+		body        string
+		want        string
+	}{
+		{"html", http.StatusOK, "text/html", "<html>login</html>", "HTML"},
+		{"json", http.StatusOK, "application/json", `{"error":"denied"}`, "JSON"},
+		{"empty", http.StatusOK, "application/x-bittorrent", "", "empty"},
+		{"non-2xx", http.StatusForbidden, "text/plain", "forbidden", "HTTP 403"},
+		{"malformed", http.StatusOK, "application/x-bittorrent", "not bencode", "bencode"},
+		{"missing info dictionary", http.StatusOK, "application/x-bittorrent", "d4:name4:teste", "info dictionary"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+			q.cfg.ProwlarrURL = srv.URL
+			_, err := q.fetchTorrent(srv.URL + "/download.torrent")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestQBittorrentVerificationTimeout(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123", Path: "/"})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	err := q.AddTorrent("magnet:?xt=urn:btih:abc", "Missing Book", "", "", "")
+	if err == nil {
+		t.Fatal("expected verification timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %q, want timeout", err.Error())
+	}
+	var warning *TorrentVerificationWarning
+	if !errors.As(err, &warning) {
+		t.Fatalf("error type = %T, want TorrentVerificationWarning", err)
+	}
+}
+
+func TestQBittorrentVerificationWaitsForDelayedVisibility(t *testing.T) {
+	infoCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123"})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", func(w http.ResponseWriter, r *http.Request) {
+		infoCalls++
+		if infoCalls < 4 {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"name":"Delayed Book","hash":"abc"}]`))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.verifyTimeout = 300 * time.Millisecond
+	q.verifyInterval = 20 * time.Millisecond
+	if err := q.AddTorrent("magnet:?xt=urn:btih:abc", "Delayed Book", "", "", ""); err != nil {
+		t.Fatalf("AddTorrent returned error for delayed visibility: %v", err)
+	}
+	if infoCalls < 4 {
+		t.Fatalf("verification made %d info calls, want at least 4", infoCalls)
+	}
+}
+
+func TestQBittorrentVerificationAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123", Path: "/"})
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	err := q.AddTorrent("magnet:?xt=urn:btih:abc", "Broken Info", "", "", "")
+	if err == nil {
+		t.Fatal("expected verification API error")
+	}
+	if !strings.Contains(err.Error(), "get torrents HTTP 500") {
+		t.Fatalf("error = %q, want HTTP 500", err.Error())
 	}
 }
 
@@ -400,7 +892,38 @@ func newAddTorrentTestQBClient(serverURL string, client *http.Client) *QBittorre
 	}
 	q := NewQBittorrentClient(cfg)
 	q.client = client
+	q.verifyTimeout = 40 * time.Millisecond
+	q.verifyInterval = 5 * time.Millisecond
 	return q
+}
+
+func torrentInfoHandler(hash, name string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if hash == "" {
+			_, _ = w.Write([]byte(`[{"name":"` + name + `","hash":""}]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"name":"` + name + `","hash":"` + hash + `"}]`))
+	}
+}
+
+func differentPortURL(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	u.Host = u.Hostname() + ":" + strconv.Itoa(port+1)
+	return u.String()
+}
+
+func validTorrentBytes() []byte {
+	return []byte("d4:infod4:name4:testee")
 }
 
 func TestGetTorrentFiles(t *testing.T) {

--- a/internal/download/torrentclient.go
+++ b/internal/download/torrentclient.go
@@ -13,9 +13,10 @@ import "github.com/JeremiahM37/librarr/internal/config"
 // deletion are scoped to torrents Librarr itself added (qBittorrent categories,
 // Transmission labels), so Librarr never touches a user's unrelated torrents.
 type TorrentClient interface {
-	// AddTorrent submits a torrent URL or magnet link. savePath and category
-	// fall back to the client's configured defaults when empty.
-	AddTorrent(torrentURL, title, savePath, category string) error
+	// AddTorrent submits a torrent URL, torrent file URL, or magnet link.
+	// savePath and category fall back to the client's configured defaults when
+	// empty. expectedInfoHash is optional and used for post-add verification.
+	AddTorrent(torrentURL, title, savePath, category, expectedInfoHash string) error
 	// GetTorrents returns torrents Librarr added under the given category
 	// (empty category returns all Librarr-scoped torrents).
 	GetTorrents(category string) ([]TorrentInfo, error)

--- a/internal/download/transmission.go
+++ b/internal/download/transmission.go
@@ -73,7 +73,7 @@ type transmissionTorrent struct {
 // by GetTorrents; savePath becomes the download-dir. Both fall back to the
 // configured qBittorrent-equivalent defaults when empty, matching the
 // qBittorrent client's behaviour for drop-in parity.
-func (t *TransmissionClient) AddTorrent(torrentURL, title, savePath, category string) error {
+func (t *TransmissionClient) AddTorrent(torrentURL, title, savePath, category, expectedInfoHash string) error {
 	if savePath == "" {
 		savePath = t.cfg.QBSavePath
 	}

--- a/internal/download/transmission_test.go
+++ b/internal/download/transmission_test.go
@@ -116,7 +116,7 @@ func TestTransmission_AddTorrentSetsLabelAndDownloadDir(t *testing.T) {
 	defer srv.Close()
 
 	tc := newTestTransmission(srv.URL)
-	if err := tc.AddTorrent("magnet:?xt=urn:btih:abc", "Some Book", "/audiobooks-incoming", "audiobooks"); err != nil {
+	if err := tc.AddTorrent("magnet:?xt=urn:btih:abc", "Some Book", "/audiobooks-incoming", "audiobooks", ""); err != nil {
 		t.Fatalf("AddTorrent error: %v", err)
 	}
 	if mock.lastMethod != "torrent-add" {
@@ -140,7 +140,7 @@ func TestTransmission_AddTorrentFallsBackToDefaults(t *testing.T) {
 	defer srv.Close()
 
 	tc := newTestTransmission(srv.URL) // QBSavePath=/downloads, QBCategory=librarr
-	if err := tc.AddTorrent("http://x/t.torrent", "T", "", ""); err != nil {
+	if err := tc.AddTorrent("http://x/t.torrent", "T", "", "", ""); err != nil {
 		t.Fatalf("AddTorrent error: %v", err)
 	}
 	if mock.lastArgs["download-dir"] != "/downloads" {

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html"
 	"log/slog"
@@ -31,6 +32,8 @@ type Watcher struct {
 	processing sync.Map // hash -> struct{}, tracks in-progress imports
 	imported   sync.Map // hash -> struct{}, tracks already-imported hashes
 }
+
+var errTorrentContentPending = errors.New("torrent content pending synchronization")
 
 // NewWatcher creates a new torrent completion watcher.
 func NewWatcher(cfg *config.Config, database *db.DB, torrent TorrentClient, organizer *organize.Organizer, targets *organize.LibraryTargets, health *search.HealthTracker) *Watcher {
@@ -106,11 +109,19 @@ func (w *Watcher) checkCompleted() {
 func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 	defer w.processing.Delete(t.Hash)
 
-	slog.Info("importing completed torrent", "name", t.Name, "hash", t.Hash, "type", mediaType)
+	slog.Debug("processing completed torrent", "name", t.Name, "hash", t.Hash, "type", mediaType)
 
 	savePath := w.resolveLocalPath(t, mediaType)
 
 	var importErr error
+	if _, err := os.Stat(savePath); err != nil {
+		if os.IsNotExist(err) {
+			slog.Info("torrent import pending", "name", t.Name, "hash", t.Hash, "type", mediaType, "path", savePath, "reason", "local synchronized path not available")
+		} else {
+			slog.Warn("torrent import pending", "name", t.Name, "hash", t.Hash, "type", mediaType, "path", savePath, "error", err)
+		}
+		return
+	}
 	switch mediaType {
 	case "ebook":
 		importErr = w.importEbook(t, savePath)
@@ -121,7 +132,11 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 	}
 
 	if importErr != nil {
-		slog.Error("torrent import failed", "name", t.Name, "type", mediaType, "error", importErr)
+		if errors.Is(importErr, errTorrentContentPending) {
+			slog.Info("torrent import pending", "name", t.Name, "hash", t.Hash, "type", mediaType, "path", savePath, "error", importErr)
+		} else {
+			slog.Error("torrent import failed", "name", t.Name, "type", mediaType, "error", importErr)
+		}
 		return
 	}
 
@@ -141,7 +156,9 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 	w.imported.Store(t.Hash, struct{}{})
 
 	// Log the import.
-	_ = w.db.LogEvent("torrent_import", t.Name, fmt.Sprintf("Imported %s from torrent", mediaType), nil, t.Hash)
+	if err := w.db.LogEvent("torrent_import", t.Name, fmt.Sprintf("Imported %s from torrent", mediaType), nil, t.Hash); err != nil {
+		slog.Warn("failed to log torrent import", "name", t.Name, "hash", t.Hash, "error", err)
+	}
 }
 
 // resolveLocalPath maps qBittorrent container paths to local paths.
@@ -208,29 +225,36 @@ func (w *Watcher) incomingDirForMedia(mediaType string) string {
 	}
 }
 
+func (w *Watcher) remoteSavePathForMedia(mediaType string) string {
+	switch mediaType {
+	case "audiobook":
+		return w.cfg.QBAudiobookSavePath
+	case "manga":
+		return w.cfg.QBMangaSavePath
+	default:
+		return w.cfg.QBSavePath
+	}
+}
+
 func (w *Watcher) resolveContentPath(t TorrentInfo, mediaType string) string {
 	contentPath := normalizeTorrentPath(t.ContentPath)
-	savePath := normalizeTorrentPath(t.SavePath)
+	contentPath = filepath.Clean(contentPath)
+	savePath := filepath.Clean(normalizeTorrentPath(t.SavePath))
 	localIncoming := w.incomingDirForMedia(mediaType)
 
 	if contentPath == "" {
 		return localIncoming
 	}
 
-	if localIncoming != "" {
-		if rel, err := filepath.Rel(localIncoming, contentPath); err == nil && rel == "." {
-			return contentPath
-		} else if err == nil && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != ".." {
-			return contentPath
+	remoteRoots := []string{savePath, filepath.Clean(normalizeTorrentPath(w.remoteSavePathForMedia(mediaType)))}
+	for _, remoteRoot := range remoteRoots {
+		if mapped, ok := mapTorrentPath(contentPath, remoteRoot, localIncoming); ok {
+			return mapped
 		}
 	}
 
-	if savePath != "" {
-		if rel, err := filepath.Rel(savePath, contentPath); err == nil && rel == "." {
-			return localIncoming
-		} else if err == nil && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && rel != ".." {
-			return filepath.Join(localIncoming, rel)
-		}
+	if mapped, ok := mapTorrentPath(contentPath, localIncoming, localIncoming); ok {
+		return mapped
 	}
 
 	if !filepath.IsAbs(contentPath) && contentPath != ".." && !strings.HasPrefix(contentPath, ".."+string(os.PathSeparator)) {
@@ -240,10 +264,30 @@ func (w *Watcher) resolveContentPath(t TorrentInfo, mediaType string) string {
 	return filepath.Join(localIncoming, filepath.Base(contentPath))
 }
 
+// mapTorrentPath translates a path reported by the remote torrent client into
+// the corresponding locally mounted path. It only succeeds for paths at or
+// below remoteRoot, preventing traversal and unrelated absolute paths from
+// escaping localRoot.
+func mapTorrentPath(reportedPath, remoteRoot, localRoot string) (string, bool) {
+	reportedPath = filepath.Clean(normalizeTorrentPath(reportedPath))
+	remoteRoot = filepath.Clean(normalizeTorrentPath(remoteRoot))
+	localRoot = filepath.Clean(normalizeTorrentPath(localRoot))
+	if reportedPath == "." || remoteRoot == "." || localRoot == "." ||
+		!filepath.IsAbs(reportedPath) || !filepath.IsAbs(remoteRoot) || !filepath.IsAbs(localRoot) {
+		return "", false
+	}
+
+	rel, err := filepath.Rel(remoteRoot, reportedPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", false
+	}
+	return filepath.Join(localRoot, rel), true
+}
+
 func (w *Watcher) importEbook(t TorrentInfo, savePath string) error {
 	bookFiles := findFilesByExt(savePath, []string{".epub", ".mobi", ".pdf", ".azw3"})
 	if len(bookFiles) == 0 {
-		return fmt.Errorf("no ebook files found at %s", savePath)
+		return fmt.Errorf("%w: no ebook files found at %s", errTorrentContentPending, savePath)
 	}
 
 	for _, bf := range bookFiles {
@@ -255,24 +299,27 @@ func (w *Watcher) importEbook(t TorrentInfo, savePath string) error {
 
 		// Try to extract author from EPUB metadata.
 		author := ""
+		metadataTitle := t.Name
 		if strings.HasSuffix(strings.ToLower(destPath), ".epub") {
-			if meta, err := organize.ExtractEPUBMeta(destPath); err == nil && meta.Author != "" {
-				author = meta.Author
+			if meta, err := organize.ExtractEPUBMeta(destPath); err == nil {
+				if meta.Author != "" {
+					author = meta.Author
+				}
+				if meta.Title != "" {
+					metadataTitle = meta.Title
+				}
 			}
 		}
 
-		w.db.AddItem(&models.LibraryItem{
-			Title:     t.Name,
-			Author:    author,
-			FilePath:  destPath,
-			FileSize:  t.TotalSize,
-			MediaType: "ebook",
-			Source:    "torrent",
-			SourceID:  t.Hash,
-		})
+		inserted, err := w.recordTorrentItem(t, "ebook", bf, destPath, t.Name, author, metadataTitle, author, fileFormat(destPath), t.TotalSize)
+		if err != nil {
+			return err
+		}
 
 		// Import to external libraries.
-		w.targets.ImportEbook(destPath, t.Name, author)
+		if inserted && w.targets != nil {
+			w.targets.ImportEbook(destPath, t.Name, author)
+		}
 	}
 
 	return nil
@@ -281,7 +328,7 @@ func (w *Watcher) importEbook(t TorrentInfo, savePath string) error {
 func (w *Watcher) importAudiobook(t TorrentInfo, savePath string) error {
 	// If the source path doesn't even exist, fail the import.
 	if _, statErr := os.Stat(savePath); os.IsNotExist(statErr) {
-		return fmt.Errorf("source path does not exist: %s", savePath)
+		return fmt.Errorf("%w: source path does not exist: %s", errTorrentContentPending, savePath)
 	}
 
 	// Extract author from torrent name if possible.
@@ -301,17 +348,14 @@ func (w *Watcher) importAudiobook(t TorrentInfo, savePath string) error {
 		return fmt.Errorf("organize audiobook %q: %w", savePath, err)
 	}
 
-	w.db.AddItem(&models.LibraryItem{
-		Title:     title,
-		Author:    author,
-		FilePath:  destPath,
-		FileSize:  t.TotalSize,
-		MediaType: "audiobook",
-		Source:    "torrent",
-		SourceID:  t.Hash,
-	})
+	inserted, err := w.recordTorrentItem(t, "audiobook", savePath, destPath, title, author, title, author, fileFormat(destPath), t.TotalSize)
+	if err != nil {
+		return err
+	}
 
-	w.targets.ImportAudiobook()
+	if inserted && w.targets != nil {
+		w.targets.ImportAudiobook()
+	}
 
 	return nil
 }
@@ -319,7 +363,7 @@ func (w *Watcher) importAudiobook(t TorrentInfo, savePath string) error {
 func (w *Watcher) importManga(t TorrentInfo, savePath string) error {
 	mangaFiles := findFilesByExt(savePath, []string{".cbz", ".cbr", ".zip", ".pdf", ".epub"})
 	if len(mangaFiles) == 0 {
-		return fmt.Errorf("no manga files found at %s", savePath)
+		return fmt.Errorf("%w: no manga files found at %s", errTorrentContentPending, savePath)
 	}
 
 	for _, mf := range mangaFiles {
@@ -329,19 +373,61 @@ func (w *Watcher) importManga(t TorrentInfo, savePath string) error {
 			destPath = mf
 		}
 
-		w.db.AddItem(&models.LibraryItem{
-			Title:     t.Name,
-			FilePath:  destPath,
-			FileSize:  t.TotalSize,
-			MediaType: "manga",
-			Source:    "torrent",
-			SourceID:  t.Hash,
-		})
+		inserted, err := w.recordTorrentItem(t, "manga", mf, destPath, t.Name, "", t.Name, "", fileFormat(destPath), t.TotalSize)
+		if err != nil {
+			return err
+		}
 
-		w.targets.ImportManga(destPath, t.Name)
+		if inserted && w.targets != nil {
+			w.targets.ImportManga(destPath, t.Name)
+		}
 	}
 
 	return nil
+}
+
+func (w *Watcher) recordTorrentItem(t TorrentInfo, mediaType, sourcePath, destinationPath, title, author, metadataTitle, metadataAuthor, format string, fileSize int64) (bool, error) {
+	if info, err := os.Stat(destinationPath); err == nil && info.Mode().IsRegular() {
+		fileSize = info.Size()
+	}
+	item := &models.LibraryItem{
+		Title:        title,
+		Author:       author,
+		FilePath:     destinationPath,
+		OriginalPath: sourcePath,
+		FileSize:     fileSize,
+		FileFormat:   format,
+		MediaType:    mediaType,
+		Source:       "torrent",
+		SourceID:     t.Hash,
+	}
+	outcome, err := w.db.AddItemWithOutcome(item)
+	fields := []any{
+		"torrent_hash", t.Hash,
+		"torrent_name", t.Name,
+		"source_path", sourcePath,
+		"normalized_source_path", db.NormalizeLibraryPath(sourcePath),
+		"destination_path", destinationPath,
+		"normalized_destination_path", outcome.NormalizedPath,
+		"file_size", fileSize,
+		"detected_format", format,
+		"metadata_title", metadataTitle,
+		"metadata_author", metadataAuthor,
+		"content_hash", outcome.ContentHash,
+		"existing_record_id", outcome.ExistingID,
+		"duplicate_decision", outcome.Reason,
+		"database_decision", map[bool]string{true: "insert", false: "reuse_existing"}[outcome.Inserted],
+	}
+	if err != nil {
+		slog.Error("torrent library import database failure", append(fields, "error", err)...)
+		return false, err
+	}
+	slog.Info("torrent library import decision", fields...)
+	return outcome.Inserted, nil
+}
+
+func fileFormat(filePath string) string {
+	return strings.TrimPrefix(strings.ToLower(filepath.Ext(filePath)), ".")
 }
 
 // normalizeTorrentPath unescapes HTML entities (e.g. &amp; -> &) that
@@ -373,7 +459,7 @@ func findFilesByExt(root string, exts []string) []string {
 		return files
 	}
 
-	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return nil
 		}
@@ -385,7 +471,9 @@ func findFilesByExt(root string, exts []string) []string {
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		slog.Warn("failed to scan torrent files", "root", root, "error", err)
+	}
 
 	return files
 }

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -291,27 +291,16 @@ func (w *Watcher) importEbook(t TorrentInfo, savePath string) error {
 	}
 
 	for _, bf := range bookFiles {
-		destPath, err := w.organizer.OrganizeEbook(bf, t.Name, "")
+		metadata := organize.ExtractEbookMetadata(bf)
+		title := firstNonEmpty(metadata.Title, t.Name)
+		author := metadata.Author
+		destPath, err := w.organizer.OrganizeEbook(bf, title, author)
 		if err != nil {
 			slog.Warn("organize ebook failed", "file", bf, "error", err)
 			destPath = bf
 		}
 
-		// Try to extract author from EPUB metadata.
-		author := ""
-		metadataTitle := t.Name
-		if strings.HasSuffix(strings.ToLower(destPath), ".epub") {
-			if meta, err := organize.ExtractEPUBMeta(destPath); err == nil {
-				if meta.Author != "" {
-					author = meta.Author
-				}
-				if meta.Title != "" {
-					metadataTitle = meta.Title
-				}
-			}
-		}
-
-		inserted, err := w.recordTorrentItem(t, "ebook", bf, destPath, t.Name, author, metadataTitle, author, fileFormat(destPath), t.TotalSize)
+		inserted, err := w.recordTorrentItem(t, "ebook", bf, destPath, title, author, metadata.Title, metadata.Author, fileFormat(destPath), t.TotalSize)
 		if err != nil {
 			return err
 		}
@@ -323,6 +312,15 @@ func (w *Watcher) importEbook(t TorrentInfo, savePath string) error {
 	}
 
 	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (w *Watcher) importAudiobook(t TorrentInfo, savePath string) error {

--- a/internal/download/watcher_test.go
+++ b/internal/download/watcher_test.go
@@ -4,11 +4,99 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
 )
+
+func TestRecordTorrentItemIsIdempotentAcrossWatcherPolls(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.New(filepath.Join(dir, "library.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	filePath := filepath.Join(dir, "book.epub")
+	if err := os.WriteFile(filePath, []byte("same torrent file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	w := &Watcher{db: database}
+	torrent := TorrentInfo{Name: "Book", Hash: "torrent-hash"}
+
+	first, err := w.recordTorrentItem(torrent, "ebook", "/downloads/book.epub", filePath, "Book", "Author", "Book", "Author", "epub", 0)
+	if err != nil || !first {
+		t.Fatalf("first recordTorrentItem = inserted %v, err %v", first, err)
+	}
+	second, err := w.recordTorrentItem(torrent, "ebook", "/downloads/book.epub", filePath, "Book", "Author", "Book", "Author", "epub", 0)
+	if err != nil || second {
+		t.Fatalf("second recordTorrentItem = inserted %v, err %v; want idempotent reuse", second, err)
+	}
+
+	count, err := database.CountItems("ebook")
+	if err != nil || count != 1 {
+		t.Fatalf("CountItems = %d, %v; want one row", count, err)
+	}
+}
+
+func TestMapTorrentPathRemoteRootToLocalRoot(t *testing.T) {
+	got, ok := mapTorrentPath("/downloads/rclone-mnt/downloads/Prince Of Persia", "/downloads/rclone-mnt/downloads", "/downloads")
+	if !ok || got != "/downloads/Prince Of Persia" {
+		t.Fatalf("mapTorrentPath = (%q, %v), want (/downloads/Prince Of Persia, true)", got, ok)
+	}
+}
+
+func TestMapTorrentPathSingleFile(t *testing.T) {
+	got, ok := mapTorrentPath("/remote/books/Book.epub", "/remote/books", "/local/incoming")
+	if !ok || got != "/local/incoming/Book.epub" {
+		t.Fatalf("mapTorrentPath = (%q, %v), want (/local/incoming/Book.epub, true)", got, ok)
+	}
+}
+
+func TestMapTorrentPathMultiFileDirectory(t *testing.T) {
+	got, ok := mapTorrentPath("/remote/books/Series/Book", "/remote/books", "/local/incoming")
+	if !ok || got != "/local/incoming/Series/Book" {
+		t.Fatalf("mapTorrentPath = (%q, %v), want (/local/incoming/Series/Book, true)", got, ok)
+	}
+}
+
+func TestMapTorrentPathIdenticalRoots(t *testing.T) {
+	got, ok := mapTorrentPath("/downloads/Book/file.epub", "/downloads", "/downloads")
+	if !ok || got != "/downloads/Book/file.epub" {
+		t.Fatalf("mapTorrentPath = (%q, %v), want unchanged path, true", got, ok)
+	}
+}
+
+func TestMapTorrentPathRejectsOutsideRemoteRoot(t *testing.T) {
+	if got, ok := mapTorrentPath("/other/Book.epub", "/remote/books", "/local/incoming"); ok || got != "" {
+		t.Fatalf("mapTorrentPath = (%q, %v), want empty path, false", got, ok)
+	}
+}
+
+func TestMapTorrentPathRejectsTraversal(t *testing.T) {
+	if got, ok := mapTorrentPath("/remote/books/../secret/Book.epub", "/remote/books", "/local/incoming"); ok || got != "" {
+		t.Fatalf("mapTorrentPath = (%q, %v), want empty path, false", got, ok)
+	}
+}
+
+func TestResolveLocalPathMapsConfiguredQBRoot(t *testing.T) {
+	w := &Watcher{cfg: &config.Config{
+		QBSavePath:  "/downloads/rclone-mnt/downloads",
+		IncomingDir: "/downloads",
+		QBCategory:  "librarr",
+	}}
+
+	got := w.resolveLocalPath(TorrentInfo{
+		ContentPath: "/downloads/rclone-mnt/downloads/Prince Of Persia",
+		SavePath:    "/downloads/rclone-mnt/downloads",
+	}, "ebook")
+	if got != "/downloads/Prince Of Persia" {
+		t.Fatalf("resolveLocalPath = %q, want /downloads/Prince Of Persia", got)
+	}
+}
 
 func TestResolveLocalPathAudiobookUsesContentPath(t *testing.T) {
 	w := &Watcher{

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -93,6 +93,7 @@ type LibraryItem struct {
 	MediaType    string    `json:"media_type"`
 	Source       string    `json:"source"`
 	SourceID     string    `json:"source_id"`
+	ContentHash  string    `json:"-"`
 	Metadata     string    `json:"metadata"`
 	AddedAt      time.Time `json:"added_at"`
 }

--- a/internal/netutil/ssrf.go
+++ b/internal/netutil/ssrf.go
@@ -178,9 +178,20 @@ func strictEffectivePort(u *url.URL) (string, error) {
 	}
 }
 
+// SanitizeLogValue strips line breaks from remote-derived values before they
+// reach structured logs, so a crafted value cannot forge additional log
+// entries.
+func SanitizeLogValue(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
+}
+
 // SanitizeSensitiveText redacts credentials and common secret query parameters
 // from error strings before they are logged or returned through API responses.
+// Line breaks are also removed so the result is safe to log.
 func SanitizeSensitiveText(text string) string {
+	text = SanitizeLogValue(text)
 	parts := strings.Fields(text)
 	for i, part := range parts {
 		trimmed := strings.Trim(part, "\"'(),")

--- a/internal/netutil/ssrf.go
+++ b/internal/netutil/ssrf.go
@@ -115,6 +115,91 @@ func ValidateOutboundURL(rawURL string) error {
 	return nil
 }
 
+// ValidateSameOriginHTTPURL parses rawURL and verifies that it has the same
+// normalized host and effective port as allowedOrigin. It is intended for
+// integration-owned URLs, such as Prowlarr download links, where the server may
+// legitimately be private or loopback but redirects must not escape the configured
+// origin.
+func ValidateSameOriginHTTPURL(rawURL, allowedOrigin string) (*url.URL, error) {
+	u, err := parseStrictHTTPURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	allowed, err := parseStrictHTTPURL(allowedOrigin)
+	if err != nil {
+		return nil, fmt.Errorf("configured origin invalid: %w", err)
+	}
+	if normalizedHostname(u) != normalizedHostname(allowed) || effectivePort(u) != effectivePort(allowed) {
+		return nil, fmt.Errorf("URL host or port does not match configured origin")
+	}
+	return u, nil
+}
+
+func parseStrictHTTPURL(rawURL string) (*url.URL, error) {
+	u, err := parseHTTPURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if u.User != nil {
+		return nil, fmt.Errorf("URL must not include credentials")
+	}
+	if _, err := strictEffectivePort(u); err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+func normalizedHostname(u *url.URL) string {
+	return strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+}
+
+func effectivePort(u *url.URL) string {
+	port, _ := strictEffectivePort(u)
+	return port
+}
+
+func strictEffectivePort(u *url.URL) (string, error) {
+	if port := u.Port(); port != "" {
+		return port, nil
+	}
+	host := u.Host
+	lastColon := strings.LastIndex(host, ":")
+	lastBracket := strings.LastIndex(host, "]")
+	if lastColon > lastBracket {
+		return "", fmt.Errorf("URL has malformed port")
+	}
+	switch u.Scheme {
+	case "http":
+		return "80", nil
+	case "https":
+		return "443", nil
+	default:
+		return "", fmt.Errorf("URL must use http or https")
+	}
+}
+
+// SanitizeSensitiveText redacts credentials and common secret query parameters
+// from error strings before they are logged or returned through API responses.
+func SanitizeSensitiveText(text string) string {
+	parts := strings.Fields(text)
+	for i, part := range parts {
+		trimmed := strings.Trim(part, "\"'(),")
+		if u, err := url.Parse(trimmed); err == nil && u.Scheme != "" && u.Host != "" {
+			u.User = nil
+			q := u.Query()
+			for key := range q {
+				lower := strings.ToLower(key)
+				if strings.Contains(lower, "key") || strings.Contains(lower, "token") || strings.Contains(lower, "pass") || strings.Contains(lower, "sid") {
+					q.Set(key, "REDACTED")
+				}
+			}
+			u.RawQuery = q.Encode()
+			parts[i] = strings.Replace(part, trimmed, u.String(), 1)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
 func isCloudMetadataIP(ip net.IP) bool {
 	ip4 := ip.To4()
 	return ip4 != nil && ip4[0] == 169 && ip4[1] == 254

--- a/internal/netutil/ssrf_test.go
+++ b/internal/netutil/ssrf_test.go
@@ -1,6 +1,9 @@
 package netutil
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidateIntegrationURL(t *testing.T) {
 	tests := []struct {
@@ -52,5 +55,44 @@ func TestValidateOutboundURL(t *testing.T) {
 				t.Errorf("ValidateOutboundURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestValidateSameOriginHTTPURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		origin  string
+		wantErr bool
+	}{
+		{"same explicit port", "http://prowlarr.example:9696/download", "http://prowlarr.example:9696", false},
+		{"same hostname case insensitive", "http://PROWLARR.example:9696/download", "http://prowlarr.EXAMPLE:9696", false},
+		{"http default port equals explicit 80", "http://prowlarr.example/download", "http://prowlarr.example:80", false},
+		{"https default port equals explicit 443", "https://prowlarr.example/download", "https://prowlarr.example:443", false},
+		{"different hostname", "http://other.example:9696/download", "http://prowlarr.example:9696", true},
+		{"different port", "http://prowlarr.example:9697/download", "http://prowlarr.example:9696", true},
+		{"credentials rejected", "http://user:pass@prowlarr.example:9696/download", "http://prowlarr.example:9696", true},
+		{"malformed port rejected", "http://prowlarr.example:bad/download", "http://prowlarr.example:9696", true},
+		{"unsupported scheme rejected", "ftp://prowlarr.example/download", "http://prowlarr.example", true},
+		{"missing host rejected", "http:///download", "http://prowlarr.example", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ValidateSameOriginHTTPURL(tt.raw, tt.origin)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateSameOriginHTTPURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSanitizeSensitiveText(t *testing.T) {
+	input := `fetch http://user:pass@example.com/download?apikey=secret&token=abc&id=1 failed`
+	got := SanitizeSensitiveText(input)
+	if strings.Contains(got, "secret") || strings.Contains(got, "abc") || strings.Contains(got, "user:pass") {
+		t.Fatalf("SanitizeSensitiveText leaked secret: %q", got)
+	}
+	if !strings.Contains(got, "id=1") {
+		t.Fatalf("SanitizeSensitiveText removed non-secret query: %q", got)
 	}
 }

--- a/internal/organize/ebookmeta.go
+++ b/internal/organize/ebookmeta.go
@@ -1,0 +1,92 @@
+package organize
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// EbookMetadata contains the best metadata available for an ebook file.
+// Metadata embedded in the file is preferred; filename values are fallbacks.
+type EbookMetadata struct {
+	Title  string
+	Author string
+}
+
+var pdfInfoValueRe = regexp.MustCompile(`/((?:Title)|(?:Author))\s*\(([^()]*)\)`)
+
+// ExtractEbookMetadata returns metadata for supported ebook formats. Readers
+// without a supported embedded metadata format still receive a useful
+// filename-derived title, while callers retain their own final fallback.
+func ExtractEbookMetadata(filePath string) EbookMetadata {
+	metadata := parseEbookFilename(filePath)
+	switch strings.ToLower(filepath.Ext(filePath)) {
+	case ".epub":
+		if embedded, err := ExtractEPUBMeta(filePath); err == nil {
+			if embedded.Title != "" {
+				metadata.Title = embedded.Title
+			}
+			if embedded.Author != "" {
+				metadata.Author = embedded.Author
+			}
+		}
+	case ".pdf":
+		if embedded := extractPDFInfo(filePath); embedded.Title != "" || embedded.Author != "" {
+			if embedded.Title != "" {
+				metadata.Title = embedded.Title
+			}
+			if embedded.Author != "" {
+				metadata.Author = embedded.Author
+			}
+		}
+	}
+	return metadata
+}
+
+func parseEbookFilename(filePath string) EbookMetadata {
+	name := strings.TrimSpace(strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath)))
+	name = bracketRe.ReplaceAllString(name, "")
+	name = whitespaceRe.ReplaceAllString(name, " ")
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return EbookMetadata{}
+	}
+
+	metadata := EbookMetadata{Title: name}
+	if parts := strings.SplitN(name, " - ", 2); len(parts) == 2 {
+		if author := strings.TrimSpace(parts[0]); author != "" {
+			metadata.Author = author
+		}
+		if title := strings.TrimSpace(parts[1]); title != "" {
+			metadata.Title = title
+		}
+	}
+	return metadata
+}
+
+func extractPDFInfo(filePath string) EbookMetadata {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return EbookMetadata{}
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(io.LimitReader(f, 4<<20))
+	if err != nil {
+		return EbookMetadata{}
+	}
+	var metadata EbookMetadata
+	for _, match := range pdfInfoValueRe.FindAllSubmatch(data, -1) {
+		value := strings.TrimSpace(string(bytes.ReplaceAll(match[2], []byte(`\\`), []byte(`\`))))
+		switch string(match[1]) {
+		case "Title":
+			metadata.Title = value
+		case "Author":
+			metadata.Author = value
+		}
+	}
+	return metadata
+}

--- a/internal/organize/ebookmeta_test.go
+++ b/internal/organize/ebookmeta_test.go
@@ -1,0 +1,65 @@
+package organize
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractEbookMetadataFilenameFallbacks(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"The Guardian's Path.epub", "Author Name - A Book.mobi", "A Book.azw3", "A Book.pdf"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("not embedded metadata"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := ExtractEbookMetadata(filepath.Join(dir, "Author Name - A Book.mobi"))
+	if got.Title != "A Book" || got.Author != "Author Name" {
+		t.Fatalf("filename metadata = %+v, want title/author from filename", got)
+	}
+	got = ExtractEbookMetadata(filepath.Join(dir, "A Book.azw3"))
+	if got.Title != "A Book" {
+		t.Fatalf("AZW3 filename title = %q, want A Book", got.Title)
+	}
+}
+
+func TestExtractEbookMetadataPrefersEPUBMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Torrent Name.epub")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zipWriter := zip.NewWriter(file)
+	opf, err := zipWriter.Create("content.opf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = opf.Write([]byte(`<package><metadata><dc:title xmlns:dc="x">The Guardian's Path</dc:title><dc:creator xmlns:dc="x">Doe, Jane</dc:creator></metadata></package>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ExtractEbookMetadata(path)
+	if got.Title != "The Guardian's Path" || got.Author != "Jane Doe" {
+		t.Fatalf("embedded metadata = %+v, want EPUB metadata", got)
+	}
+}
+
+func TestExtractEbookMetadataPDFInfo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Torrent Name.pdf")
+	if err := os.WriteFile(path, []byte("%PDF-1.7 /Title (The Guardian's Path) /Author (Jane Doe)"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got := ExtractEbookMetadata(path)
+	if got.Title != "The Guardian's Path" || got.Author != "Jane Doe" {
+		t.Fatalf("PDF metadata = %+v, want PDF info values", got)
+	}
+}

--- a/internal/organize/epub.go
+++ b/internal/organize/epub.go
@@ -10,10 +10,7 @@ import (
 )
 
 // EPUBMeta holds extracted EPUB metadata.
-type EPUBMeta struct {
-	Title  string
-	Author string
-}
+type EPUBMeta = EbookMetadata
 
 // ExtractEPUBMeta reads an EPUB file (ZIP archive) and extracts dc:title and dc:creator
 // from the OPF metadata file.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -4,6 +4,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -205,9 +206,14 @@ func (s *Scheduler) startDownload(result models.SearchResult, title string) {
 		if url == "" {
 			url = "magnet:?xt=urn:btih:" + result.InfoHash
 		}
-		err := s.downloadMgr.StartTorrentDownload(url, title, "", "")
+		err := s.downloadMgr.StartTorrentDownload(url, title, "", "", result.InfoHash)
 		if err != nil {
-			slog.Error("scheduler: auto-download failed", "title", title, "error", err)
+			var verificationWarning *download.TorrentVerificationWarning
+			if errors.As(err, &verificationWarning) {
+				slog.Warn("scheduler: torrent accepted; verification pending", "title", title, "warning", err.Error())
+			} else {
+				slog.Error("scheduler: auto-download failed", "title", title, "error", err)
+			}
 		}
 	}
 }

--- a/internal/scheduler/wishlist_cleanup_test.go
+++ b/internal/scheduler/wishlist_cleanup_test.go
@@ -268,7 +268,7 @@ func addLibraryItem(t *testing.T, database *db.DB, title, author, mediaType stri
 		Title:      title,
 		Author:     author,
 		MediaType:  mediaType,
-		FilePath:   "/library/" + title,
+		FilePath:   "/library/" + title + "/" + author,
 		FileFormat: "epub",
 		Source:     "test",
 	})


### PR DESCRIPTION
with help from codex. my situation is a remote seedbox running Qbit

## Summary

This PR improves qBittorrent integration for remote deployments and makes completed torrent imports restart-safe.

It fixes a long-standing issue where Librarr forwarded Prowlarr download URLs directly to remote qBittorrent instances, which cannot access locally hosted indexers.

It also prevents duplicate library entries when completed torrents remain in qBittorrent across Librarr restarts.

---

## Changes

### qBittorrent

- Download `.torrent` files through Librarr and upload them directly to qBittorrent
- Preserve magnet workflow
- Verify uploads using BitTorrent v1 info hashes
- Support hexadecimal and Base32 btih hashes
- Treat verification timeout after a successful add as a warning instead of a failure

### Security

- Restrict torrent downloads to the configured Prowlarr origin
- Prevent redirect escape
- Limit API-key forwarding to approved Prowlarr requests

### Import pipeline

- Translate qBittorrent save paths to Librarr local paths
- Handle pending imports while waiting for synchronized storage (e.g. rclone)
- Prevent duplicate imports after application restarts
- Use canonical destination paths and SHA-256 content hashes
- Preserve separate EPUB and MOBI library entries

### Database

- Add additive schema migration for content hashes
- Backfill hashes when files are available
- Existing duplicate rows are intentionally preserved
- No uniqueness constraint is introduced in this PR

### Tests

Added coverage for:

- torrent parsing
- malformed torrents
- info hash generation
- magnet normalization
- SSRF protections
- remote path translation
- verification warnings
- schema migration
- duplicate prevention
- restart-safe imports
- concurrency

---

## Validation

Tested successfully with:

- Remote qBittorrent seedbox
- Prowlarr
- rclone synchronization
- Existing database
- Fresh imports
- Restarted Librarr
- Completed torrents left in qBittorrent

Verified that no duplicate imports occur after restart.

---

## Notes

This PR intentionally does **not** remove existing duplicate library rows or introduce a unique database constraint. Those are left for a future maintenance PR. 

