### PR TITLE
Surface Anna's Archive edition metadata and fix Open Library series matching

### DIFF
--- a/e2e/test_user_journey.py
+++ b/e2e/test_user_journey.py
@@ -220,3 +220,92 @@ def test_language_toggle_rerenders(ui):
     assert before != after, "language toggle changed nothing"
     page.click('[data-action="toggleLanguage"]')  # restore EN for later tests
     page.wait_for_timeout(300)
+
+
+# ── Edition metadata on result cards (issue #94) ────────────────────────────
+
+def test_language_badge_comes_from_real_source_metadata(searched):
+    """The stub declares languages:["en"] on every book, so the language badge
+    must reach the card through the real Gutenberg parser and API response —
+    not just through the renderer."""
+    page = searched["page"]
+    badges = page.locator(".result-language")
+    assert badges.count() == 3, f"expected a language badge per card, got {badges.count()}"
+    assert badges.first.inner_text().strip().lower() == "en"
+
+
+def _render_card(page, result):
+    """Render one result through the shipped renderer and return its badge row."""
+    page.evaluate(
+        "r => { document.getElementById('search-results').innerHTML = renderBookCard(r, 0); }",
+        result,
+    )
+    return page
+
+
+def test_edition_metadata_badges_render(ui):
+    """An Anna's Archive hit now carries language, year and publisher; all three
+    have to reach the card, because they are what tells near-identical rows
+    apart."""
+    page = _render_card(ui["page"], {
+        "source": "annas",
+        "title": "The Mark of Athena",
+        "author": "Rick Riordan",
+        "size_human": "1.2MB",
+        "format": "epub",
+        "language": "en",
+        "year": "2012",
+        "publisher": "Hyperion Book CH",
+        "md5": "3e8184fac9f9d2413af8260dbf240ac9",
+    })
+    assert page.locator(".result-language").inner_text().strip().lower() == "en"
+    assert page.locator(".result-year").inner_text().strip() == "2012"
+    assert page.locator(".result-publisher").inner_text().strip() == "Hyperion Book CH"
+    # The publisher is truncated by CSS, so the full imprint lives in the tooltip.
+    assert page.locator(".result-publisher").get_attribute("title") == "Hyperion Book CH"
+    assert page.locator(".result-copies").count() == 0, "single copy must not show a count"
+
+
+def test_missing_metadata_renders_no_empty_badges(ui):
+    """Sources that report none of this must not leak 'undefined' into the row."""
+    page = _render_card(ui["page"], {
+        "source": "prowlarr",
+        "title": "Some Torrent Release",
+        "size_human": "700MB",
+        "seeders": 12,
+    })
+    for cls in (".result-language", ".result-year", ".result-publisher", ".result-copies"):
+        assert page.locator(cls).count() == 0, f"{cls} rendered without data"
+    assert "undefined" not in page.inner_text(".book-card")
+
+
+def test_copies_badge_reports_collapsed_duplicates(ui):
+    page = _render_card(ui["page"], {
+        "source": "annas",
+        "title": "The Mark of Athena",
+        "size_human": "1.3MB",
+        "format": "epub",
+        "copies": 3,
+        "md5": "aaa",
+    })
+    badge = page.locator(".result-copies")
+    assert badge.count() == 1
+    assert "3" in badge.inner_text()
+    assert "3" in badge.get_attribute("title")
+
+
+def test_metadata_badges_escape_hostile_values(ui):
+    """These fields are scraped from a third-party page, so they are untrusted
+    input on a strict-CSP page. They must be escaped, not executed."""
+    page = _render_card(ui["page"], {
+        "source": "annas",
+        "title": "Injection Probe",
+        "publisher": '<img src=x onerror="window.__pwned=1">',
+        "year": '"><script>window.__pwned=1</script>',
+        "language": "en",
+        "md5": "bbb",
+    })
+    page.wait_for_timeout(300)
+    assert page.evaluate("() => window.__pwned") is None, "metadata badge executed injected markup"
+    assert page.locator("#search-results img").count() == 0
+    assert "<img" in page.locator(".result-publisher").inner_text()

--- a/internal/metadata/match.go
+++ b/internal/metadata/match.go
@@ -1,0 +1,163 @@
+package metadata
+
+import (
+	"math"
+	"regexp"
+	"strings"
+)
+
+// Open Library's relevance ranking regularly places an omnibus above the volume
+// that was actually searched for — `title=Catching Fire` returns "The Hunger
+// Games Trilogy (Hunger Games / Catching Fire / Mockingjay)" ahead of "Catching
+// Fire". Taking docs[0] therefore captions a single-volume search with a box
+// set's cover, year and page count. pickBestDoc re-ranks the candidates so the
+// volume wins, while leaving Open Library's own ordering as the tiebreak.
+
+var (
+	olWordRe = regexp.MustCompile(`\p{L}+|\d+`)
+
+	// Titles that describe a bundle rather than a single volume. The book-range
+	// alternative catches "Books I-III" and "Books 1 - 3" style spines.
+	olCollectionRe = regexp.MustCompile(`(?i)\b(box(ed)?[ -]?sets?|boxsets?|omnibus|collections?|complete series|complete works|anthology|trilogy|quartet|quintet|tetralogy|bind[ -]?up|\d+\s+books?\b|books?\s+[ivxlcdm\d]+\s*[-–—/]\s*[ivxlcdm\d]+)`)
+)
+
+var olStopwords = map[string]bool{
+	"the": true, "a": true, "an": true, "of": true, "and": true, "in": true,
+	"on": true, "to": true, "for": true, "or": true, "by": true,
+}
+
+// olNumerals folds spelled-out and Roman volume numbers onto digits so a
+// "Book Three" record matches a "book 3" query. Roman numerals shorter than two
+// characters are deliberately absent: mapping a bare "I" would rewrite titles
+// like "I Am Legend".
+var olNumerals = map[string]string{
+	"one": "1", "two": "2", "three": "3", "four": "4", "five": "5",
+	"six": "6", "seven": "7", "eight": "8", "nine": "9", "ten": "10",
+	"eleven": "11", "twelve": "12",
+	"ii": "2", "iii": "3", "iv": "4", "v": "5", "vi": "6", "vii": "7",
+	"viii": "8", "ix": "9", "x": "10", "xi": "11", "xii": "12",
+}
+
+// olTitleWords reduces a title to comparable tokens: lowercased, punctuation
+// dropped, stopwords removed, volume numbers normalised to digits.
+func olTitleWords(title string) []string {
+	var words []string
+	for _, w := range olWordRe.FindAllString(strings.ToLower(title), -1) {
+		if olStopwords[w] {
+			continue
+		}
+		if n, ok := olNumerals[w]; ok {
+			w = n
+		}
+		words = append(words, w)
+	}
+	return words
+}
+
+func olWordSet(words []string) map[string]bool {
+	set := make(map[string]bool, len(words))
+	for _, w := range words {
+		set[w] = true
+	}
+	return set
+}
+
+func olSameWords(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for w := range a {
+		if !b[w] {
+			return false
+		}
+	}
+	return true
+}
+
+// olAuthorMatches reports whether any of a record's authors looks like the one
+// the caller asked for. Open Library lists adaptors and illustrators alongside
+// the author, so a hit on any entry counts.
+func olAuthorMatches(names []string, author string) bool {
+	want := strings.ToLower(strings.TrimSpace(author))
+	if want == "" {
+		return false
+	}
+	for _, n := range names {
+		got := strings.ToLower(strings.TrimSpace(n))
+		if got == "" {
+			continue
+		}
+		if strings.Contains(got, want) || strings.Contains(want, got) {
+			return true
+		}
+	}
+	return false
+}
+
+// scoreOLDoc rates one candidate against the query. The weights encode a simple
+// preference order: cover every word of the query, add nothing the query didn't
+// ask for, and don't be a box set.
+func scoreOLDoc(query string, queryWords []string, querySet map[string]bool, author string, doc olSearchDoc, index int) float64 {
+	docWords := olTitleWords(doc.Title)
+	if len(docWords) == 0 {
+		return math.Inf(-1)
+	}
+	docSet := olWordSet(docWords)
+
+	hits := 0
+	for w := range querySet {
+		if docSet[w] {
+			hits++
+		}
+	}
+	score := 60 * float64(hits) / float64(len(querySet))
+
+	// Same word set means the titles differ only in punctuation or articles.
+	if olSameWords(querySet, docSet) {
+		score += 40
+	}
+
+	// Every word the query didn't ask for dilutes the match — an omnibus title
+	// names all of its volumes, so this alone separates most of them out.
+	extra := 0
+	for w := range docSet {
+		if !querySet[w] {
+			extra++
+		}
+	}
+	score -= math.Min(float64(extra), 12) * 3
+
+	// ...and an explicit bundle marker settles the rest, unless the caller was
+	// actually looking for the bundle.
+	if olCollectionRe.MatchString(doc.Title) && !olCollectionRe.MatchString(query) {
+		score -= 50
+	}
+
+	if olAuthorMatches(doc.AuthorName, author) {
+		score += 20
+	}
+
+	// Preserve Open Library's ranking between otherwise equal candidates.
+	return score - 0.5*float64(index)
+}
+
+// pickBestDoc chooses the record that best matches the queried title, falling
+// back to Open Library's first result when the query carries no usable words.
+func pickBestDoc(query, author string, docs []olSearchDoc) *olSearchDoc {
+	if len(docs) == 0 {
+		return nil
+	}
+	queryWords := olTitleWords(query)
+	if len(queryWords) == 0 {
+		return &docs[0]
+	}
+	querySet := olWordSet(queryWords)
+
+	bestIdx, bestScore := 0, math.Inf(-1)
+	for i := range docs {
+		if s := scoreOLDoc(query, queryWords, querySet, author, docs[i], i); s > bestScore {
+			bestIdx, bestScore = i, s
+		}
+	}
+	return &docs[bestIdx]
+}

--- a/internal/metadata/match_test.go
+++ b/internal/metadata/match_test.go
@@ -1,0 +1,181 @@
+package metadata
+
+import "testing"
+
+func docs(titles ...string) []olSearchDoc {
+	out := make([]olSearchDoc, 0, len(titles))
+	for _, t := range titles {
+		out = append(out, olSearchDoc{Title: t, Key: "/works/" + t})
+	}
+	return out
+}
+
+func TestPickBestDoc(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  string
+		author string
+		docs   []olSearchDoc
+		want   string
+	}{
+		{
+			// The regression this function exists for: on 2026-08-06 the live
+			// API ranked the trilogy first for title=Catching Fire.
+			name:  "single volume beats the omnibus that outranks it",
+			query: "Catching Fire",
+			docs: docs(
+				"The Hunger Games Trilogy (Hunger Games / Catching Fire / Mockingjay)",
+				"Hunger Games, catching fire",
+				"Catching fire",
+			),
+			want: "Catching fire",
+		},
+		{
+			name:  "box set loses to the volume",
+			query: "The Mark of Athena",
+			docs: docs(
+				"Heroes of Olympus Complete Collection 5 Books Box Set -The Lost Hero/The Son of Neptune/The Mark of Athena",
+				"The Mark of Athena",
+			),
+			want: "The Mark of Athena",
+		},
+		{
+			name:  "book-range spine loses to the volume",
+			query: "A Storm of Swords",
+			docs: docs(
+				"A Song of Ice and Fire, Books I-III",
+				"A Storm of Swords",
+			),
+			want: "A Storm of Swords",
+		},
+		{
+			name:  "spelled-out volume number matches a digit query",
+			query: "Heroes of Olympus Book 3",
+			docs: docs(
+				"Heroes of Olympus Series, 4 Books Collection Set",
+				"Heroes of Olympus, Book Three: The Mark of Athena",
+			),
+			want: "Heroes of Olympus, Book Three: The Mark of Athena",
+		},
+		{
+			// Penalising bundles must not make bundles unfindable.
+			name:  "a collection query still gets the collection",
+			query: "The Hunger Games Trilogy",
+			docs: docs(
+				"Catching Fire",
+				"The Hunger Games Trilogy",
+			),
+			want: "The Hunger Games Trilogy",
+		},
+		{
+			name:  "articles and punctuation do not matter",
+			query: "Two Towers",
+			docs: docs(
+				"The Lord of the Rings: The Two Towers, The Return of the King",
+				"The Two Towers",
+			),
+			want: "The Two Towers",
+		},
+		{
+			// Nothing better to pick — Open Library's own ranking stands.
+			name:  "falls back to the first result when all are equally bad",
+			query: "Something Entirely Unrelated",
+			docs:  docs("A Wholly Different Book", "Another Different Book"),
+			want:  "A Wholly Different Book",
+		},
+		{
+			name:  "query with no usable words keeps Open Library order",
+			query: "The",
+			docs:  docs("The Trial", "The Castle"),
+			want:  "The Trial",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pickBestDoc(tt.query, tt.author, tt.docs)
+			if got == nil {
+				t.Fatalf("pickBestDoc(%q) = nil, want %q", tt.query, tt.want)
+			}
+			if got.Title != tt.want {
+				t.Errorf("pickBestDoc(%q) = %q, want %q", tt.query, got.Title, tt.want)
+			}
+		})
+	}
+}
+
+func TestPickBestDoc_AuthorTiebreakPicksTheRightRecord(t *testing.T) {
+	// Same title twice: only the author field can separate them, so assert on
+	// the record rather than the title.
+	got := pickBestDoc("The Two Towers", "J.R.R. Tolkien", []olSearchDoc{
+		{Title: "The Two Towers", AuthorName: []string{"Some Abridger"}},
+		{Title: "The Two Towers", AuthorName: []string{"J.R.R. Tolkien"}},
+	})
+	if got == nil || len(got.AuthorName) == 0 || got.AuthorName[0] != "J.R.R. Tolkien" {
+		t.Fatalf("pickBestDoc picked %+v, want the Tolkien record", got)
+	}
+}
+
+func TestPickBestDoc_Empty(t *testing.T) {
+	if got := pickBestDoc("anything", "", nil); got != nil {
+		t.Errorf("pickBestDoc(nil docs) = %+v, want nil", got)
+	}
+}
+
+func TestOLTitleWords(t *testing.T) {
+	tests := []struct {
+		title string
+		want  []string
+	}{
+		{"The Mark of Athena", []string{"mark", "athena"}},
+		{"Heroes of Olympus, Book Three", []string{"heroes", "olympus", "book", "3"}},
+		{"Books I-III", []string{"books", "i", "3"}}, // bare "I" is left alone on purpose
+		{"", nil},
+		{"The", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			got := olTitleWords(tt.title)
+			if len(got) != len(tt.want) {
+				t.Fatalf("olTitleWords(%q) = %v, want %v", tt.title, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("olTitleWords(%q) = %v, want %v", tt.title, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestOLCollectionRe(t *testing.T) {
+	bundles := []string{
+		"The Hunger Games Trilogy",
+		"Heroes of Olympus Complete Collection 5 Books Box Set",
+		"A Song of Ice and Fire, Books I-III",
+		"The Chronicles of Narnia Boxed Set",
+		"Discworld Omnibus",
+		"The Heroes of Olympus Paperback 3-Book Boxed Set",
+		"Foundation: Books 1 - 3",
+	}
+	for _, title := range bundles {
+		if !olCollectionRe.MatchString(title) {
+			t.Errorf("olCollectionRe did not match bundle title %q", title)
+		}
+	}
+
+	volumes := []string{
+		"The Mark of Athena",
+		"Catching Fire",
+		"Harry Potter and the Chamber of Secrets",
+		"The Two Towers",
+		"A Storm of Swords",
+		"The Collector", // "collection" must not match by prefix
+	}
+	for _, title := range volumes {
+		if olCollectionRe.MatchString(title) {
+			t.Errorf("olCollectionRe wrongly matched single volume %q", title)
+		}
+	}
+}

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -138,7 +138,9 @@ func (c *Client) searchOL(ctx context.Context, title, author string) (*olSearchD
 		q.Set("author", author)
 	}
 	q.Set("fields", "key,title,author_name,first_publish_year,cover_i,isbn,publisher,language,number_of_pages_median")
-	q.Set("limit", "3")
+	// Wider than strictly needed: the volume a series query is after is often
+	// ranked below one or more box sets, and pickBestDoc has to be able to see it.
+	q.Set("limit", "10")
 	req.URL.RawQuery = q.Encode()
 	req.Header.Set("User-Agent", "Librarr/2.0 (book download manager; github.com/JeremiahM37/librarr)")
 
@@ -156,11 +158,7 @@ func (c *Client) searchOL(ctx context.Context, title, author string) (*olSearchD
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return nil, err
 	}
-	if len(data.Docs) == 0 {
-		return nil, nil
-	}
-
-	return &data.Docs[0], nil
+	return pickBestDoc(title, author, data.Docs), nil
 }
 
 // enrichFromWork fetches the Works API for description and series info.

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -25,6 +25,18 @@ type SearchResult struct {
 	MediaType        string `json:"media_type,omitempty"`        // ebook, audiobook, manga
 	DownloadProtocol string `json:"download_protocol,omitempty"` // "torrent" or "nzb"
 
+	// Edition metadata, filled in by sources that publish it (Anna's Archive,
+	// Gutenberg). Language is an ISO 639 code ("en", "ru") so the UI can render
+	// it compactly; Year is a string because "not reported" and "year 0" are
+	// different things.
+	Language  string `json:"language,omitempty"`
+	Publisher string `json:"publisher,omitempty"`
+	Year      string `json:"year,omitempty"`
+
+	// Copies counts how many results collapsed into this one because they were
+	// identical apart from their content hash. Zero or one means nothing merged.
+	Copies int `json:"copies,omitempty"`
+
 	// Scoring fields (populated by scorer).
 	Score          float64         `json:"score,omitempty"`
 	ScoreBreakdown *ScoreBreakdown `json:"score_breakdown,omitempty"`

--- a/internal/search/annas.go
+++ b/internal/search/annas.go
@@ -17,6 +17,127 @@ import (
 
 var annasMetadataFormatRe = regexp.MustCompile(`(?i)·\s*([a-z0-9]+)\s*·`)
 
+// Anna's Archive prints one interpunct-separated metadata line per result card:
+//
+//	English [en] · EPUB · 1.2MB · 2012 · 📕 Book (fiction) · 🚀/lgli/zlib
+//
+// The segments are not positional — a card may omit the year, the language, or
+// both — so each one is classified independently and unrecognised segments
+// (content type, mirror list, the trailing "Save" control) are ignored.
+var (
+	annasLangRe = regexp.MustCompile(`^[\p{L} ()'.-]+\[([a-zA-Z]{2,3}(?:-[a-zA-Z]{2,4})?)\]$`)
+	annasSizeRe = regexp.MustCompile(`(?i)^\d+(?:\.\d+)?\s*(?:[KMGT]i?)?B$`)
+	annasYearRe = regexp.MustCompile(`^[12]\d{3}$`)
+	// Trailing "[Riordan, Rick]" style inverted-name duplicates on author links.
+	annasAuthorAltRe = regexp.MustCompile(`\s*\[[^\]]*\]\s*$`)
+)
+
+// annasFormats lists the file extensions Anna's Archive reports in the metadata
+// line. Anything else in that position is treated as unknown rather than
+// guessed at, so a stray segment never masquerades as a format.
+var annasFormats = map[string]bool{
+	"epub": true, "pdf": true, "mobi": true, "azw": true, "azw3": true,
+	"djvu": true, "fb2": true, "cbz": true, "cbr": true, "txt": true,
+	"rtf": true, "doc": true, "docx": true, "lit": true, "zip": true,
+	"m4b": true, "m4a": true, "mp3": true, "opf": true,
+}
+
+// annasCardMeta is the subset of an Anna's Archive card that librarr surfaces.
+type annasCardMeta struct {
+	Language string
+	Format   string
+	Size     string
+	Year     string
+}
+
+// parseAnnasMetaLine classifies each interpunct-separated segment of a card's
+// metadata line by shape, so segment order and optional fields don't matter.
+func parseAnnasMetaLine(line string) annasCardMeta {
+	var meta annasCardMeta
+	for _, seg := range strings.Split(line, "·") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		switch {
+		case meta.Language == "" && annasLangRe.MatchString(seg):
+			meta.Language = strings.ToLower(annasLangRe.FindStringSubmatch(seg)[1])
+		case meta.Size == "" && annasSizeRe.MatchString(seg):
+			meta.Size = seg
+		case meta.Year == "" && annasYearRe.MatchString(seg):
+			meta.Year = seg
+		case meta.Format == "" && annasFormats[strings.ToLower(seg)]:
+			meta.Format = strings.ToLower(seg)
+		}
+	}
+	return meta
+}
+
+// annasMetaLineText finds a card's metadata line. The line lives in a
+// `font-semibold … leading-[1.2]` div that sits next to the title link, but
+// Anna's markup churns, so the search is by shape: the shortest descendant div
+// carrying interpuncts. Scripts are stripped first — goquery's Text() would
+// otherwise splice the card's inline JS into the line.
+func annasMetaLineText(link *goquery.Selection) string {
+	best := ""
+	consider := func(sel *goquery.Selection) {
+		clone := sel.Clone()
+		clone.Find("script, style").Remove()
+		text := strings.TrimSpace(clone.Text())
+		if !strings.Contains(text, "·") {
+			return
+		}
+		if best == "" || len(text) < len(best) {
+			best = text
+		}
+	}
+
+	// Some layouts nest the metadata inside the title link itself.
+	link.Find("div").Each(func(_ int, sel *goquery.Selection) { consider(sel) })
+	if best != "" {
+		return best
+	}
+	link.Closest("div.flex").Find("div").Each(func(_ int, sel *goquery.Selection) { consider(sel) })
+	return best
+}
+
+// annasPublisherImprint reduces the publisher link's full citation to just the
+// imprint. Anna's crams series, city, distributor and date into that one link:
+//
+//	"Hyperion Book CH, The Heroes of Olympus, Book Three, New York, USA, 2012"
+//	"Disney Book Group : Made available through hoopla"
+//
+// so the imprint is whatever precedes the first separator. An over-long result
+// means the shape wasn't what we expected — drop it rather than show noise.
+func annasPublisherImprint(citation string) string {
+	cut := len(citation)
+	for _, sep := range []string{",", " : ", ";"} {
+		if idx := strings.Index(citation, sep); idx > 0 && idx < cut {
+			cut = idx
+		}
+	}
+	imprint := strings.TrimSpace(citation[:cut])
+	if len(imprint) > 80 {
+		return ""
+	}
+	return imprint
+}
+
+// annasCardLink returns the text of the sibling link marked with the given
+// Material Design icon class — Anna's tags the author link with
+// `mdi--user-edit` and the publisher link with `mdi--company`.
+func annasCardLink(link *goquery.Selection, iconClass string) string {
+	matches := link.Closest("div.flex").Find("a").FilterFunction(func(_ int, a *goquery.Selection) bool {
+		return a.Find("span[class*='"+iconClass+"']").Length() > 0
+	})
+	// Exactly one, or the enclosing div.flex wasn't this card's — showing a
+	// neighbouring book's author would be worse than showing none.
+	if matches.Length() != 1 {
+		return ""
+	}
+	return strings.TrimSpace(matches.First().Text())
+}
+
 // AnnasArchive searches Anna's Archive by scraping HTML results.
 type AnnasArchive struct {
 	cfg    *config.Config
@@ -134,17 +255,23 @@ func (a *AnnasArchive) doSearch(ctx context.Context, query, ext string, seenMD5 
 		}
 		seenMD5[md5] = true
 
-		// Match with metadata size by index (they appear in the same order as results).
-		sizeHuman := ""
-		if resultIdx < len(metadataSizes) {
+		meta := parseAnnasMetaLine(annasMetaLineText(s))
+
+		// Prefer the size printed on this card; fall back to positional matching
+		// against the sizes scraped from the page as a whole.
+		sizeHuman := meta.Size
+		if sizeHuman == "" && resultIdx < len(metadataSizes) {
 			sizeHuman = metadataSizes[resultIdx]
 		}
-		format := ext
-		metadataText := s.Closest("div.flex").Find("div.font-semibold").Last().Text()
-		if match := annasMetadataFormatRe.FindStringSubmatch(metadataText); len(match) > 1 {
-			format = strings.ToLower(match[1])
-		} else if format == "" {
-			format = extractFormatFromTitle(title)
+		format := meta.Format
+		if format == "" {
+			format = ext
+			metadataText := s.Closest("div.flex").Find("div.font-semibold").Last().Text()
+			if match := annasMetadataFormatRe.FindStringSubmatch(metadataText); len(match) > 1 {
+				format = strings.ToLower(match[1])
+			} else if format == "" {
+				format = extractFormatFromTitle(title)
+			}
 		}
 		resultIdx++
 
@@ -157,6 +284,16 @@ func (a *AnnasArchive) doSearch(ctx context.Context, query, ext string, seenMD5 
 				title = strings.TrimSpace(title[idx+3:])
 			}
 		}
+		// That pattern only fires on a minority of titles; the card's own author
+		// link is the reliable source when it doesn't.
+		if author == "" {
+			author = annasAuthorAltRe.ReplaceAllString(annasCardLink(s, "mdi--user-edit"), "")
+			if len(author) > 120 {
+				author = ""
+			}
+		}
+
+		publisher := annasPublisherImprint(annasCardLink(s, "mdi--company"))
 
 		results = append(results, models.SearchResult{
 			Source:    "annas",
@@ -164,6 +301,9 @@ func (a *AnnasArchive) doSearch(ctx context.Context, query, ext string, seenMD5 
 			Author:    author,
 			SizeHuman: sizeHuman,
 			Format:    format,
+			Language:  meta.Language,
+			Publisher: publisher,
+			Year:      meta.Year,
 			MD5:       md5,
 			URL:       fmt.Sprintf("https://%s/md5/%s", a.cfg.AnnasArchiveDomain, md5),
 		})

--- a/internal/search/annas_test.go
+++ b/internal/search/annas_test.go
@@ -209,3 +209,256 @@ func TestParseSizeBytes_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+// annasCardHTML mirrors the markup annas-archive.gl actually serves for one
+// search hit: a cover link, a title link, icon-tagged author/publisher links, a
+// description, and the interpunct metadata line — inline <script> included,
+// because that script is what breaks a naive .Text() read of the line.
+func annasCardHTML(md5, title, author, publisher, metaLine string) string {
+	return `
+	<div class="flex pt-3 pb-3 border-b last:border-b-0 border-gray-100">
+	  <a href="/md5/` + md5 + `" class="custom-a block mr-2 sm:mr-4 hover:opacity-80">
+	    <div class="w-20 h-[7.5rem] rounded shadow relative overflow-hidden text-left">
+	      <img src="https://example.invalid/cover.jpg" alt=""/>
+	    </div>
+	  </a>
+	  <div class="max-w-full overflow-hidden flex flex-col justify-around">
+	    <div>
+	      <div class="line-clamp-[2] text-[9px] text-gray-500 font-mono">lgli/` + author + ` - ` + title + `.epub</div>
+	      <a href="/md5/` + md5 + `" class="js-vim-focus custom-a font-semibold text-lg leading-[1.2]">` + title + `</a>
+	      <a href="/search?q=x" class="custom-a text-sm leading-[1.2]"><span class="icon-[mdi--user-edit] text-base align-sub"></span> ` + author + `</a>
+	      <a href="/search?q=y" class="custom-a text-sm leading-[1.2]"><span class="icon-[mdi--company] text-base align-sub"></span> ` + publisher + `</a>
+	    </div>
+	    <div>
+	      <div class="text-sm text-gray-600 mt-2 mb-2 leading-[1.3]">In The Son of Neptune, Percy and Frank met at Camp Jupiter.</div>
+	    </div>
+	    <div class="text-gray-800 font-semibold text-sm leading-[1.2] mt-2">` + metaLine + ` · <a href="#" class="custom-a font-semibold text-sm">Save<script>var aarecord_id = "md5:` + md5 + `";</script></a></div>
+	  </div>
+	</div>`
+}
+
+func TestParseAnnasMetaLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want annasCardMeta
+	}{
+		{
+			name: "full line",
+			line: "English [en] · EPUB · 1.2MB · 2012 · 📕 Book (fiction) · 🚀/lgli/zlib",
+			want: annasCardMeta{Language: "en", Format: "epub", Size: "1.2MB", Year: "2012"},
+		},
+		{
+			name: "no year",
+			line: "German [de] · PDF · 12.4MB · 📕 Book (fiction)",
+			want: annasCardMeta{Language: "de", Format: "pdf", Size: "12.4MB"},
+		},
+		{
+			name: "no language",
+			line: "AZW3 · 900KB · 1998",
+			want: annasCardMeta{Format: "azw3", Size: "900KB", Year: "1998"},
+		},
+		{
+			name: "multiword language name",
+			line: "Chinese (Simplified) [zh] · EPUB · 3.0MB",
+			want: annasCardMeta{Language: "zh", Format: "epub", Size: "3.0MB"},
+		},
+		{
+			name: "segments in an unexpected order",
+			line: "2012 · 4.5MiB · epub · Spanish [es]",
+			want: annasCardMeta{Language: "es", Format: "epub", Size: "4.5MiB", Year: "2012"},
+		},
+		{
+			name: "content type is not mistaken for a format",
+			line: "English [en] · 1.1MB · 📗 Book (unknown)",
+			want: annasCardMeta{Language: "en", Size: "1.1MB"},
+		},
+		{
+			name: "page counts and ids are not mistaken for years",
+			line: "English [en] · EPUB · 2.0MB · 9781423140672",
+			want: annasCardMeta{Language: "en", Format: "epub", Size: "2.0MB"},
+		},
+		{
+			name: "empty",
+			line: "",
+			want: annasCardMeta{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseAnnasMetaLine(tt.line); got != tt.want {
+				t.Errorf("parseAnnasMetaLine(%q) = %+v, want %+v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnnasPublisherImprint(t *testing.T) {
+	tests := []struct {
+		citation string
+		want     string
+	}{
+		{"Hyperion Book CH, The Heroes of Olympus, Book Three, New York, USA, 2012", "Hyperion Book CH"},
+		{"Disney Book Group : Made available through hoopla", "Disney Book Group"},
+		{"Thorndike Press;Disney Hyperion", "Thorndike Press"},
+		{"Penguin Books", "Penguin Books"},
+		{"", ""},
+		{strings.Repeat("x", 200), ""}, // not a citation shape — drop rather than show noise
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.citation, func(t *testing.T) {
+			if got := annasPublisherImprint(tt.citation); got != tt.want {
+				t.Errorf("annasPublisherImprint(%q) = %q, want %q", tt.citation, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnnasArchive_SurfacesCardMetadata(t *testing.T) {
+	htmlContent := "<html><body>" +
+		annasCardHTML(
+			"3e8184fac9f9d2413af8260dbf240ac9",
+			"The Mark of Athena",
+			"Rick Riordan [Riordan, Rick]",
+			"Hyperion Book CH, The Heroes of Olympus, Book Three, New York, USA, October 2, 2012",
+			"English [en] · EPUB · 1.2MB · 2012 · 📕 Book (fiction)",
+		) +
+		annasCardHTML(
+			"e90a8c3dcdb0a30eb61b0b9b0c686502",
+			"Das Zeichen der Athene",
+			"Rick Riordan",
+			"Carlsen Verlag GmbH",
+			"German [de] · EPUB · 0.7MB",
+		) +
+		"</body></html>"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(htmlContent))
+	}))
+	defer server.Close()
+
+	a := &AnnasArchive{
+		cfg:    &config.Config{AnnasArchiveDomain: "annas-archive.gl", UserAgent: "test"},
+		client: &http.Client{Transport: &rewriteTransport{serverURL: server.URL}},
+	}
+
+	results, err := a.doSearch(context.Background(), "mark of athena", "epub", make(map[string]bool))
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+
+	got := results[0]
+	if got.Title != "The Mark of Athena" {
+		t.Errorf("Title = %q, want %q", got.Title, "The Mark of Athena")
+	}
+	// The "Last, First" alias Anna's appends to the author link is noise.
+	if got.Author != "Rick Riordan" {
+		t.Errorf("Author = %q, want %q", got.Author, "Rick Riordan")
+	}
+	if got.Language != "en" {
+		t.Errorf("Language = %q, want %q", got.Language, "en")
+	}
+	if got.Year != "2012" {
+		t.Errorf("Year = %q, want %q", got.Year, "2012")
+	}
+	if got.Publisher != "Hyperion Book CH" {
+		t.Errorf("Publisher = %q, want %q", got.Publisher, "Hyperion Book CH")
+	}
+	if got.SizeHuman != "1.2MB" {
+		t.Errorf("SizeHuman = %q, want %q", got.SizeHuman, "1.2MB")
+	}
+	if got.Format != "epub" {
+		t.Errorf("Format = %q, want %q", got.Format, "epub")
+	}
+
+	if results[1].Language != "de" {
+		t.Errorf("second result Language = %q, want %q", results[1].Language, "de")
+	}
+	if results[1].Publisher != "Carlsen Verlag GmbH" {
+		t.Errorf("second result Publisher = %q, want %q", results[1].Publisher, "Carlsen Verlag GmbH")
+	}
+	// This card carries no year; nothing should be invented for it.
+	if results[1].Year != "" {
+		t.Errorf("second result Year = %q, want empty", results[1].Year)
+	}
+}
+
+func TestAnnasArchive_TitlePatternAuthorStillWins(t *testing.T) {
+	// The legacy "Last, First - Title" heuristic must keep working on cards that
+	// carry no author link at all.
+	htmlContent := `<html><body>
+		<div class="flex">
+			<a href="/md5/abc123def456789012345678901234ab">Fitzgerald, F. Scott - The Great Gatsby</a>
+			<div class="font-semibold leading-[1.2]">English [en] · EPUB · 1.5MB · 1925</div>
+		</div>
+	</body></html>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(htmlContent))
+	}))
+	defer server.Close()
+
+	a := &AnnasArchive{
+		cfg:    &config.Config{AnnasArchiveDomain: "annas-archive.gl", UserAgent: "test"},
+		client: &http.Client{Transport: &rewriteTransport{serverURL: server.URL}},
+	}
+	results, err := a.doSearch(context.Background(), "gatsby", "epub", make(map[string]bool))
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].Author != "Fitzgerald, F. Scott" {
+		t.Errorf("Author = %q, want %q", results[0].Author, "Fitzgerald, F. Scott")
+	}
+	if results[0].Title != "The Great Gatsby" {
+		t.Errorf("Title = %q, want %q", results[0].Title, "The Great Gatsby")
+	}
+	if results[0].Language != "en" || results[0].Year != "1925" || results[0].SizeHuman != "1.5MB" {
+		t.Errorf("metadata = {lang:%q year:%q size:%q}, want {en 1925 1.5MB}",
+			results[0].Language, results[0].Year, results[0].SizeHuman)
+	}
+}
+
+func TestAnnasCardLink_IgnoresAmbiguousContainers(t *testing.T) {
+	// If Anna's markup ever changes such that Closest("div.flex") lands on a
+	// container holding several cards, the author links become ambiguous.
+	// Reporting nothing is correct; reporting a neighbouring book's author is not.
+	htmlContent := `<html><body>
+		<div class="flex">
+			<a href="/md5/11111111111111111111111111111111">Book One</a>
+			<a href="/search?q=a"><span class="icon-[mdi--user-edit]"></span> Author One</a>
+			<a href="/md5/22222222222222222222222222222222">Book Two</a>
+			<a href="/search?q=b"><span class="icon-[mdi--user-edit]"></span> Author Two</a>
+		</div>
+	</body></html>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(htmlContent))
+	}))
+	defer server.Close()
+
+	a := &AnnasArchive{
+		cfg:    &config.Config{AnnasArchiveDomain: "annas-archive.gl", UserAgent: "test"},
+		client: &http.Client{Transport: &rewriteTransport{serverURL: server.URL}},
+	}
+	results, err := a.doSearch(context.Background(), "book", "epub", make(map[string]bool))
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	for i, r := range results {
+		if r.Author != "" {
+			t.Errorf("results[%d].Author = %q, want empty for an ambiguous container", i, r.Author)
+		}
+	}
+}

--- a/internal/search/dedupe_test.go
+++ b/internal/search/dedupe_test.go
@@ -1,0 +1,127 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+func TestCollapseDuplicateCopies(t *testing.T) {
+	annas := func(md5, title, size string) models.SearchResult {
+		return models.SearchResult{
+			Source: "annas", Title: title, Author: "Rick Riordan",
+			Publisher: "Disney Hyperion", Format: "epub", Language: "en",
+			Year: "2012", SizeHuman: size, MD5: md5,
+		}
+	}
+
+	t.Run("rows differing only by hash merge into one", func(t *testing.T) {
+		got := CollapseDuplicateCopies([]models.SearchResult{
+			annas("aaa", "The Mark of Athena", "1.3MB"),
+			annas("bbb", "The Mark of Athena", "1.3MB"),
+			annas("ccc", "The Mark of Athena", "1.3MB"),
+		})
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		if got[0].Copies != 3 {
+			t.Errorf("Copies = %d, want 3", got[0].Copies)
+		}
+		if got[0].MD5 != "aaa" {
+			t.Errorf("survivor MD5 = %q, want the first (best-scoring) one", got[0].MD5)
+		}
+	})
+
+	t.Run("a different size is a different book to the reader", func(t *testing.T) {
+		// The whole point of showing size: 1.3MB is the single volume, 9.1MB is
+		// the omnibus. Merging them would hide the one the user wanted.
+		got := CollapseDuplicateCopies([]models.SearchResult{
+			annas("aaa", "The Mark of Athena", "1.3MB"),
+			annas("bbb", "The Mark of Athena", "9.1MB"),
+		})
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+	})
+
+	t.Run("every displayed field keeps rows apart", func(t *testing.T) {
+		base := annas("aaa", "The Mark of Athena", "1.3MB")
+		variants := map[string]func(models.SearchResult) models.SearchResult{
+			"title":     func(r models.SearchResult) models.SearchResult { r.Title = "The House of Hades"; return r },
+			"author":    func(r models.SearchResult) models.SearchResult { r.Author = "Someone Else"; return r },
+			"publisher": func(r models.SearchResult) models.SearchResult { r.Publisher = "Thorndike Press"; return r },
+			"format":    func(r models.SearchResult) models.SearchResult { r.Format = "pdf"; return r },
+			"language":  func(r models.SearchResult) models.SearchResult { r.Language = "de"; return r },
+			"year":      func(r models.SearchResult) models.SearchResult { r.Year = "2014"; return r },
+			"source":    func(r models.SearchResult) models.SearchResult { r.Source = "zlibrary"; return r },
+			"mediatype": func(r models.SearchResult) models.SearchResult { r.MediaType = "audiobook"; return r },
+		}
+		for name, mutate := range variants {
+			t.Run(name, func(t *testing.T) {
+				other := mutate(base)
+				other.MD5 = "bbb"
+				if got := CollapseDuplicateCopies([]models.SearchResult{base, other}); len(got) != 2 {
+					t.Errorf("differing %s merged: len = %d, want 2", name, len(got))
+				}
+			})
+		}
+	})
+
+	t.Run("punctuation and casing do not keep copies apart", func(t *testing.T) {
+		a := annas("aaa", "The Mark of Athena", "1.3MB")
+		b := annas("bbb", "the mark of athena!", "1.3 MB")
+		if got := CollapseDuplicateCopies([]models.SearchResult{a, b}); len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+	})
+
+	t.Run("hashless results are never merged", func(t *testing.T) {
+		// Two torrent rows for one release differ by seeders and indexer, which
+		// the key does not cover — so they must pass through untouched.
+		torrent := models.SearchResult{
+			Source: "prowlarr", Title: "The Mark of Athena", Format: "epub",
+			SizeHuman: "1.3MB", Seeders: 12, Indexer: "Indexer A",
+		}
+		other := torrent
+		other.Seeders = 3
+		other.Indexer = "Indexer B"
+		got := CollapseDuplicateCopies([]models.SearchResult{torrent, other})
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+		if got[0].Copies != 0 || got[1].Copies != 0 {
+			t.Errorf("Copies set on unmerged rows: %d, %d", got[0].Copies, got[1].Copies)
+		}
+	})
+
+	t.Run("order and singletons are preserved", func(t *testing.T) {
+		in := []models.SearchResult{
+			annas("aaa", "First", "1MB"),
+			annas("bbb", "Second", "2MB"),
+			annas("ccc", "First", "1MB"),
+			annas("ddd", "Third", "3MB"),
+		}
+		got := CollapseDuplicateCopies(in)
+		want := []string{"First", "Second", "Third"}
+		if len(got) != len(want) {
+			t.Fatalf("len = %d, want %d", len(got), len(want))
+		}
+		for i, title := range want {
+			if got[i].Title != title {
+				t.Errorf("got[%d].Title = %q, want %q", i, got[i].Title, title)
+			}
+		}
+		if got[0].Copies != 2 {
+			t.Errorf("First Copies = %d, want 2", got[0].Copies)
+		}
+		if got[1].Copies != 0 {
+			t.Errorf("Second Copies = %d, want 0 (nothing merged)", got[1].Copies)
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		if got := CollapseDuplicateCopies(nil); len(got) != 0 {
+			t.Errorf("len = %d, want 0", len(got))
+		}
+	})
+}

--- a/internal/search/gutenberg.go
+++ b/internal/search/gutenberg.go
@@ -78,6 +78,11 @@ func (g *Gutenberg) Search(ctx context.Context, query string) ([]models.SearchRe
 
 		coverURL, _ := book.Formats["image/jpeg"]
 
+		language := ""
+		if len(book.Languages) > 0 {
+			language = strings.ToLower(book.Languages[0])
+		}
+
 		results = append(results, models.SearchResult{
 			Source:        "gutenberg",
 			Title:         book.Title,
@@ -87,6 +92,7 @@ func (g *Gutenberg) Search(ctx context.Context, query string) ([]models.SearchRe
 			EpubURL:       epubURL,
 			Format:        "epub",
 			CoverURL:      coverURL,
+			Language:      language,
 			SizeHuman:     "Public Domain",
 			DownloadCount: book.DownloadCount,
 		})
@@ -103,6 +109,7 @@ type gutendexBook struct {
 	ID            int               `json:"id"`
 	Title         string            `json:"title"`
 	Authors       []gutendexAuthor  `json:"authors"`
+	Languages     []string          `json:"languages"`
 	Formats       map[string]string `json:"formats"`
 	DownloadCount int               `json:"download_count"`
 }

--- a/internal/search/gutenberg_test.go
+++ b/internal/search/gutenberg_test.go
@@ -132,3 +132,42 @@ func TestGutenberg_SearchHTTPError(t *testing.T) {
 		t.Errorf("unexpected name: %s", g.Name())
 	}
 }
+
+func TestGutenberg_PopulatesLanguage(t *testing.T) {
+	response := gutendexResponse{
+		Results: []gutendexBook{
+			{
+				ID:        1342,
+				Title:     "Pride and Prejudice",
+				Languages: []string{"EN"},
+				Formats:   map[string]string{"application/epub+zip": "https://example.invalid/1342.epub"},
+			},
+			{
+				ID:      84,
+				Title:   "Frankenstein",
+				Formats: map[string]string{"application/epub+zip": "https://example.invalid/84.epub"},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	cfg := configWithRegistry(t)
+	cfg.Sources.Gutenberg.URL = server.URL
+	results, err := NewGutenberg(cfg, server.Client()).Search(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if results[0].Language != "en" {
+		t.Errorf("Language = %q, want %q (normalised to lower case)", results[0].Language, "en")
+	}
+	if results[1].Language != "" {
+		t.Errorf("Language = %q, want empty when gutendex reports none", results[1].Language)
+	}
+}

--- a/internal/search/searcher.go
+++ b/internal/search/searcher.go
@@ -231,7 +231,60 @@ func (m *Manager) processResults(results []models.SearchResult, query, author st
 			}
 		}
 	}
-	return results
+	// After sorting, so the copy that survives a merge is the best-scoring one.
+	return CollapseDuplicateCopies(results)
+}
+
+// CollapseDuplicateCopies merges results that match on everything the UI shows
+// and differ only by content hash. Anna's Archive lists the same upload under
+// several MD5s, which fills the result grid with rows a user has no way to tell
+// apart. Only hashed results are considered: two torrent rows for one release
+// legitimately differ by seeders and indexer, so those are left alone.
+//
+// The key deliberately covers every displayed field, size and publisher
+// included — a 1MB single volume and a 9MB omnibus of the same title are
+// different books to the reader, and must not be folded together. The survivor
+// keeps its rank and records how many rows it now stands for.
+func CollapseDuplicateCopies(results []models.SearchResult) []models.SearchResult {
+	out := make([]models.SearchResult, 0, len(results))
+	seen := make(map[string]int, len(results))
+
+	for _, r := range results {
+		if r.MD5 == "" {
+			out = append(out, r)
+			continue
+		}
+		key := strings.Join([]string{
+			r.Source,
+			normalizeForDedupe(r.Title),
+			normalizeForDedupe(r.Author),
+			normalizeForDedupe(r.Publisher),
+			strings.ToLower(r.Format),
+			strings.ToLower(r.Language),
+			r.Year,
+			// Sizes are compared with spacing removed rather than word-split,
+			// so "1.3 MB" and "1.3MB" match without "1.3MB" and "13MB" doing so.
+			strings.ToLower(strings.Join(strings.Fields(r.SizeHuman), "")),
+			r.MediaType,
+		}, "\x00")
+
+		if i, ok := seen[key]; ok {
+			if out[i].Copies == 0 {
+				out[i].Copies = 1
+			}
+			out[i].Copies++
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, r)
+	}
+	return out
+}
+
+// normalizeForDedupe reduces a field to its words so that punctuation, casing
+// and spacing differences don't keep two otherwise identical rows apart.
+func normalizeForDedupe(s string) string {
+	return strings.Join(wordRe.FindAllString(strings.ToLower(s), -1), " ")
 }
 
 // GetSources returns all registered sources.

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -69,6 +69,8 @@ const I18N = {
     search_failed: 'Search failed: {msg}',
     n_seeds: '{n} seed',
     n_leech: '{n} leech',
+    n_copies: '{n} copies',
+    n_copies_title: '{n} identical copies, differing only by file hash',
     // Library
     library_filter_placeholder: 'Filter library...',
     library_empty: 'Your library is empty',
@@ -270,6 +272,8 @@ const I18N = {
     search_failed: 'Ошибка поиска: {msg}',
     n_seeds: '{n} сид.',
     n_leech: '{n} лич.',
+    n_copies: '{n} копий',
+    n_copies_title: '{n} одинаковых копий, различаются только хешем файла',
     // Library
     library_filter_placeholder: 'Фильтр библиотеки...',
     library_empty: 'Ваша библиотека пуста',
@@ -1174,6 +1178,15 @@ function renderBookCard(result, index) {
   const size = sizeText ? `<span class="text-slate-400 text-xs font-medium">${escapeHtml(sizeText)}</span>` : '';
   const format = result.format ? `<span class="text-slate-500 text-xs uppercase">${escapeHtml(result.format)}</span>` : '';
   const indexer = result.indexer ? `<span class="text-slate-600 text-xs">${escapeHtml(result.indexer)}</span>` : '';
+  // Edition metadata — what separates otherwise identical-looking hits.
+  const language = result.language ? `<span class="result-language text-sky-400 text-xs uppercase font-medium">${escapeHtml(result.language)}</span>` : '';
+  const year = result.year ? `<span class="result-year text-slate-500 text-xs">${escapeHtml(result.year)}</span>` : '';
+  const publisher = result.publisher
+    ? `<span class="result-publisher text-slate-500 text-xs truncate max-w-[10rem]" title="${escapeHtml(result.publisher)}">${escapeHtml(result.publisher)}</span>`
+    : '';
+  const copies = result.copies > 1
+    ? `<span class="result-copies text-slate-500 text-xs" title="${escapeHtml(t('n_copies_title', {n: result.copies}))}">${escapeHtml(t('n_copies', {n: result.copies}))}</span>`
+    : '';
 
   const buttonState = (isDownloading || isTrackedAnnaDownload || isTrackedDirectDownload) ? 'loading' : (downloadOutcome ? downloadOutcome.status : 'idle');
   const buttonStyles = {
@@ -1208,7 +1221,7 @@ function renderBookCard(result, index) {
         <h3 class="text-sm font-semibold text-white line-clamp-2 mb-1" title="${escapeHtml(result.title || '')}">${escapeHtml(result.title || 'Unknown')}</h3>
         <p class="text-xs text-slate-400 mb-2 line-clamp-1">${escapeHtml(result.author || '')}</p>
         <div class="flex items-center gap-2 flex-wrap mt-auto mb-2">
-          ${seeders}${leechers}${size}${format}${indexer}
+          ${seeders}${leechers}${size}${format}${language}${year}${publisher}${indexer}${copies}
         </div>
         <button
           data-action="startDownload" data-idx="${index}"


### PR DESCRIPTION
Fixes #94.

## What was wrong

**Anna's Archive metadata was being thrown away.** Every AA result card carries a metadata line — `English [en] · EPUB · 1.2MB · 2012 · 📕 Book (fiction)` — plus icon-tagged author and publisher links. The scraper read only format and size out of it, so rows for the same book looked identical even when they were different editions. Author was filled only for the minority of titles shaped `Last, First - Title`.

**Open Library's ranking was trusted blindly.** `searchOL` returned `docs[0]`. Against the live API today, `title=Catching Fire` returns:

```
1. The Hunger Games Trilogy (Hunger Games / Catching Fire / Mockingjay)
2. Hunger Games, catching fire
3. Catching fire
```

so the header above a single-volume search showed a box set's cover, year and page count.

## What changed

**Anna's Archive parsing** (`internal/search/annas.go`) — the metadata line is now split on interpuncts and each segment classified *by shape* rather than by position, because cards omit the year, the language, or both. Unrecognised segments (content type, mirror list, the trailing `Save` control) are ignored, and inline `<script>` is stripped before reading text — `goquery`'s `Text()` otherwise splices the card's JS into the line. Author falls back to the card's `mdi--user-edit` link when the title pattern doesn't fire; publisher comes from the `mdi--company` link, reduced from its full citation to the imprint.

Replaying a live `annas-archive.gl` page for "mark of athena" through the new parser:

| field | before | after |
|---|---|---|
| language | — | 45/50 |
| year | — | 50/50 |
| publisher | — | 45/50 |
| author | 0/50 | 45/50 |
| size | 50/50 (positional) | 50/50 (per-card) |

Size now comes off the card itself rather than being index-matched against a page-wide regex sweep, so one desynchronised card can no longer shift every subsequent row's size. The positional path is kept as a fallback.

**Open Library matching** (`internal/metadata/match.go`) — candidates are scored instead of taken in order: reward covering every query word, penalise words the query didn't ask for, penalise explicit bundle markers (`box set`, `omnibus`, `trilogy`, `5 Books`, `Books I-III`, …) unless the query itself is asking for a bundle, and fold spelled-out and Roman volume numbers onto digits so "Book Three" matches "book 3". Open Library's own ordering remains the tiebreak, and the search limit went 3 → 10 so the right volume is reachable. Checked against 15 live queries: the box-set pick is fixed, the trilogy query still gets its trilogy, and **no previously correct pick changed**.

**Duplicate collapsing** (`internal/search/searcher.go`) — results identical in every displayed field and differing only by MD5 now merge into one row carrying a copy count. The key deliberately includes size *and* publisher: a 1.3 MB single volume and a 9 MB omnibus of the same title are different books, and must not fold together. Only hashed results participate, so two torrent rows that legitimately differ by seeders or indexer are untouched. On the live page above this took 50 rows to 44.

**UI** (`web/static/js/app.js`) — language, year, publisher and copy count render next to size and format, with `en`/`ru` strings. Gutenberg also reports a language, so it now populates the same field.

Badge row now reads e.g. `8.1MB · EPUB · EN · 2014 · Disney Book Group`.

## Testing

- **Unit** — `parseAnnasMetaLine` table tests (reordered segments, missing year/language, content-type and ISBN segments that must *not* be read as format or year); a full-card fixture mirroring real AA markup including the inline script; the ambiguous-container guard; `pickBestDoc` including the `Catching Fire` regression; `CollapseDuplicateCopies` including a case asserting differing sizes never merge.
- **e2e (Playwright, real Chromium + real binary)** — 5 new tests: the language badge arriving through the real Gutenberg parser and API response; badge rendering; no empty badges when a source reports nothing; the copy count; and escaping of hostile publisher/year values, since these are scraped from a third-party page onto a strict-CSP page. All 5 were confirmed to fail with the change reverted.
- **Full local CI equivalent** — `gofmt` clean, `go vet` clean, `staticcheck` clean, `go test ./... -race` 13/13 packages ok, integration tag suite ok, all 6 fuzz targets 15s each ok, `pytest e2e/` **15 passed**.
- **Live sanity check** — booted the binary against the real Anna's Archive and Open Library and drove the UI in a browser: 40 results, 37 with a language badge, 39 with year and publisher, 3 collapsed pairs showing "2 copies", and the Open Library header resolving to *The Mark of Athena* rather than a collection set.

## Deliberately not addressed

Issue #94 notes that release profiles don't filter `/api/search`, so omnibus packs still appear in interactive results. That's left alone here — filtering interactive search is a behaviour change beyond surfacing metadata, and with language, size, year and publisher now visible, packs are at least easy to spot. Happy to do it as a follow-up.

`govulncheck` wasn't run locally (the installed binary is built against go1.24 and refuses this go1.25 module); CI installs a current one.