### PR TITLE
Fix NZB/SABnzbd download path end-to-end (#89)

### DIFF
--- a/cmd/librarr/main.go
+++ b/cmd/librarr/main.go
@@ -129,8 +129,8 @@ func main() {
 		}
 	}
 
-	// Start torrent completion watcher.
-	watcher := download.NewWatcher(cfg, database, torrentClient, organizer, targets, health)
+	// Start download completion watcher (torrents + SABnzbd).
+	watcher := download.NewWatcher(cfg, database, torrentClient, sab, organizer, targets, health)
 	go watcher.Start(ctx)
 
 	// Start audiobook folder scanner (Feature 21).

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -232,6 +232,10 @@ func (s *Server) handleDownloadTorrent(w http.ResponseWriter, r *http.Request) {
 		req.Title = "Unknown"
 	}
 	req.MediaType = "ebook"
+	if isNZBResult(req) && s.cfg.HasSABnzbd() {
+		s.handleNZBDownload(w, req)
+		return
+	}
 	s.handleTorrentDownload(w, r, req)
 }
 
@@ -265,6 +269,12 @@ func (s *Server) handleDownloadAudiobook(w http.ResponseWriter, r *http.Request)
 		req.Title = "Unknown"
 	}
 	req.MediaType = "audiobook"
+	// Usenet audiobook grabs must go to SABnzbd, not the torrent client, which
+	// would silently discard the NZB payload.
+	if isNZBResult(req) && s.cfg.HasSABnzbd() {
+		s.handleNZBDownload(w, req)
+		return
+	}
 	s.handleTorrentDownload(w, r, req)
 }
 
@@ -464,7 +474,11 @@ func (s *Server) handleNZBDownload(w http.ResponseWriter, req models.DownloadReq
 		return
 	}
 
-	nzoID, err := s.downloadMgr.StartNZBDownload(nzbURL, req.Title)
+	mediaType := req.MediaType
+	if mediaType == "" {
+		mediaType = "ebook"
+	}
+	nzoID, err := s.downloadMgr.StartNZBDownload(nzbURL, req.Title, mediaType)
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"success": err == nil,
 		"title":   req.Title,

--- a/internal/api/requests.go
+++ b/internal/api/requests.go
@@ -513,7 +513,11 @@ func (s *Server) processApprovedRequest(req *models.Request) {
 
 	// Check if NZB.
 	if chosen.DownloadProtocol == "nzb" && s.cfg.HasSABnzbd() {
-		nzoID, err := s.downloadMgr.StartNZBDownload(chosen.DownloadURL, chosen.Title)
+		mediaType := dlReq.MediaType
+		if mediaType == "" {
+			mediaType = "ebook"
+		}
+		nzoID, err := s.downloadMgr.StartNZBDownload(chosen.DownloadURL, chosen.Title, mediaType)
 		if err != nil {
 			s.failRequest(req, fmt.Sprintf("NZB download failed: %v", err))
 			return

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -99,6 +99,13 @@ func (d *DB) migrate() error {
 			media_type TEXT NOT NULL DEFAULT 'ebook',
 			added_at REAL NOT NULL DEFAULT (strftime('%s','now'))
 		)`,
+		`CREATE TABLE IF NOT EXISTS nzb_jobs (
+			nzo_id TEXT PRIMARY KEY,
+			title TEXT NOT NULL DEFAULT '',
+			media_type TEXT NOT NULL DEFAULT 'ebook',
+			imported INTEGER NOT NULL DEFAULT 0,
+			created_at REAL NOT NULL DEFAULT (strftime('%s','now'))
+		)`,
 		`CREATE INDEX IF NOT EXISTS idx_library_items_source_id ON library_items(source_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_library_items_media_type ON library_items(media_type)`,
 		`CREATE INDEX IF NOT EXISTS idx_activity_log_timestamp ON activity_log(timestamp)`,

--- a/internal/db/nzb.go
+++ b/internal/db/nzb.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+// --- NZB Jobs ---
+//
+// SABnzbd exposes a single category, so a completed download's history entry
+// doesn't tell us which library it belongs to. We record the media type when
+// the NZB is submitted and clear the row once the watcher imports it.
+
+// RecordNZBJob remembers an NZB submitted to SABnzbd. It is idempotent: a
+// repeated nzo_id (e.g. a retried submit) is ignored rather than resurrecting
+// an already-imported job.
+func (d *DB) RecordNZBJob(nzoID, title, mediaType string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if mediaType == "" {
+		mediaType = "ebook"
+	}
+	_, err := d.db.Exec(
+		`INSERT OR IGNORE INTO nzb_jobs (nzo_id, title, media_type) VALUES (?, ?, ?)`,
+		nzoID, title, mediaType,
+	)
+	return err
+}
+
+// PendingNZBJobs returns NZB jobs that have not yet been imported.
+func (d *DB) PendingNZBJobs() ([]models.NZBJob, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	rows, err := d.db.Query(
+		`SELECT nzo_id, title, media_type FROM nzb_jobs WHERE imported = 0`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobs []models.NZBJob
+	for rows.Next() {
+		var j models.NZBJob
+		if err := rows.Scan(&j.NzoID, &j.Title, &j.MediaType); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, j)
+	}
+	return jobs, rows.Err()
+}
+
+// MarkNZBJobImported flags an NZB job as imported so it is not processed again.
+func (d *DB) MarkNZBJobImported(nzoID string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_, err := d.db.Exec(`UPDATE nzb_jobs SET imported = 1 WHERE nzo_id = ?`, nzoID)
+	return err
+}

--- a/internal/db/nzb_test.go
+++ b/internal/db/nzb_test.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"testing"
+)
+
+func TestNZBJobLifecycle(t *testing.T) {
+	database := newTestDB(t)
+
+	if err := database.RecordNZBJob("nzo_1", "An Audiobook", "audiobook"); err != nil {
+		t.Fatalf("RecordNZBJob: %v", err)
+	}
+
+	pending, err := database.PendingNZBJobs()
+	if err != nil {
+		t.Fatalf("PendingNZBJobs: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending = %d, want 1", len(pending))
+	}
+	if pending[0].NzoID != "nzo_1" || pending[0].MediaType != "audiobook" {
+		t.Fatalf("pending[0] = %+v, want nzo_1/audiobook", pending[0])
+	}
+
+	if err := database.MarkNZBJobImported("nzo_1"); err != nil {
+		t.Fatalf("MarkNZBJobImported: %v", err)
+	}
+	pending, err = database.PendingNZBJobs()
+	if err != nil {
+		t.Fatalf("PendingNZBJobs after import: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending after import = %d, want 0", len(pending))
+	}
+}
+
+func TestRecordNZBJobIsIdempotentAndDoesNotResurrect(t *testing.T) {
+	database := newTestDB(t)
+
+	if err := database.RecordNZBJob("nzo_1", "Book", "ebook"); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.MarkNZBJobImported("nzo_1"); err != nil {
+		t.Fatal(err)
+	}
+	// A duplicate submit of the same nzo_id must not flip imported back to 0.
+	if err := database.RecordNZBJob("nzo_1", "Book", "ebook"); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := database.PendingNZBJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending = %d, want 0 (already-imported job must not resurrect)", len(pending))
+	}
+}
+
+func TestRecordNZBJobDefaultsMediaType(t *testing.T) {
+	database := newTestDB(t)
+
+	if err := database.RecordNZBJob("nzo_1", "Book", ""); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := database.PendingNZBJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].MediaType != "ebook" {
+		t.Fatalf("pending = %+v, want one ebook job", pending)
+	}
+}

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -102,12 +102,22 @@ func (m *Manager) StartTorrentDownload(torrentURL, title, savePath, category, ex
 	return m.torrent.AddTorrent(torrentURL, title, savePath, category, expectedInfoHash)
 }
 
-// StartNZBDownload sends an NZB URL to SABnzbd.
-func (m *Manager) StartNZBDownload(nzbURL, title string) (string, error) {
+// StartNZBDownload sends an NZB URL to SABnzbd and records the media type so
+// the completion watcher can import it into the right library.
+func (m *Manager) StartNZBDownload(nzbURL, title, mediaType string) (string, error) {
 	if m.sab == nil {
 		return "", fmt.Errorf("SABnzbd not configured")
 	}
-	return m.sab.AddNZB(nzbURL, title)
+	nzoID, err := m.sab.AddNZB(nzbURL, title)
+	if err != nil {
+		return "", err
+	}
+	if nzoID != "" {
+		if err := m.db.RecordNZBJob(nzoID, title, mediaType); err != nil {
+			slog.Warn("failed to record NZB job for import tracking", "nzo_id", nzoID, "error", err)
+		}
+	}
+	return nzoID, nil
 }
 
 // StartDirectDownload starts a background download from a direct URL.

--- a/internal/download/nzb_import_test.go
+++ b/internal/download/nzb_import_test.go
@@ -1,0 +1,176 @@
+package download
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/organize"
+)
+
+func newNZBTestWatcher(t *testing.T, cfg *config.Config) (*Watcher, *db.DB) {
+	t.Helper()
+	database, err := db.New(filepath.Join(t.TempDir(), "library.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return &Watcher{
+		cfg:       cfg,
+		db:        database,
+		organizer: organize.NewOrganizer(cfg),
+	}, database
+}
+
+// TestImportNZBIntoLibrary is the regression for finding 3: a completed SAB
+// download must be imported, not left on disk.
+func TestImportNZBIntoLibrary(t *testing.T) {
+	incoming := t.TempDir()
+	cfg := &config.Config{IncomingDir: incoming, FileOrgEnabled: false}
+	w, database := newNZBTestWatcher(t, cfg)
+
+	if err := database.RecordNZBJob("nzo_1", "Some Book", "ebook"); err != nil {
+		t.Fatal(err)
+	}
+
+	// SAB unpacked the download into INCOMING_DIR/<name>.
+	jobDir := filepath.Join(incoming, "Some Book")
+	if err := os.MkdirAll(jobDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobDir, "book.epub"), []byte("epub"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w.importNZB(SABnzbdHistorySlot{NzoID: "nzo_1", Name: "Some Book", Status: "Completed"}, "ebook")
+
+	count, err := database.CountItems("ebook")
+	if err != nil || count != 1 {
+		t.Fatalf("CountItems(ebook) = %d, %v; want 1 imported item", count, err)
+	}
+	pending, err := database.PendingNZBJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending NZB jobs = %d, want 0 after import", len(pending))
+	}
+}
+
+// TestImportNZBPendingWhenNotYetOnDisk ensures a not-yet-visible download stays
+// pending and is retried, rather than being marked imported with nothing to show.
+func TestImportNZBPendingWhenNotYetOnDisk(t *testing.T) {
+	cfg := &config.Config{IncomingDir: t.TempDir(), FileOrgEnabled: false}
+	w, database := newNZBTestWatcher(t, cfg)
+	if err := database.RecordNZBJob("nzo_1", "Missing", "ebook"); err != nil {
+		t.Fatal(err)
+	}
+
+	w.importNZB(SABnzbdHistorySlot{NzoID: "nzo_1", Name: "Missing", Status: "Completed"}, "ebook")
+
+	pending, err := database.PendingNZBJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending = %d, want 1 (retry preserved)", len(pending))
+	}
+}
+
+func TestResolveNZBPathPrefersStorageWhenPresent(t *testing.T) {
+	storage := t.TempDir()
+	cfg := &config.Config{IncomingDir: "/incoming", FileOrgEnabled: false}
+	w := &Watcher{cfg: cfg}
+
+	got := w.resolveNZBPath(SABnzbdHistorySlot{Name: "Book", Storage: storage}, "ebook")
+	if got != storage {
+		t.Fatalf("resolveNZBPath = %q, want storage path %q", got, storage)
+	}
+
+	// When storage is absent, fall back to the incoming dir joined with name.
+	got = w.resolveNZBPath(SABnzbdHistorySlot{Name: "Book"}, "ebook")
+	if got != filepath.Join("/incoming", "Book") {
+		t.Fatalf("resolveNZBPath fallback = %q, want /incoming/Book", got)
+	}
+}
+
+// TestCheckCompletedNZBResolvesFailedJobs ensures a failed SAB job is dropped
+// from the pending list instead of lingering forever.
+func TestCheckCompletedNZBResolvesFailedJobs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := SABnzbdHistoryResponse{}
+		resp.History.Slots = []SABnzbdHistorySlot{
+			{NzoID: "nzo_fail", Name: "Broken", Status: "Failed", FailMessage: "unpack error"},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{IncomingDir: t.TempDir(), SABnzbdURL: srv.URL, SABnzbdAPIKey: "k"}
+	w, database := newNZBTestWatcher(t, cfg)
+	w.sab = NewSABnzbdClient(cfg)
+	if err := database.RecordNZBJob("nzo_fail", "Broken", "ebook"); err != nil {
+		t.Fatal(err)
+	}
+
+	w.checkCompletedNZB()
+
+	pending, err := database.PendingNZBJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending = %d, want 0 (failed job should be resolved)", len(pending))
+	}
+}
+
+// TestCheckCompletedNZBImportsCompleted drives the full poll path against a
+// fake SAB history endpoint.
+func TestCheckCompletedNZBImportsCompleted(t *testing.T) {
+	incoming := t.TempDir()
+	jobDir := filepath.Join(incoming, "Done Book")
+	if err := os.MkdirAll(jobDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobDir, "book.epub"), []byte("epub"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := SABnzbdHistoryResponse{}
+		resp.History.Slots = []SABnzbdHistorySlot{
+			{NzoID: "nzo_done", Name: "Done Book", Status: "Completed"},
+			{NzoID: "nzo_untracked", Name: "Not Ours", Status: "Completed"},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{IncomingDir: incoming, FileOrgEnabled: false, SABnzbdURL: srv.URL, SABnzbdAPIKey: "k"}
+	w, database := newNZBTestWatcher(t, cfg)
+	w.sab = NewSABnzbdClient(cfg)
+	if err := database.RecordNZBJob("nzo_done", "Done Book", "ebook"); err != nil {
+		t.Fatal(err)
+	}
+
+	w.checkCompletedNZB()
+
+	// importNZB runs in a goroutine; wait briefly for it to finish.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, _ := database.CountItems("ebook"); c == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if c, _ := database.CountItems("ebook"); c != 1 {
+		t.Fatalf("CountItems(ebook) = %d, want 1", c)
+	}
+}

--- a/internal/download/sabnzbd.go
+++ b/internal/download/sabnzbd.go
@@ -49,10 +49,13 @@ type SABnzbdQueueResponse struct {
 
 // SABnzbdHistorySlot represents a completed download in history.
 type SABnzbdHistorySlot struct {
-	NzoID  string `json:"nzo_id"`
-	Name   string `json:"name"`
-	Status string `json:"status"`
-	Size   string `json:"size"`
+	NzoID       string `json:"nzo_id"`
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	Size        string `json:"size"`
+	Category    string `json:"category"`
+	Storage     string `json:"storage"`      // final on-disk path once complete
+	FailMessage string `json:"fail_message"` // populated when Status == "Failed"
 }
 
 // SABnzbdHistoryResponse is the response from mode=history.

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -25,22 +25,26 @@ type Watcher struct {
 	cfg       *config.Config
 	db        *db.DB
 	torrent   TorrentClient
+	sab       *SABnzbdClient
 	organizer *organize.Organizer
 	targets   *organize.LibraryTargets
 	health    *search.HealthTracker
 
-	processing sync.Map // hash -> struct{}, tracks in-progress imports
-	imported   sync.Map // hash -> struct{}, tracks already-imported hashes
+	processing    sync.Map // hash -> struct{}, tracks in-progress imports
+	imported      sync.Map // hash -> struct{}, tracks already-imported hashes
+	processingNZB sync.Map // nzo_id -> struct{}, tracks in-progress NZB imports
 }
 
 var errTorrentContentPending = errors.New("torrent content pending synchronization")
 
-// NewWatcher creates a new torrent completion watcher.
-func NewWatcher(cfg *config.Config, database *db.DB, torrent TorrentClient, organizer *organize.Organizer, targets *organize.LibraryTargets, health *search.HealthTracker) *Watcher {
+// NewWatcher creates a new download completion watcher covering both the
+// torrent client and SABnzbd.
+func NewWatcher(cfg *config.Config, database *db.DB, torrent TorrentClient, sab *SABnzbdClient, organizer *organize.Organizer, targets *organize.LibraryTargets, health *search.HealthTracker) *Watcher {
 	return &Watcher{
 		cfg:       cfg,
 		db:        database,
 		torrent:   torrent,
+		sab:       sab,
 		organizer: organizer,
 		targets:   targets,
 		health:    health,
@@ -49,26 +53,36 @@ func NewWatcher(cfg *config.Config, database *db.DB, torrent TorrentClient, orga
 
 // Start begins the background watcher loop. It blocks until ctx is cancelled.
 func (w *Watcher) Start(ctx context.Context) {
-	if w.torrent == nil {
-		slog.Info("torrent watcher disabled (no torrent client configured)")
+	watchNZB := w.sab != nil && w.cfg.HasSABnzbd()
+	if w.torrent == nil && !watchNZB {
+		slog.Info("download watcher disabled (no torrent client or SABnzbd configured)")
 		return
 	}
 
-	slog.Info("torrent completion watcher started", "client", w.torrent.Name(), "interval", "30s")
+	slog.Info("download completion watcher started", "torrent", w.torrent != nil, "sabnzbd", watchNZB, "interval", "30s")
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
 	// Run once immediately.
-	w.checkCompleted()
+	w.poll()
 
 	for {
 		select {
 		case <-ctx.Done():
-			slog.Info("torrent watcher stopping")
+			slog.Info("download watcher stopping")
 			return
 		case <-ticker.C:
-			w.checkCompleted()
+			w.poll()
 		}
+	}
+}
+
+func (w *Watcher) poll() {
+	if w.torrent != nil {
+		w.checkCompleted()
+	}
+	if w.sab != nil && w.cfg.HasSABnzbd() {
+		w.checkCompletedNZB()
 	}
 }
 
@@ -124,11 +138,11 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 	}
 	switch mediaType {
 	case "ebook":
-		importErr = w.importEbook(t, savePath)
+		importErr = w.importEbook(t, savePath, "torrent")
 	case "audiobook":
-		importErr = w.importAudiobook(t, savePath)
+		importErr = w.importAudiobook(t, savePath, "torrent")
 	case "manga":
-		importErr = w.importManga(t, savePath)
+		importErr = w.importManga(t, savePath, "torrent")
 	}
 
 	if importErr != nil {
@@ -159,6 +173,109 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 	if err := w.db.LogEvent("torrent_import", t.Name, fmt.Sprintf("Imported %s from torrent", mediaType), nil, t.Hash); err != nil {
 		slog.Warn("failed to log torrent import", "name", t.Name, "hash", t.Hash, "error", err)
 	}
+}
+
+// sabHistoryLimit bounds how many SABnzbd history entries we scan per poll.
+const sabHistoryLimit = 200
+
+// checkCompletedNZB imports SABnzbd downloads that librarr submitted and that
+// have finished post-processing. Because SABnzbd exposes only a single
+// category, the media type is recovered from the nzb_jobs table (recorded at
+// submit time) rather than from the history entry.
+func (w *Watcher) checkCompletedNZB() {
+	pending, err := w.db.PendingNZBJobs()
+	if err != nil {
+		slog.Warn("failed to list pending NZB jobs", "error", err)
+		return
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	mediaByNzo := make(map[string]string, len(pending))
+	for _, j := range pending {
+		mediaByNzo[j.NzoID] = j.MediaType
+	}
+
+	history, err := w.sab.GetHistory(sabHistoryLimit)
+	if err != nil {
+		slog.Warn("failed to fetch SABnzbd history", "error", err)
+		return
+	}
+
+	for _, slot := range history {
+		mediaType, tracked := mediaByNzo[slot.NzoID]
+		if !tracked {
+			continue
+		}
+		switch strings.ToLower(slot.Status) {
+		case "completed":
+			// Guard against a second goroutine for the same job while the
+			// first is still importing.
+			if _, loaded := w.processingNZB.LoadOrStore(slot.NzoID, struct{}{}); loaded {
+				continue
+			}
+			go w.importNZB(slot, mediaType)
+		case "failed":
+			// A failed job never produces files; stop tracking it so it does
+			// not linger in the pending list forever.
+			slog.Warn("SABnzbd download failed", "name", slot.Name, "nzo_id", slot.NzoID, "reason", slot.FailMessage)
+			if err := w.db.MarkNZBJobImported(slot.NzoID); err != nil {
+				slog.Warn("failed to mark failed NZB job resolved", "nzo_id", slot.NzoID, "error", err)
+			}
+		}
+	}
+}
+
+func (w *Watcher) importNZB(slot SABnzbdHistorySlot, mediaType string) {
+	defer w.processingNZB.Delete(slot.NzoID)
+
+	savePath := w.resolveNZBPath(slot, mediaType)
+	if _, err := os.Stat(savePath); err != nil {
+		// Not visible on the local mount yet — retry on the next poll.
+		slog.Info("nzb import pending", "name", slot.Name, "nzo_id", slot.NzoID, "type", mediaType, "path", savePath)
+		return
+	}
+
+	t := TorrentInfo{Name: slot.Name, Hash: slot.NzoID}
+	var importErr error
+	switch mediaType {
+	case "audiobook":
+		importErr = w.importAudiobook(t, savePath, "nzb")
+	case "manga":
+		importErr = w.importManga(t, savePath, "nzb")
+	default:
+		importErr = w.importEbook(t, savePath, "nzb")
+	}
+
+	if importErr != nil {
+		if errors.Is(importErr, errTorrentContentPending) {
+			slog.Info("nzb import pending", "name", slot.Name, "nzo_id", slot.NzoID, "type", mediaType, "path", savePath, "error", importErr)
+		} else {
+			slog.Error("nzb import failed", "name", slot.Name, "type", mediaType, "error", importErr)
+		}
+		return
+	}
+
+	if err := w.db.MarkNZBJobImported(slot.NzoID); err != nil {
+		slog.Warn("failed to mark NZB job imported", "nzo_id", slot.NzoID, "error", err)
+	}
+	if err := w.db.LogEvent("nzb_import", slot.Name, fmt.Sprintf("Imported %s from SABnzbd", mediaType), nil, slot.NzoID); err != nil {
+		slog.Warn("failed to log nzb import", "name", slot.Name, "nzo_id", slot.NzoID, "error", err)
+	}
+}
+
+// resolveNZBPath returns the local path of a completed SABnzbd download. It
+// prefers the storage path SABnzbd reports (valid when librarr and SABnzbd
+// share the completed-downloads mount) and falls back to the media type's
+// incoming directory joined with the job name.
+func (w *Watcher) resolveNZBPath(slot SABnzbdHistorySlot, mediaType string) string {
+	if storage := normalizeTorrentPath(slot.Storage); storage != "" {
+		if _, err := os.Stat(storage); err == nil {
+			return storage
+		}
+	}
+	return filepath.Join(w.incomingDirForMedia(mediaType), normalizeTorrentPath(slot.Name))
 }
 
 // resolveLocalPath maps qBittorrent container paths to local paths.
@@ -284,7 +401,7 @@ func mapTorrentPath(reportedPath, remoteRoot, localRoot string) (string, bool) {
 	return filepath.Join(localRoot, rel), true
 }
 
-func (w *Watcher) importEbook(t TorrentInfo, savePath string) error {
+func (w *Watcher) importEbook(t TorrentInfo, savePath, source string) error {
 	bookFiles := findFilesByExt(savePath, []string{".epub", ".mobi", ".pdf", ".azw3"})
 	if len(bookFiles) == 0 {
 		return fmt.Errorf("%w: no ebook files found at %s", errTorrentContentPending, savePath)
@@ -300,7 +417,7 @@ func (w *Watcher) importEbook(t TorrentInfo, savePath string) error {
 			destPath = bf
 		}
 
-		inserted, err := w.recordTorrentItem(t, "ebook", bf, destPath, title, author, metadata.Title, metadata.Author, fileFormat(destPath), t.TotalSize)
+		inserted, err := w.recordTorrentItem(source, t, "ebook", bf, destPath, title, author, metadata.Title, metadata.Author, fileFormat(destPath), t.TotalSize)
 		if err != nil {
 			return err
 		}
@@ -323,7 +440,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func (w *Watcher) importAudiobook(t TorrentInfo, savePath string) error {
+func (w *Watcher) importAudiobook(t TorrentInfo, savePath, source string) error {
 	// If the source path doesn't even exist, fail the import.
 	if _, statErr := os.Stat(savePath); os.IsNotExist(statErr) {
 		return fmt.Errorf("%w: source path does not exist: %s", errTorrentContentPending, savePath)
@@ -346,7 +463,7 @@ func (w *Watcher) importAudiobook(t TorrentInfo, savePath string) error {
 		return fmt.Errorf("organize audiobook %q: %w", savePath, err)
 	}
 
-	inserted, err := w.recordTorrentItem(t, "audiobook", savePath, destPath, title, author, title, author, fileFormat(destPath), t.TotalSize)
+	inserted, err := w.recordTorrentItem(source, t, "audiobook", savePath, destPath, title, author, title, author, fileFormat(destPath), t.TotalSize)
 	if err != nil {
 		return err
 	}
@@ -358,7 +475,7 @@ func (w *Watcher) importAudiobook(t TorrentInfo, savePath string) error {
 	return nil
 }
 
-func (w *Watcher) importManga(t TorrentInfo, savePath string) error {
+func (w *Watcher) importManga(t TorrentInfo, savePath, source string) error {
 	mangaFiles := findFilesByExt(savePath, []string{".cbz", ".cbr", ".zip", ".pdf", ".epub"})
 	if len(mangaFiles) == 0 {
 		return fmt.Errorf("%w: no manga files found at %s", errTorrentContentPending, savePath)
@@ -371,7 +488,7 @@ func (w *Watcher) importManga(t TorrentInfo, savePath string) error {
 			destPath = mf
 		}
 
-		inserted, err := w.recordTorrentItem(t, "manga", mf, destPath, t.Name, "", t.Name, "", fileFormat(destPath), t.TotalSize)
+		inserted, err := w.recordTorrentItem(source, t, "manga", mf, destPath, t.Name, "", t.Name, "", fileFormat(destPath), t.TotalSize)
 		if err != nil {
 			return err
 		}
@@ -384,7 +501,7 @@ func (w *Watcher) importManga(t TorrentInfo, savePath string) error {
 	return nil
 }
 
-func (w *Watcher) recordTorrentItem(t TorrentInfo, mediaType, sourcePath, destinationPath, title, author, metadataTitle, metadataAuthor, format string, fileSize int64) (bool, error) {
+func (w *Watcher) recordTorrentItem(source string, t TorrentInfo, mediaType, sourcePath, destinationPath, title, author, metadataTitle, metadataAuthor, format string, fileSize int64) (bool, error) {
 	if info, err := os.Stat(destinationPath); err == nil && info.Mode().IsRegular() {
 		fileSize = info.Size()
 	}
@@ -396,7 +513,7 @@ func (w *Watcher) recordTorrentItem(t TorrentInfo, mediaType, sourcePath, destin
 		FileSize:     fileSize,
 		FileFormat:   format,
 		MediaType:    mediaType,
-		Source:       "torrent",
+		Source:       source,
 		SourceID:     t.Hash,
 	}
 	outcome, err := w.db.AddItemWithOutcome(item)

--- a/internal/download/watcher_test.go
+++ b/internal/download/watcher_test.go
@@ -27,11 +27,11 @@ func TestRecordTorrentItemIsIdempotentAcrossWatcherPolls(t *testing.T) {
 	w := &Watcher{db: database}
 	torrent := TorrentInfo{Name: "Book", Hash: "torrent-hash"}
 
-	first, err := w.recordTorrentItem(torrent, "ebook", "/downloads/book.epub", filePath, "Book", "Author", "Book", "Author", "epub", 0)
+	first, err := w.recordTorrentItem("torrent", torrent, "ebook", "/downloads/book.epub", filePath, "Book", "Author", "Book", "Author", "epub", 0)
 	if err != nil || !first {
 		t.Fatalf("first recordTorrentItem = inserted %v, err %v", first, err)
 	}
-	second, err := w.recordTorrentItem(torrent, "ebook", "/downloads/book.epub", filePath, "Book", "Author", "Book", "Author", "epub", 0)
+	second, err := w.recordTorrentItem("torrent", torrent, "ebook", "/downloads/book.epub", filePath, "Book", "Author", "Book", "Author", "epub", 0)
 	if err != nil || second {
 		t.Fatalf("second recordTorrentItem = inserted %v, err %v; want idempotent reuse", second, err)
 	}

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -109,6 +109,18 @@ type ActivityEvent struct {
 	Timestamp     time.Time `json:"timestamp"`
 }
 
+// NZBJob tracks an NZB submitted to SABnzbd so the completion watcher can
+// import it with the right media type once SABnzbd finishes. SABnzbd uses a
+// single category, so the media type can't be recovered from its history —
+// it is recorded here at submit time and cleared once imported.
+type NZBJob struct {
+	NzoID     string    `json:"nzo_id"`
+	Title     string    `json:"title"`
+	MediaType string    `json:"media_type"`
+	Imported  bool      `json:"imported"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 // WishlistItem represents a user's wish for a book/audiobook/manga.
 type WishlistItem struct {
 	ID        int64     `json:"id"`

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1341,6 +1341,11 @@ async function startDownload(result) {
       author: result.author || '',
       info_hash: result.info_hash || '',
       magnet: result.magnet || '',
+      // Preserve usenet-vs-torrent routing: Prowlarr proxy download URLs don't
+      // match the backend's NZB URL heuristics, so without this a usenet grab
+      // is misrouted to the torrent client and silently discarded.
+      media_type: result.media_type || '',
+      download_protocol: result.download_protocol || '',
     };
 
     const data = await apiJson('/api/download', {


### PR DESCRIPTION
Fixes the three findings in #89.

**1. UI dropped `download_protocol`.** `startDownload()` now includes `download_protocol` and `media_type` in the POST body. Prowlarr proxy URLs don't match the backend's NZB URL heuristics, so without this a usenet grab was misrouted to the torrent client.

**2. Audiobook grabs bypassed NZB routing.** `handleDownloadAudiobook` (and `handleDownloadTorrent`, same latent bug) now take the `isNZBResult` branch instead of unconditionally calling the torrent client.

**3. Completed SAB downloads were never imported.** The watcher now polls SAB history and imports completed jobs. Since SAB exposes a single category, media type is recorded per `nzo_id` at submit time in a new `nzb_jobs` table; the watcher looks it up, imports into the right library, and marks it done. Failed jobs are dropped from the pending list. The watcher also runs in SAB-only setups (no torrent client).

Local path resolution prefers SAB's reported `storage`, falling back to the media type's incoming dir.

Tests: new coverage for the nzb_jobs DB lifecycle, `importNZB`, path resolution, and the full history-poll path. Full suite + `go vet` pass.