### PR TITLE
Normalize service base URLs missing a scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Open `http://localhost:5050` in your browser.
 
 All configuration is via environment variables. Every variable has a sensible default.
 
+Service URLs (`ABS_URL`, `PROWLARR_URL`, `KAVITA_URL`, …) may be written with or
+without a scheme — `audiobookshelf:13378` is normalized to
+`http://audiobookshelf:13378`, and trailing slashes are trimmed. The same applies
+to URLs saved from the Settings UI. Use `https://` explicitly when the service is
+behind TLS.
+
 ### Server
 
 | Variable | Default | Description |

--- a/internal/api/library_external.go
+++ b/internal/api/library_external.go
@@ -103,7 +103,7 @@ func (s *Server) handleLibraryAudiobooks(w http.ResponseWriter, r *http.Request)
 	client := &http.Client{Timeout: 15 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		slog.Error("ABS library request failed", "error", err)
+		slog.Error("ABS library request failed", "abs_url", s.cfg.ABSURL, "error", err)
 		writeJSON(w, http.StatusBadGateway, map[string]interface{}{
 			"error": "Failed to reach Audiobookshelf",
 		})

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/netutil"
 	"github.com/JeremiahM37/librarr/internal/sources"
 )
@@ -115,6 +116,7 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	if value, ok := data["annas_archive_domain"].(string); ok && value != "" {
 		data["annas_archive_domain"] = sources.NormalizeDomain(value)
 	}
+	normalizeSettingURLs(data)
 
 	// Don't save masked values (user didn't change them).
 	for k := range sensitiveKeys {
@@ -184,6 +186,26 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{"success": true})
+}
+
+// normalizeSettingURLs repairs service base URLs in an incoming settings
+// payload — mainly by adding the "http://" a user leaves off when they type
+// "audiobookshelf:13378" into the Integrations form. Without a scheme every
+// request built from that value dies with `unsupported protocol scheme ""`
+// (issue #92). Normalizing on write means settings.json, the UI and the
+// runtime config all agree; config.Load repairs the env layer separately.
+func normalizeSettingURLs(data map[string]interface{}) {
+	for _, key := range config.BaseURLSettingKeys {
+		v, ok := data[key]
+		if !ok {
+			continue
+		}
+		str, isStr := v.(string)
+		if !isStr {
+			continue
+		}
+		data[key] = config.NormalizeBaseURL(str)
+	}
 }
 
 func (s *Server) loadSettings() map[string]interface{} {

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -216,3 +216,55 @@ func TestGetSettings_MasksSensitiveValues(t *testing.T) {
 		t.Errorf("unset abs_token should be empty string, got %v", got)
 	}
 }
+
+// TestSaveSettings_NormalizesSchemeLessURLs — regression for issue #92. A URL
+// typed without "http://" was persisted verbatim, and every request built from
+// it failed with `unsupported protocol scheme ""` (library page stuck on
+// "Failed to load library", "abs scan failed" in the logs). The save handler
+// now repairs the value, so settings.json and the next GET both show the URL
+// the runtime will actually use.
+func TestSaveSettings_NormalizesSchemeLessURLs(t *testing.T) {
+	s, path := settingsTestServer(t)
+
+	saveSettings(t, s, map[string]interface{}{
+		"abs_url":      "audiobookshelf:13378",
+		"abs_token":    "tok",
+		"kavita_url":   "  kavita:5000/  ",
+		"komga_url":    "https://komga.example.com",
+		"prowlarr_url": "192.168.1.5:9696",
+	})
+
+	saved := readSettingsFile(t, path)
+	for key, want := range map[string]string{
+		"abs_url":      "http://audiobookshelf:13378",
+		"kavita_url":   "http://kavita:5000",
+		"komga_url":    "https://komga.example.com",
+		"prowlarr_url": "http://192.168.1.5:9696",
+	} {
+		if got := saved[key]; got != want {
+			t.Errorf("settings.json %s = %v, want %q", key, got, want)
+		}
+	}
+
+	// Non-URL values must pass through untouched.
+	if got := saved["abs_token"]; got != "tok" {
+		t.Errorf("abs_token = %v, want tok", got)
+	}
+}
+
+// TestSaveSettings_WhitespaceOnlyURLClearsOverride — a field wiped to spaces
+// normalizes to "", which must take the same "delete the override" path as an
+// empty string so the env value reapplies on restart.
+func TestSaveSettings_WhitespaceOnlyURLClearsOverride(t *testing.T) {
+	s, path := settingsTestServer(t)
+
+	saveSettings(t, s, map[string]interface{}{"prowlarr_url": "http://saved:9696"})
+	if got := readSettingsFile(t, path)["prowlarr_url"]; got != "http://saved:9696" {
+		t.Fatalf("setup failed: prowlarr_url = %v", got)
+	}
+
+	saveSettings(t, s, map[string]interface{}{"prowlarr_url": "   "})
+	if _, exists := readSettingsFile(t, path)["prowlarr_url"]; exists {
+		t.Error("whitespace-only URL should delete the override, not persist a value")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,6 +210,7 @@ func Load() *Config {
 	cfg := buildFromEnv()
 	cfg.applySettingsFileOverrides()
 	cfg.AnnasArchiveDomain = sources.NormalizeDomain(cfg.AnnasArchiveDomain)
+	cfg.normalizeServiceURLs()
 	cfg.probeSettingsFileWritable()
 	return cfg
 }

--- a/internal/config/urlnorm.go
+++ b/internal/config/urlnorm.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"regexp"
+	"strings"
+)
+
+// schemeRe matches an explicit URI scheme prefix ("http://", "https://",
+// "unix://", …). A bare "host:port" does NOT match, because there is no "//"
+// after the colon — which is exactly the input we need to repair.
+var schemeRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*://`)
+
+// NormalizeBaseURL cleans a service base URL that came from an env var or the
+// settings file: trims whitespace and trailing slashes, and prepends "http://"
+// when no scheme is present.
+//
+// Issue #92: a scheme-less value such as "audiobookshelf:13378" reaches
+// net/http as a relative URL, so every request against it fails with the
+// opaque `unsupported protocol scheme ""`. The user-visible symptoms are a
+// library page stuck on "Failed to load library" and an "abs scan failed" log
+// line, neither of which points at the URL as the cause. Repairing the value
+// once, at load time, fixes every consumer at once.
+//
+// A non-http scheme is left alone — if someone configures "unix://…" that's
+// their call, and mangling it into "http://unix://…" would be worse than the
+// original error.
+func NormalizeBaseURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	if !schemeRe.MatchString(s) {
+		s = "http://" + s
+	}
+	// Trim trailing slashes so callers can concatenate "/api/..." without
+	// producing a double slash — but never trim into the scheme separator
+	// itself, which would turn "http://" into "http:".
+	scheme := schemeRe.FindString(s)
+	return scheme + strings.TrimRight(s[len(scheme):], "/")
+}
+
+// BaseURLSettingKeys lists the settings.json keys that hold a service base URL
+// — the subset of settings normalizeServiceURLs repairs at load time. The
+// settings API normalizes the same keys on write, so the value the UI shows
+// after a save matches the one the runtime will use.
+var BaseURLSettingKeys = []string{
+	"qb_url",
+	"transmission_url",
+	"prowlarr_url",
+	"sabnzbd_url",
+	"abs_url",
+	"abs_public_url",
+	"kavita_url",
+	"kavita_public_url",
+	"komga_url",
+	"calibre_url",
+	"flibusta_url",
+}
+
+// normalizeServiceURLs runs every configured service base URL through
+// NormalizeBaseURL. Called from Load after both the env layer and the
+// settings-file layer have been applied, so a bad value is repaired no matter
+// which source it came from.
+//
+// Deliberately excluded: WebhookURL and the OIDC endpoints. Those are full
+// endpoint URLs handed to a third party verbatim (a Discord webhook path, an
+// OIDC issuer that must byte-match the provider's discovery document), not
+// base URLs we append paths to.
+func (c *Config) normalizeServiceURLs() {
+	for _, field := range []*string{
+		&c.QBUrl,
+		&c.ProwlarrURL,
+		&c.SABnzbdURL,
+		&c.ABSURL,
+		&c.ABSPublicURL,
+		&c.KavitaURL,
+		&c.KavitaPublicURL,
+		&c.KomgaURL,
+		&c.CalibreURL,
+		&c.DelugeURL,
+		&c.TransmissionURL,
+		&c.FlibustaURL,
+		&c.ZLibraryURL,
+		&c.BookTrackerURL,
+	} {
+		*field = NormalizeBaseURL(*field)
+	}
+}

--- a/internal/config/urlnorm_test.go
+++ b/internal/config/urlnorm_test.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNormalizeBaseURL covers the shapes users actually paste into the
+// Integrations form or an env var.
+//
+// Regression for issue #92: "audiobookshelf:13378" (no scheme) reaches
+// net/http as a relative URL, and every request built from it fails with
+// `unsupported protocol scheme ""`.
+func TestNormalizeBaseURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty stays empty", "", ""},
+		{"whitespace only stays empty", "   ", ""},
+		{"already valid is untouched", "http://abs:13378", "http://abs:13378"},
+		{"https is untouched", "https://abs.example.com", "https://abs.example.com"},
+		{"scheme case preserved", "HTTP://abs:13378", "HTTP://abs:13378"},
+		{"host:port gets http", "audiobookshelf:13378", "http://audiobookshelf:13378"},
+		{"bare host gets http", "audiobookshelf", "http://audiobookshelf"},
+		{"ip:port gets http", "192.168.1.5:13378", "http://192.168.1.5:13378"},
+		{"host with path gets http", "abs.example.com/abs", "http://abs.example.com/abs"},
+		{"surrounding whitespace trimmed", "  http://abs:13378  ", "http://abs:13378"},
+		{"trailing slash trimmed", "http://abs:13378/", "http://abs:13378"},
+		{"repeated trailing slashes trimmed", "http://abs:13378///", "http://abs:13378"},
+		{"trailing slash trimmed after scheme added", "audiobookshelf:13378/", "http://audiobookshelf:13378"},
+		{"subpath keeps its shape", "https://host/abs/", "https://host/abs"},
+		{"non-http scheme left alone", "unix:///var/run/abs.sock", "unix:///var/run/abs.sock"},
+		{"scheme-only input is not truncated", "http://", "http://"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeBaseURL(tc.in); got != tc.want {
+				t.Errorf("NormalizeBaseURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeBaseURL_ProducesUsableRequests is the end-to-end half of the
+// regression: net/http must accept the normalized value. Before the fix, the
+// raw input produced `unsupported protocol scheme ""` at request time.
+func TestNormalizeBaseURL_ProducesUsableRequests(t *testing.T) {
+	for _, raw := range []string{"audiobookshelf:13378", "audiobookshelf", "192.168.1.5:13378"} {
+		t.Run(raw, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, NormalizeBaseURL(raw)+"/api/libraries", nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			if req.URL.Scheme != "http" {
+				t.Errorf("scheme = %q, want http", req.URL.Scheme)
+			}
+			if req.URL.Host == "" {
+				t.Error("host is empty — request would fail with unsupported protocol scheme")
+			}
+		})
+	}
+}
+
+// TestLoad_NormalizesEnvURLs proves the repair reaches the config the app
+// actually runs on, for both config sources (env vars here, settings.json in
+// the next test).
+func TestLoad_NormalizesEnvURLs(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SETTINGS_FILE", filepath.Join(dir, "settings.json"))
+	t.Setenv("ABS_URL", "audiobookshelf:13378")
+	t.Setenv("ABS_PUBLIC_URL", "abs.example.com/")
+	t.Setenv("PROWLARR_URL", "prowlarr:9696")
+	t.Setenv("QB_URL", "  qbittorrent:8080  ")
+	t.Setenv("KAVITA_URL", "https://kavita.example.com")
+
+	cfg := Load()
+
+	for _, tc := range []struct {
+		field string
+		got   string
+		want  string
+	}{
+		{"ABSURL", cfg.ABSURL, "http://audiobookshelf:13378"},
+		{"ABSPublicURL", cfg.ABSPublicURL, "http://abs.example.com"},
+		{"ProwlarrURL", cfg.ProwlarrURL, "http://prowlarr:9696"},
+		{"QBUrl", cfg.QBUrl, "http://qbittorrent:8080"},
+		{"KavitaURL", cfg.KavitaURL, "https://kavita.example.com"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.field, tc.got, tc.want)
+		}
+	}
+}
+
+// TestLoad_NormalizesSettingsFileURLs is the path the issue reporter hit:
+// the URL was typed into the UI, so it arrives via settings.json rather than
+// an env var. Every key in BaseURLSettingKeys is exercised, which also guards
+// against the list drifting away from normalizeServiceURLs.
+func TestLoad_NormalizesSettingsFileURLs(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	// Scheme-less value for every base-URL key the settings file supports.
+	body := `{
+	  "qb_url": "qbittorrent:8080",
+	  "transmission_url": "transmission:9091",
+	  "prowlarr_url": "prowlarr:9696",
+	  "sabnzbd_url": "sabnzbd:8080",
+	  "abs_url": "audiobookshelf:13378",
+	  "abs_public_url": "abs.example.com",
+	  "kavita_url": "kavita:5000",
+	  "kavita_public_url": "kavita.example.com",
+	  "komga_url": "komga:25600",
+	  "calibre_url": "calibre-web:8083",
+	  "flibusta_url": "flibusta.is"
+	}`
+	if err := os.WriteFile(settingsPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SETTINGS_FILE", settingsPath)
+
+	cfg := Load()
+
+	got := map[string]string{
+		"qb_url":            cfg.QBUrl,
+		"transmission_url":  cfg.TransmissionURL,
+		"prowlarr_url":      cfg.ProwlarrURL,
+		"sabnzbd_url":       cfg.SABnzbdURL,
+		"abs_url":           cfg.ABSURL,
+		"abs_public_url":    cfg.ABSPublicURL,
+		"kavita_url":        cfg.KavitaURL,
+		"kavita_public_url": cfg.KavitaPublicURL,
+		"komga_url":         cfg.KomgaURL,
+		"calibre_url":       cfg.CalibreURL,
+		"flibusta_url":      cfg.FlibustaURL,
+	}
+
+	for _, key := range BaseURLSettingKeys {
+		value, ok := got[key]
+		if !ok {
+			t.Fatalf("BaseURLSettingKeys contains %q but this test does not assert on it — "+
+				"add the matching Config field so the list can't drift", key)
+		}
+		if !strings.HasPrefix(value, "http://") {
+			t.Errorf("%s = %q, want an http:// prefix", key, value)
+		}
+	}
+}

--- a/internal/organize/targets.go
+++ b/internal/organize/targets.go
@@ -143,7 +143,10 @@ func (lt *LibraryTargets) absLibraryScan(libraryID string) {
 
 	resp, err := lt.client.Do(req)
 	if err != nil {
-		slog.Error("abs scan failed", "library_id", libraryID, "error", err)
+		// Include the configured base URL: the most common cause of a
+		// failure here is a malformed ABS_URL, and the bare net/http error
+		// ("unsupported protocol scheme") never says which URL it came from.
+		slog.Error("abs scan failed", "library_id", libraryID, "abs_url", lt.cfg.ABSURL, "error", err)
 		return
 	}
 	defer resp.Body.Close()

--- a/internal/organize/targets_test.go
+++ b/internal/organize/targets_test.go
@@ -1,0 +1,98 @@
+package organize
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+)
+
+// TestMain silences slog — the guard tests deliberately exercise paths that
+// log, and that noise is not a failure.
+func TestMain(m *testing.M) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	os.Exit(m.Run())
+}
+
+// TestImportAudiobook_TriggersScanWithSchemeLessConfiguredURL is the
+// end-to-end regression for issue #92: an ABS URL configured without a scheme
+// (typed as "audiobookshelf:13378" in the UI, or set that way in ABS_URL) made
+// every scan die with `unsupported protocol scheme ""`, so nothing ever
+// imported. config.Load must hand organize a URL net/http can dial.
+func TestImportAudiobook_TriggersScanWithSchemeLessConfiguredURL(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		hits   []string
+		auth   string
+		method string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits = append(hits, r.URL.Path)
+		auth = r.Header.Get("Authorization")
+		method = r.Method
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Strip the scheme the test server hands us — this is exactly the value
+	// the issue reporter had configured.
+	schemeLess := strings.TrimPrefix(srv.URL, "http://")
+
+	dir := t.TempDir()
+	t.Setenv("SETTINGS_FILE", filepath.Join(dir, "settings.json"))
+	t.Setenv("ABS_URL", schemeLess)
+	t.Setenv("ABS_TOKEN", "test-token")
+	t.Setenv("ABS_LIBRARY_ID", "lib-1")
+
+	cfg := config.Load()
+	if cfg.ABSURL != srv.URL {
+		t.Fatalf("config.Load left ABSURL = %q, want %q", cfg.ABSURL, srv.URL)
+	}
+
+	NewLibraryTargets(cfg).ImportAudiobook()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 request to ABS, got %d: %v", len(hits), hits)
+	}
+	if hits[0] != "/api/libraries/lib-1/scan" {
+		t.Errorf("path = %q, want /api/libraries/lib-1/scan", hits[0])
+	}
+	if method != http.MethodPost {
+		t.Errorf("method = %q, want POST", method)
+	}
+	if auth != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want Bearer test-token", auth)
+	}
+}
+
+// TestImportAudiobook_SkipsWhenUnconfigured — no ABS config must mean no
+// outbound request at all, rather than a request to a relative URL.
+func TestImportAudiobook_SkipsWhenUnconfigured(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{"no url or token", &config.Config{ABSLibraryID: "lib-1"}},
+		{"url but no token", &config.Config{ABSURL: "http://abs:13378", ABSLibraryID: "lib-1"}},
+		{"configured but no library id", &config.Config{ABSURL: "http://abs:13378", ABSToken: "t"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A nil http.Client would panic if a request were attempted, which
+			// is the assertion: the guards must return before that.
+			lt := &LibraryTargets{cfg: tc.cfg}
+			lt.ImportAudiobook()
+		})
+	}
+}


### PR DESCRIPTION
Fixes #92.

A service URL configured without `http://` (e.g. `audiobookshelf:13378`) reaches `net/http` as a relative URL, so every request built from it fails with `unsupported protocol scheme ""` — the library page shows "Failed to load library" and imports log `abs scan failed`.

`config.Load` now normalizes every service base URL (trim whitespace and trailing slashes, prepend `http://` when no scheme is present), covering both env vars and `settings.json`. The settings API normalizes the same keys on write so the saved value matches what the runtime uses. Non-http schemes are left alone. ABS failure logs now include the configured URL.

**Verified** against a stub Audiobookshelf with `ABS_URL=localhost` (no scheme):

| | `/api/library/audiobooks` | log |
|---|---|---|
| before | `502 Failed to reach Audiobookshelf` | `unsupported protocol scheme ""` |
| after | `200` + the item | — |

**Tests** — 5 new tests, each confirmed to fail without the fix: `NormalizeBaseURL` table cases, `Load` normalization from env and from `settings.json` (covers every key, guarding against list drift), settings-save normalization, and an end-to-end `ImportAudiobook` scan against an `httptest` server configured with a scheme-less URL. Full suite green (`go test ./... -race`, integration, staticcheck, vet, 10/10 e2e).