### PR TITLE
Detect books already in the library before downloading them

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Librarr searches all configured indexers in parallel, scores results by confiden
 - **Quality profiles** -- define format ranking and preferred attributes, auto-upgrade existing downloads
 - **Release profiles** -- preferred and excluded words for fine-grained filtering
 - **Blocklist** -- failed downloads are auto-blocked to prevent retries; manual entries supported
+- **Already-in-library detection** -- results you already own are flagged with `in_library` / `library_item_id` and badged in the UI; matching normalizes punctuation, author prefixes and parenthetical alternate titles, so `Agatha Christie - 4.50 From Paddington` finds `4:50 from Paddington`
 
 ### Download Management
 
@@ -375,6 +376,9 @@ Legacy per-source env vars (e.g. `PROWLARR_URL` and other per-driver overrides) 
 | GET | `/api/search/audiobooks?q=` | Search audiobooks |
 | GET | `/api/search/manga?q=` | Search manga |
 
+Every result carries `in_library` (always present), plus `library_item_id` and
+`library_title` when the book is already in your library.
+
 ### Downloads
 
 | Method | Path | Description |
@@ -388,6 +392,11 @@ Legacy per-source env vars (e.g. `PROWLARR_URL` and other per-driver overrides) 
 | DELETE | `/api/downloads/novel/{jobID}` | Remove a novel download job |
 | POST | `/api/downloads/clear` | Clear finished downloads |
 | POST | `/api/downloads/jobs/{id}/retry` | Retry a failed download |
+
+All four download endpoints refuse a book that is already in your library with
+`409 Conflict` and `{"code": "already_in_library", "library_item_id": N}`. Set
+`"force": true` on the request to download it anyway (a different edition, a
+different format); that is what the UI's **Download anyway** button sends.
 
 ### Library
 

--- a/e2e/test_library_ownership.py
+++ b/e2e/test_library_ownership.py
@@ -1,0 +1,200 @@
+"""End-to-end coverage for "already in library" detection (issue #96).
+
+Runs the real binary + real Chromium against the stubbed Gutenberg source (see
+conftest.py). The journey is the one from the issue, in reverse: download a
+book for real, then go back to search and confirm the app now knows you own it
+— in the API response, on the card, and in the server's refusal to fetch it a
+second time.
+"""
+import time
+
+import pytest
+
+OWNED_TITLE = "Adventure of the Test Case"
+
+
+def _search(page, query):
+    page.click('[data-action="switchTab"][data-arg="search"]')
+    page.fill("#search-input", query)
+    page.press("#search-input", "Enter")
+    page.wait_for_selector('[data-action="startDownload"]', timeout=30000)
+
+
+def _result_by_title(page, title):
+    return page.evaluate(
+        "t => (state.renderedResults || []).find(r => r.title === t) || null", title)
+
+
+def _library_titles(page):
+    data = page.evaluate("() => fetch('/api/library?limit=200').then(r => r.json())")
+    items = data.get("items") or data.get("library") or []
+    return [i.get("title", "") for i in items]
+
+
+@pytest.fixture()
+def owned(ui):
+    """Downloads OWNED_TITLE for real and yields once it is in the library.
+
+    The app fixture is session-scoped, so after the first test this is a
+    library lookup that finds the book already there.
+    """
+    page = ui["page"]
+    _search(page, OWNED_TITLE)
+
+    if OWNED_TITLE not in _library_titles(page):
+        idx = page.evaluate(
+            "t => (state.renderedResults || []).findIndex(r => r.title === t)", OWNED_TITLE)
+        assert idx >= 0, f"{OWNED_TITLE!r} not among the stub results"
+        page.click(f'[data-action="startDownload"][data-idx="{idx}"]')
+
+        deadline = time.time() + 90
+        while time.time() < deadline:
+            if OWNED_TITLE in _library_titles(page):
+                break
+            time.sleep(2)  # gentle poll — 1/s trips the API rate limiter
+        else:
+            pytest.fail(f"{OWNED_TITLE!r} never landed in the library")
+
+    return ui
+
+
+def test_search_reports_ownership_in_the_api_response(owned):
+    """The fields the issue asked for, on the real /api/search response."""
+    page = owned["page"]
+    data = page.evaluate(
+        "q => fetch('/api/search?q=' + encodeURIComponent(q)).then(r => r.json())",
+        OWNED_TITLE)
+    results = data.get("results") or []
+    assert results, "search returned nothing"
+
+    owned_results = [r for r in results if r["title"] == OWNED_TITLE]
+    assert owned_results, f"{OWNED_TITLE!r} missing from search results"
+    for r in owned_results:
+        assert r.get("in_library") is True, f"owned book not flagged: {r}"
+        assert r.get("library_item_id"), f"no library_item_id on an owned result: {r}"
+
+    for r in results:
+        # The flag must always be present, so a client can tell "not owned"
+        # from "this build does not report ownership".
+        assert "in_library" in r, f"in_library missing from result: {r}"
+        if r["title"] != OWNED_TITLE:
+            assert r["in_library"] is False, f"unowned book flagged as owned: {r}"
+            assert "library_item_id" not in r
+
+
+def test_card_shows_the_in_library_badge_and_download_anyway(owned):
+    page = owned["page"]
+    _search(page, OWNED_TITLE)
+
+    card = page.locator(".book-card", has=page.locator(f'h3[title="{OWNED_TITLE}"]'))
+    assert card.count() == 1, f"expected one card for {OWNED_TITLE!r}, got {card.count()}"
+    assert card.locator(".result-in-library").count() == 1, "owned card has no badge"
+    assert "In Library" in card.locator(".result-in-library").inner_text()
+    assert OWNED_TITLE in card.locator(".result-in-library").get_attribute("title")
+    assert "anyway" in card.locator('[data-action="startDownload"]').inner_text().lower()
+
+    # Books the user does not own keep the plain Download button and no badge.
+    others = page.locator(".book-card").count() - 1
+    assert page.locator(".result-in-library").count() == 1, \
+        f"badge leaked onto {others} unowned cards"
+
+
+def test_download_of_an_owned_book_is_refused_by_the_server(owned):
+    """The core of the issue: the API itself must stop the duplicate, not the
+    UI. Posted directly, exactly as a script or third-party client would."""
+    page = owned["page"]
+    result = _result_by_title(page, OWNED_TITLE)
+    assert result, "owned result missing from the rendered list"
+
+    resp = page.evaluate(
+        """r => fetch('/api/download', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                title: r.title, author: r.author || '', source: r.source,
+                download_url: r.download_url || r.url || '',
+            }),
+        }).then(async res => ({status: res.status, body: await res.json()}))""",
+        result)
+
+    assert resp["status"] == 409, f"duplicate download was accepted: {resp}"
+    body = resp["body"]
+    assert body["success"] is False
+    assert body["in_library"] is True
+    assert body["code"] == "already_in_library"
+    assert body["library_item_id"] > 0
+    assert body["library_title"] == OWNED_TITLE
+
+    # And nothing was queued behind that refusal.
+    jobs = page.evaluate("() => fetch('/api/downloads').then(r => r.json())")
+    running = [j for j in (jobs.get("downloads") or [])
+               if j.get("title") == OWNED_TITLE and j.get("status") not in ("completed",)]
+    assert not running, f"the refused download still started a job: {running}"
+
+
+def test_author_prefixed_result_title_still_matches(owned):
+    """Sources publish "Author - Title"; the library row holds only the title.
+    This is the normalization case from the issue, checked against the real
+    matcher through the real endpoint."""
+    page = owned["page"]
+    resp = page.evaluate(
+        """t => fetch('/api/download', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                title: 'Carol Coder - ' + t + ' (Illustrated Edition)',
+                author: 'Carol Coder', source: 'annas',
+                download_url: 'http://127.0.0.1:1/nope.epub',
+            }),
+        }).then(async res => ({status: res.status, body: await res.json()}))""",
+        OWNED_TITLE)
+    assert resp["status"] == 409, f"decorated title slipped past the check: {resp}"
+    assert resp["body"]["library_title"] == OWNED_TITLE
+
+
+def test_download_anyway_overrides_the_check(owned):
+    """The block must not be a dead end — a second edition is a real want."""
+    page = owned["page"]
+    result = _result_by_title(page, OWNED_TITLE)
+
+    resp = page.evaluate(
+        """r => fetch('/api/download', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                title: r.title, author: r.author || '', source: r.source,
+                download_url: r.download_url || r.url || '', force: true,
+            }),
+        }).then(async res => ({status: res.status, body: await res.json()}))""",
+        result)
+
+    assert resp["status"] != 409, f"force was ignored: {resp}"
+    assert resp["body"].get("code") != "already_in_library"
+
+    # The UI's owned button is what sends that flag.
+    _search(page, OWNED_TITLE)
+    sends_force = page.evaluate(
+        "() => (state.renderedResults || []).some(r => r.in_library === true)")
+    assert sends_force, "no rendered result is flagged, so nothing would send force"
+
+
+def test_unowned_book_downloads_without_a_prompt(owned):
+    """Ownership detection must not get in the way of a normal grab."""
+    page = owned["page"]
+    _search(page, "test adventure")
+    unowned = page.evaluate(
+        "t => (state.renderedResults || []).find(r => !r.in_library && r.title !== t) || null",
+        OWNED_TITLE)
+    assert unowned, "no unowned stub book left to check"
+
+    resp = page.evaluate(
+        """r => fetch('/api/download', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                title: r.title, author: r.author || '', source: r.source,
+                download_url: r.download_url || r.url || '',
+            }),
+        }).then(async res => ({status: res.status, body: await res.json()}))""",
+        unowned)
+    assert resp["status"] != 409, f"an unowned book was blocked: {resp}"

--- a/e2e/test_user_journey.py
+++ b/e2e/test_user_journey.py
@@ -309,3 +309,17 @@ def test_metadata_badges_escape_hostile_values(ui):
     assert page.evaluate("() => window.__pwned") is None, "metadata badge executed injected markup"
     assert page.locator("#search-results img").count() == 0
     assert "<img" in page.locator(".result-publisher").inner_text()
+
+
+def test_quotes_in_metadata_do_not_truncate_tooltips(ui):
+    """Escaping via textContent leaves quotes intact, which would close a
+    title="..." attribute early and silently drop the rest of the tooltip."""
+    publisher = 'The "Best" Books Ltd.'
+    page = _render_card(ui["page"], {
+        "source": "annas",
+        "title": 'A "Quoted" Title',
+        "publisher": publisher,
+        "md5": "ccc",
+    })
+    assert page.locator(".result-publisher").get_attribute("title") == publisher
+    assert page.locator(".book-card h3").get_attribute("title") == 'A "Quoted" Title'

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -73,7 +73,39 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// rejectIfInLibrary blocks a download whose title and author already exist in
+// the library, and reports whether it wrote the response.
+//
+// This lives on the server rather than in the UI on purpose: the API is used
+// directly by scripts, the OPDS/Torznab clients and third-party tooling, so a
+// frontend-only check would not actually stop duplicate grabs. Setting
+// "force": true on the request is the documented override, used by the
+// "Download anyway" button for people who do want another edition.
+func (s *Server) rejectIfInLibrary(w http.ResponseWriter, req models.DownloadRequest) bool {
+	if req.Force {
+		return false
+	}
+	match, ok := s.libraryIndex().Lookup(req.Title, req.Author, req.MediaType)
+	if !ok {
+		return false
+	}
+	slog.Info("download blocked, already in library",
+		"title", req.Title, "library_item_id", match.ID, "library_title", match.Title)
+	writeJSON(w, http.StatusConflict, map[string]interface{}{
+		"success":         false,
+		"error":           "Already in library",
+		"code":            "already_in_library",
+		"in_library":      true,
+		"library_item_id": match.ID,
+		"library_title":   match.Title,
+	})
+	return true
+}
+
 func (s *Server) handleTorrentDownload(w http.ResponseWriter, r *http.Request, req models.DownloadRequest) {
+	if s.rejectIfInLibrary(w, req) {
+		return
+	}
 	if !s.cfg.HasTorrentClient() {
 		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
 			"success": false,
@@ -140,6 +172,10 @@ func (s *Server) handleTorrentDownload(w http.ResponseWriter, r *http.Request, r
 }
 
 func (s *Server) handleDirectDownloadReq(w http.ResponseWriter, req models.DownloadRequest) {
+	if s.rejectIfInLibrary(w, req) {
+		return
+	}
+
 	// Anna's Archive download.
 	if req.MD5 != "" {
 		if !validateMD5(req.MD5) {
@@ -454,6 +490,9 @@ func isNZBResult(req models.DownloadRequest) bool {
 }
 
 func (s *Server) handleNZBDownload(w http.ResponseWriter, req models.DownloadRequest) {
+	if s.rejectIfInLibrary(w, req) {
+		return
+	}
 	if !s.cfg.HasSABnzbd() {
 		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
 			"success": false,

--- a/internal/api/ownership.go
+++ b/internal/api/ownership.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"log/slog"
+
+	"github.com/JeremiahM37/librarr/internal/library"
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+// mediaTypeForTab maps a search tab to the media type its results import as.
+// Most sources leave media_type empty on the ebook tab, so the tab is the only
+// thing that says which shelf a hit belongs to.
+func mediaTypeForTab(tab string) string {
+	switch tab {
+	case "audiobook", "manga":
+		return tab
+	default:
+		return "ebook"
+	}
+}
+
+// libraryIndex builds the ownership index for one request. A failure here must
+// not fail the search: an empty index simply reports nothing as owned, which
+// leaves behaviour exactly as it was before ownership detection existed.
+func (s *Server) libraryIndex() *library.Index {
+	if s.db == nil {
+		return nil
+	}
+	idx, err := s.db.LibraryMatchIndex()
+	if err != nil {
+		slog.Warn("library ownership index unavailable", "error", err)
+		return nil
+	}
+	return idx
+}
+
+// annotateOwnership marks every result the user already owns. Results are
+// annotated rather than filtered out — a user may legitimately want another
+// edition, and silently dropping hits would look like a broken search.
+func annotateOwnership(idx *library.Index, results []models.SearchResult, tab string) []models.SearchResult {
+	if idx == nil || idx.Len() == 0 {
+		return results
+	}
+	tabMediaType := mediaTypeForTab(tab)
+	for i := range results {
+		mediaType := results[i].MediaType
+		if mediaType == "" {
+			mediaType = tabMediaType
+		}
+		match, ok := idx.Lookup(results[i].Title, results[i].Author, mediaType)
+		if !ok {
+			continue
+		}
+		results[i].InLibrary = true
+		results[i].LibraryItemID = match.ID
+		results[i].LibraryTitle = match.Title
+	}
+	return results
+}

--- a/internal/api/ownership_test.go
+++ b/internal/api/ownership_test.go
@@ -1,0 +1,288 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/download"
+	"github.com/JeremiahM37/librarr/internal/models"
+	"github.com/JeremiahM37/librarr/internal/search"
+)
+
+// newOwnershipTestServer builds a server whose library already holds the book
+// from issue #96, imported from Kavita exactly as the reporter described.
+func newOwnershipTestServer(t *testing.T) *Server {
+	t.Helper()
+	database, err := db.New(filepath.Join(t.TempDir(), "library.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if _, err := database.AddItem(&models.LibraryItem{
+		Title:      "4:50 from Paddington",
+		Author:     "Agatha Christie",
+		FilePath:   "/books/Agatha Christie/4-50 from Paddington.epub",
+		FileFormat: "epub",
+		MediaType:  "ebook",
+		Source:     "kavita-existing",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// No download client and no download URLs anywhere in these tests: a
+	// request that survives the library check must fail on the *next* guard,
+	// which is what proves the check let it through without ever starting a
+	// real transfer.
+	cfg := &config.Config{}
+	manager := download.NewManager(cfg, database, nil, nil, nil, nil, nil, search.NewHealthTracker(3, 300))
+	return &Server{
+		cfg:         cfg,
+		db:          database,
+		downloadMgr: manager,
+		searchMgr:   search.NewManager(cfg, nil, search.NewHealthTracker(3, 300)),
+	}
+}
+
+func postDownload(t *testing.T, server *Server, body map[string]interface{}) (*httptest.ResponseRecorder, map[string]interface{}) {
+	t.Helper()
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("POST", "/api/download", strings.NewReader(string(encoded)))
+	rr := httptest.NewRecorder()
+	server.handleDownload(rr, r)
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("response is not JSON: %s", rr.Body.String())
+	}
+	return rr, response
+}
+
+// The issue's exact repro: POST /api/download for a book already in the
+// library returned 200 and downloaded a second copy.
+func TestDownloadOfOwnedBookIsRejected(t *testing.T) {
+	server := newOwnershipTestServer(t)
+
+	rr, response := postDownload(t, server, map[string]interface{}{
+		"title":  "Agatha Christie - 4.50 From Paddington",
+		"author": "Agatha Christie",
+		"source": "annas",
+		"md5":    "3e8184fac9f9d2413af8260dbf240ac9",
+	})
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", rr.Code, rr.Body.String())
+	}
+	if response["success"] != false {
+		t.Errorf("success = %v, want false", response["success"])
+	}
+	if response["in_library"] != true {
+		t.Errorf("in_library = %v, want true", response["in_library"])
+	}
+	if response["code"] != "already_in_library" {
+		t.Errorf("code = %v, want already_in_library", response["code"])
+	}
+	if id, ok := response["library_item_id"].(float64); !ok || id <= 0 {
+		t.Errorf("library_item_id = %v, want the owned item's id", response["library_item_id"])
+	}
+	if response["library_title"] != "4:50 from Paddington" {
+		t.Errorf("library_title = %v, want the title as stored", response["library_title"])
+	}
+	if response["job_id"] != nil {
+		t.Errorf("a download job was started anyway: %s", rr.Body.String())
+	}
+}
+
+// "Download anyway" has to work: wanting a second edition is legitimate, and
+// the block would otherwise be a dead end.
+func TestForceOverridesTheLibraryCheck(t *testing.T) {
+	server := newOwnershipTestServer(t)
+
+	// Carrying no download URL, the request falls through to the next guard —
+	// reaching it at all is the proof that force skipped the library check.
+	rr, response := postDownload(t, server, map[string]interface{}{
+		"title":  "Agatha Christie - 4.50 From Paddington",
+		"author": "Agatha Christie",
+		"source": "annas",
+		"force":  true,
+	})
+
+	if rr.Code == http.StatusConflict || response["code"] == "already_in_library" {
+		t.Fatalf("force was ignored: %s", rr.Body.String())
+	}
+	if !strings.Contains(response["error"].(string), "No download source") {
+		t.Fatalf("expected the request to reach the download guards, got: %s", rr.Body.String())
+	}
+}
+
+func TestDownloadOfUnownedBookIsUnaffected(t *testing.T) {
+	server := newOwnershipTestServer(t)
+
+	rr, response := postDownload(t, server, map[string]interface{}{
+		"title":  "Murder on the Orient Express",
+		"author": "Agatha Christie",
+		"source": "annas",
+	})
+
+	if rr.Code == http.StatusConflict {
+		t.Fatalf("a different book by the same author was blocked: %s", rr.Body.String())
+	}
+	if response["in_library"] == true {
+		t.Fatalf("unowned book reported as owned: %s", rr.Body.String())
+	}
+}
+
+// Every path that can start a download must check, not just the one the web UI
+// happens to use — the API is also driven by scripts and Torznab clients.
+func TestEveryDownloadRouteChecksTheLibrary(t *testing.T) {
+	body := map[string]interface{}{
+		"title":  "Agatha Christie - 4.50 From Paddington",
+		"author": "Agatha Christie",
+		"source": "annas",
+		"md5":    "3e8184fac9f9d2413af8260dbf240ac9",
+	}
+
+	routes := map[string]func(*Server) http.HandlerFunc{
+		"/api/download":         func(s *Server) http.HandlerFunc { return s.handleDownload },
+		"/api/download/annas":   func(s *Server) http.HandlerFunc { return s.handleDownloadAnnas },
+		"/api/download/torrent": func(s *Server) http.HandlerFunc { return s.handleDownloadTorrent },
+	}
+
+	for route, handler := range routes {
+		t.Run(route, func(t *testing.T) {
+			server := newOwnershipTestServer(t)
+			encoded, err := json.Marshal(body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := httptest.NewRequest("POST", route, strings.NewReader(string(encoded)))
+			rr := httptest.NewRecorder()
+			handler(server)(rr, r)
+
+			if rr.Code != http.StatusConflict {
+				t.Fatalf("status = %d, want 409: %s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+// The audiobook route grabs a different media type, so an owned ebook must not
+// block the audiobook of the same title.
+func TestOwnedEbookDoesNotBlockTheAudiobook(t *testing.T) {
+	server := newOwnershipTestServer(t)
+
+	encoded, err := json.Marshal(map[string]interface{}{
+		"title":     "4:50 from Paddington",
+		"author":    "Agatha Christie",
+		"source":    "audiobook",
+		"info_hash": "0123456789abcdef0123456789abcdef01234567",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("POST", "/api/download/audiobook", strings.NewReader(string(encoded)))
+	rr := httptest.NewRecorder()
+	server.handleDownloadAudiobook(rr, r)
+
+	if rr.Code == http.StatusConflict {
+		t.Fatalf("owned ebook blocked the audiobook edition: %s", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "No torrent download client") {
+		t.Fatalf("expected the request to reach the download guards, got: %s", rr.Body.String())
+	}
+}
+
+func TestSearchResultsAreAnnotatedWithOwnership(t *testing.T) {
+	server := newOwnershipTestServer(t)
+	index := server.libraryIndex()
+	if index.Len() == 0 {
+		t.Fatal("ownership index is empty; the library row was not loaded")
+	}
+
+	results := annotateOwnership(index, []models.SearchResult{
+		{Source: "annas", Title: "Agatha Christie - 4.50 From Paddington", Author: "Agatha Christie"},
+		{Source: "annas", Title: "4.50 from Paddington (aka What Mrs. Mcgillicuddy Saw)"},
+		{Source: "annas", Title: "Murder on the Orient Express", Author: "Agatha Christie"},
+	}, "main")
+
+	if !results[0].InLibrary || results[0].LibraryItemID == 0 {
+		t.Errorf("author-prefixed result not flagged: %+v", results[0])
+	}
+	if results[0].LibraryTitle != "4:50 from Paddington" {
+		t.Errorf("library_title = %q, want the title as stored", results[0].LibraryTitle)
+	}
+	if !results[1].InLibrary {
+		t.Errorf("alternate-title result not flagged: %+v", results[1])
+	}
+	if results[2].InLibrary {
+		t.Errorf("a different book was flagged as owned: %+v", results[2])
+	}
+
+	// The JSON contract the issue asked for: in_library is always present, so
+	// a client can tell "not owned" from "server does not report ownership".
+	encoded, err := json.Marshal(results[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := decoded["in_library"]; !present {
+		t.Errorf("in_library missing from an unowned result: %s", encoded)
+	}
+	if _, present := decoded["library_item_id"]; present {
+		t.Errorf("library_item_id should be omitted when unowned: %s", encoded)
+	}
+}
+
+func TestAnnotateOwnershipUsesTheSearchTabForMediaType(t *testing.T) {
+	server := newOwnershipTestServer(t)
+	index := server.libraryIndex()
+
+	// The library holds the ebook. Audiobook-tab results carry no media type
+	// of their own, so the tab is what keeps them off the ebook shelf.
+	audiobookTab := annotateOwnership(index, []models.SearchResult{
+		{Source: "audiobook", Title: "4:50 from Paddington", Author: "Agatha Christie"},
+	}, "audiobook")
+	if audiobookTab[0].InLibrary {
+		t.Error("an owned ebook was reported as owned on the audiobook tab")
+	}
+
+	ebookTab := annotateOwnership(index, []models.SearchResult{
+		{Source: "annas", Title: "4:50 from Paddington", Author: "Agatha Christie"},
+	}, "main")
+	if !ebookTab[0].InLibrary {
+		t.Error("the owned ebook was not flagged on the ebook tab")
+	}
+}
+
+func TestOwnershipIsInertWithoutALibrary(t *testing.T) {
+	database, err := db.New(filepath.Join(t.TempDir(), "empty.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	server := &Server{cfg: &config.Config{}, db: database}
+
+	results := annotateOwnership(server.libraryIndex(), []models.SearchResult{
+		{Source: "annas", Title: "Anything At All", Author: "Someone"},
+	}, "main")
+	if results[0].InLibrary {
+		t.Error("an empty library reported ownership")
+	}
+
+	rr := httptest.NewRecorder()
+	if server.rejectIfInLibrary(rr, models.DownloadRequest{Title: "Anything At All"}) {
+		t.Error("an empty library blocked a download")
+	}
+}

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -38,6 +38,7 @@ func (s *Server) handleSearchTab(w http.ResponseWriter, r *http.Request, tab, ac
 	if results == nil {
 		results = []models.SearchResult{}
 	}
+	results = annotateOwnership(s.libraryIndex(), results, tab)
 
 	resp := map[string]interface{}{
 		"results":        results,
@@ -93,6 +94,10 @@ func (s *Server) handleSearchStreamTab(w http.ResponseWriter, r *http.Request, t
 	w.Header().Set("X-Accel-Buffering", "no")
 
 	author := truncateSearchQuery(r.URL.Query().Get("author"))
+	// Built once: the stream re-processes the whole result set on every source
+	// update, and rebuilding the index each time would rescan the library
+	// table a dozen times per search.
+	ownership := s.libraryIndex()
 	var allResults []models.SearchResult
 	emit := func(event string, payload interface{}) bool {
 		data, err := json.Marshal(payload)
@@ -121,6 +126,7 @@ func (s *Server) handleSearchStreamTab(w http.ResponseWriter, r *http.Request, t
 		if results == nil {
 			results = []models.SearchResult{}
 		}
+		results = annotateOwnership(ownership, results, tab)
 		payload := map[string]interface{}{
 			"source":         update.Source,
 			"source_done":    update.Done,
@@ -141,6 +147,7 @@ func (s *Server) handleSearchStreamTab(w http.ResponseWriter, r *http.Request, t
 	if finalResults == nil {
 		finalResults = []models.SearchResult{}
 	}
+	finalResults = annotateOwnership(ownership, finalResults, tab)
 	emit("complete", map[string]interface{}{
 		"results": finalResults,
 		"sources": s.searchMgr.SourceMeta(),

--- a/internal/db/library.go
+++ b/internal/db/library.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/JeremiahM37/librarr/internal/library"
 	"github.com/JeremiahM37/librarr/internal/models"
 	"github.com/JeremiahM37/librarr/internal/netutil"
 )
@@ -316,6 +317,36 @@ func (d *DB) HasSourceID(sourceID string) bool {
 	var exists int
 	err := d.db.QueryRow("SELECT 1 FROM library_items WHERE source_id = ?", sourceID).Scan(&exists)
 	return err == nil
+}
+
+// LibraryMatchIndex builds an ownership index over the whole library so search
+// results and download requests can be checked against what the user already
+// has.
+//
+// Only the four columns matching needs are read: a library of several thousand
+// books would otherwise drag file paths, metadata blobs and content hashes
+// through memory on every search. Building the index is a single sequential
+// scan and the result is queried by map lookup, so callers should build it once
+// per request and reuse it across every result they annotate.
+func (d *DB) LibraryMatchIndex() (*library.Index, error) {
+	rows, err := d.db.Query("SELECT id, title, author, media_type FROM library_items")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var candidates []library.Candidate
+	for rows.Next() {
+		var c library.Candidate
+		if err := rows.Scan(&c.ID, &c.Title, &c.Author, &c.MediaType); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return library.NewIndex(candidates), nil
 }
 
 // FindByTitle performs a case-insensitive title lookup.

--- a/internal/library/match.go
+++ b/internal/library/match.go
@@ -1,0 +1,318 @@
+// Package library answers one question: does the user already own this book?
+//
+// It is used in two places that must agree — the wishlist cleaner (which
+// deletes wishlist rows once the book lands) and search/download ownership
+// detection (which flags and blocks duplicate grabs). Both compare a loose,
+// human-entered title against the titles the importer wrote into
+// library_items, so the normalization lives here rather than being reinvented
+// per caller.
+//
+// Matching is deliberately conservative. A false positive tells a user they
+// own a book they do not, and hides the download behind an extra click; that
+// is a worse failure than missing a match, so every rule here only ever
+// removes noise that cannot change which book is meant.
+package library
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Candidate is the slim projection of a library row needed to answer
+// ownership. Loading whole models.LibraryItem values (file paths, metadata
+// blobs, hashes) for every one of a 3,000+ book library on each search would
+// be pure waste.
+type Candidate struct {
+	ID        int64
+	Title     string
+	Author    string
+	MediaType string
+}
+
+// Match is a resolved ownership hit.
+type Match struct {
+	ID    int64
+	Title string
+}
+
+// NormalizeTitle folds a title to its comparable form: lowercase, punctuation
+// collapsed to single spaces, edition noise removed.
+//
+// Collapsing punctuation is what makes "4:50 from Paddington" and
+// "4.50 From Paddington" the same book — both become "4 50 from paddington".
+func NormalizeTitle(s string) string {
+	normalized := NormalizeWords(s)
+	for _, suffix := range []string{" unabridged", " abridged"} {
+		normalized = strings.TrimSuffix(normalized, suffix)
+	}
+	return strings.TrimSpace(normalized)
+}
+
+// NormalizePerson folds an author name to its comparable form.
+func NormalizePerson(s string) string {
+	return NormalizeWords(s)
+}
+
+// NormalizeWords lowercases, drops punctuation and symbols, and collapses
+// whitespace runs to a single space.
+func NormalizeWords(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	lastSpace := true
+	for _, r := range s {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			b.WriteRune(r)
+			lastSpace = false
+		case unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r):
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// AuthorMatches reports whether a normalized author agrees with a raw author
+// field that may hold several names ("Neil Gaiman & Terry Pratchett").
+// An empty wanted author agrees with anything; a known wanted author never
+// agrees with a blank field.
+func AuthorMatches(wantNormalized, raw string) bool {
+	if wantNormalized == "" {
+		return true
+	}
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+	if NormalizePerson(raw) == wantNormalized {
+		return true
+	}
+	for _, part := range SplitAuthorList(raw) {
+		if NormalizePerson(part) == wantNormalized {
+			return true
+		}
+	}
+	return false
+}
+
+// SplitAuthorList splits a multi-author field on the separators sources
+// actually use.
+func SplitAuthorList(author string) []string {
+	replacer := strings.NewReplacer("&", ",", ";", ",", " and ", ",")
+	return strings.Split(replacer.Replace(" "+strings.ToLower(author)+" "), ",")
+}
+
+// placeholderAuthors are the strings importers write when a file names no
+// author. They are absence of information, not a person, and must not be
+// compared as one.
+var placeholderAuthors = map[string]struct{}{
+	"unknown":         {},
+	"unknown author":  {},
+	"various":         {},
+	"various authors": {},
+	"anonymous":       {},
+	"n a":             {}, // "n/a" after normalization
+}
+
+// KnownAuthor returns the normalized author name, or "" when the field carries
+// no usable name.
+func KnownAuthor(author string) string {
+	normalized := NormalizePerson(author)
+	if _, placeholder := placeholderAuthors[normalized]; placeholder {
+		return ""
+	}
+	return normalized
+}
+
+// authorsAgree decides whether an author field blocks a title match.
+//
+// When either side names no author the titles decide alone. Imported
+// collections routinely hold rows with an empty or "Unknown" author — an EPUB
+// with no dc:creator, a Calibre export, a bare filename — and refusing to
+// recognise those books would leave exactly the users this feature is for
+// (people bringing in a big existing library) with no ownership detection at
+// all. The cost of being wrong is a badge and one extra click, never a lost
+// download.
+func authorsAgree(wantNormalized, libraryAuthor string) bool {
+	if wantNormalized == "" || KnownAuthor(libraryAuthor) == "" {
+		return true
+	}
+	return AuthorMatches(wantNormalized, libraryAuthor)
+}
+
+// DefaultMediaType normalizes a possibly-empty media type. Search results from
+// the ebook tab often carry no media type at all.
+func DefaultMediaType(mediaType string) string {
+	if trimmed := strings.TrimSpace(mediaType); trimmed != "" {
+		return trimmed
+	}
+	return "ebook"
+}
+
+// Index is an ownership lookup built once from the library table and then
+// queried per search result. Lookups are map hits, so annotating a full page
+// of results costs nothing measurable.
+//
+// The zero value is a usable empty index that matches nothing, so callers with
+// no database do not need a nil check.
+type Index struct {
+	// byTitle is keyed on normalized title + media type. Several editions of
+	// one book share a key, which is fine: any of them proves ownership.
+	byTitle map[string][]Candidate
+	// authors holds every normalized author name in the library, used to
+	// recognise an "Author - Title" prefix on a result title.
+	authors map[string]struct{}
+}
+
+// NewIndex builds an ownership index from library rows.
+func NewIndex(candidates []Candidate) *Index {
+	idx := &Index{
+		byTitle: make(map[string][]Candidate, len(candidates)),
+		authors: make(map[string]struct{}),
+	}
+	for _, c := range candidates {
+		title := NormalizeTitle(c.Title)
+		if title == "" {
+			continue
+		}
+		key := titleKey(title, DefaultMediaType(c.MediaType))
+		idx.byTitle[key] = append(idx.byTitle[key], c)
+		for _, part := range SplitAuthorList(c.Author) {
+			if normalized := KnownAuthor(part); normalized != "" {
+				idx.authors[normalized] = struct{}{}
+			}
+		}
+	}
+	return idx
+}
+
+// Len reports how many distinct title/media-type keys the index holds.
+func (i *Index) Len() int {
+	if i == nil {
+		return 0
+	}
+	return len(i.byTitle)
+}
+
+// Lookup reports whether a search result names a book already in the library.
+//
+// A hit requires the normalized titles to be equal — after stripping the noise
+// sources add around the title — and, when the result names an author, that
+// author to agree with the library row. A result with no author at all matches
+// on title alone, which is the best that can be done for sources that publish
+// nothing else.
+func (i *Index) Lookup(title, author, mediaType string) (Match, bool) {
+	if i == nil || len(i.byTitle) == 0 {
+		return Match{}, false
+	}
+
+	wantAuthor := KnownAuthor(author)
+	mt := DefaultMediaType(mediaType)
+
+	for _, variant := range i.titleVariants(title, wantAuthor) {
+		for _, candidate := range i.byTitle[titleKey(variant, mt)] {
+			if !authorsAgree(wantAuthor, candidate.Author) {
+				continue
+			}
+			return Match{ID: candidate.ID, Title: candidate.Title}, true
+		}
+	}
+	return Match{}, false
+}
+
+// titleVariants returns the normalized forms a result title could reasonably
+// take, most faithful first. Sources wrap the actual title in author prefixes
+// and parenthetical alternate titles, none of which appear in the library row
+// the importer wrote.
+func (i *Index) titleVariants(title string, wantAuthor string) []string {
+	seen := make(map[string]struct{}, 4)
+	var variants []string
+	add := func(s string) {
+		normalized := NormalizeTitle(s)
+		if normalized == "" {
+			return
+		}
+		if _, dup := seen[normalized]; dup {
+			return
+		}
+		seen[normalized] = struct{}{}
+		variants = append(variants, normalized)
+	}
+
+	add(title)
+
+	// "4.50 from Paddington (aka What Mrs. McGillicuddy Saw)" -> the title
+	// before the alternate-title aside.
+	trimmed := stripTrailingAside(title)
+	add(trimmed)
+
+	// "Agatha Christie - 4.50 From Paddington" -> drop the author prefix. Only
+	// done when the prefix is genuinely an author name: either the one the
+	// result itself reports, or one the library already knows. Otherwise
+	// "Dune - Book One" would lose half its title.
+	for _, base := range []string{title, trimmed} {
+		if stripped, ok := i.stripAuthorAffix(base, wantAuthor); ok {
+			add(stripped)
+			add(stripTrailingAside(stripped))
+		}
+	}
+
+	return variants
+}
+
+// stripAuthorAffix removes a leading "Author - " or trailing " - Author"
+// segment when that segment is recognisably an author name.
+func (i *Index) stripAuthorAffix(title, wantAuthor string) (string, bool) {
+	for _, sep := range []string{" - ", " – ", " — ", " _ "} {
+		head, tail, found := strings.Cut(title, sep)
+		if !found {
+			continue
+		}
+		if strings.TrimSpace(tail) != "" && i.isKnownAuthor(head, wantAuthor) {
+			return tail, true
+		}
+		// Trailing form: take the last segment as the candidate author.
+		if idx := strings.LastIndex(title, sep); idx > 0 {
+			lead, trail := title[:idx], title[idx+len(sep):]
+			if strings.TrimSpace(lead) != "" && i.isKnownAuthor(trail, wantAuthor) {
+				return lead, true
+			}
+		}
+	}
+	return "", false
+}
+
+func (i *Index) isKnownAuthor(segment, wantAuthor string) bool {
+	normalized := NormalizePerson(segment)
+	if normalized == "" {
+		return false
+	}
+	if wantAuthor != "" && normalized == wantAuthor {
+		return true
+	}
+	_, known := i.authors[normalized]
+	return known
+}
+
+// stripTrailingAside removes a trailing parenthesised or bracketed segment,
+// which sources use for alternate titles, formats and series notes.
+func stripTrailingAside(title string) string {
+	trimmed := strings.TrimSpace(title)
+	for _, pair := range [][2]string{{"(", ")"}, {"[", "]"}, {"{", "}"}} {
+		if !strings.HasSuffix(trimmed, pair[1]) {
+			continue
+		}
+		if open := strings.LastIndex(trimmed, pair[0]); open > 0 {
+			candidate := strings.TrimSpace(trimmed[:open])
+			if candidate != "" {
+				return candidate
+			}
+		}
+	}
+	return trimmed
+}
+
+func titleKey(normalizedTitle, mediaType string) string {
+	return normalizedTitle + "\x00" + mediaType
+}

--- a/internal/library/match_test.go
+++ b/internal/library/match_test.go
@@ -1,0 +1,345 @@
+package library
+
+import "testing"
+
+// The library standing in for a real user's imported collection. The Agatha
+// Christie row is the one from issue #96, imported from Kavita with a colon in
+// the title that the download sources write as a full stop.
+func testIndex() *Index {
+	return NewIndex([]Candidate{
+		{ID: 1, Title: "4:50 from Paddington", Author: "Agatha Christie", MediaType: "ebook"},
+		{ID: 2, Title: "The Hobbit", Author: "J. R. R. Tolkien", MediaType: "ebook"},
+		{ID: 3, Title: "Good Omens", Author: "Neil Gaiman & Terry Pratchett", MediaType: "ebook"},
+		{ID: 4, Title: "Project Hail Mary", Author: "Andy Weir", MediaType: "audiobook"},
+		{ID: 5, Title: "Dune", Author: "", MediaType: "ebook"},
+	})
+}
+
+func TestLookupMatchesIssue96Titles(t *testing.T) {
+	idx := testIndex()
+
+	tests := []struct {
+		name      string
+		title     string
+		author    string
+		mediaType string
+		wantID    int64
+	}{
+		{
+			name:   "exact title",
+			title:  "4:50 from Paddington",
+			author: "Agatha Christie",
+			wantID: 1,
+		},
+		{
+			name:   "punctuation differs between colon and full stop",
+			title:  "4.50 From Paddington",
+			author: "Agatha Christie",
+			wantID: 1,
+		},
+		{
+			name:   "source prefixes the title with the author",
+			title:  "Agatha Christie - 4.50 From Paddington",
+			author: "Agatha Christie",
+			wantID: 1,
+		},
+		{
+			name:   "alternate title in parentheses",
+			title:  "4.50 from Paddington (aka What Mrs. Mcgillicuddy Saw)",
+			author: "Agatha Christie",
+			wantID: 1,
+		},
+		{
+			name:   "author prefix and parenthetical aside together",
+			title:  "Agatha Christie - 4.50 from Paddington (Miss Marple #8)",
+			author: "Agatha Christie",
+			wantID: 1,
+		},
+		{
+			name:   "author suffix after the title",
+			title:  "4.50 from Paddington - Agatha Christie",
+			author: "Agatha Christie",
+			wantID: 1,
+		},
+		{
+			name:   "author prefix recognised from the library when the result reports none",
+			title:  "Agatha Christie - 4.50 From Paddington",
+			author: "",
+			wantID: 1,
+		},
+		{
+			name:   "case and spacing are irrelevant",
+			title:  "  the   HOBBIT  ",
+			author: "j. r. r. tolkien",
+			wantID: 2,
+		},
+		{
+			name:   "author matches one name in a multi-author library row",
+			title:  "Good Omens",
+			author: "Terry Pratchett",
+			wantID: 3,
+		},
+		{
+			name:   "unabridged suffix is edition noise, not a different book",
+			title:  "Project Hail Mary Unabridged",
+			author: "Andy Weir",
+			// The audiobook shelf: an audiobook result must find the
+			// audiobook row.
+			mediaType: "audiobook",
+			wantID:    4,
+		},
+		{
+			// Imported collections are full of rows like this — an EPUB with
+			// no dc:creator, a bare filename — so the title has to decide.
+			name:   "library row without an author matches on title alone",
+			title:  "Dune",
+			author: "Frank Herbert",
+			wantID: 5,
+		},
+		{
+			name:   "result without an author matches the authorless row",
+			title:  "Dune",
+			author: "",
+			wantID: 5,
+		},
+		{
+			name:   "placeholder author on the result is not treated as a name",
+			title:  "The Hobbit",
+			author: "Unknown",
+			wantID: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match, ok := idx.Lookup(tc.title, tc.author, tc.mediaType)
+			if tc.wantID == 0 {
+				if ok {
+					t.Fatalf("expected no match, got item %d (%q)", match.ID, match.Title)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("expected item %d, got no match", tc.wantID)
+			}
+			if match.ID != tc.wantID {
+				t.Fatalf("matched item %d (%q), want %d", match.ID, match.Title, tc.wantID)
+			}
+			if match.Title == "" {
+				t.Error("match carries no library title to show the user")
+			}
+		})
+	}
+}
+
+// False positives are the expensive failure: they tell a user they own a book
+// they do not and hide the download behind an extra click.
+func TestLookupRejectsDifferentBooks(t *testing.T) {
+	idx := testIndex()
+
+	tests := []struct {
+		name      string
+		title     string
+		author    string
+		mediaType string
+	}{
+		{
+			name:   "same title, different author",
+			title:  "The Hobbit",
+			author: "Someone Else",
+		},
+		{
+			name:   "different book by an author in the library",
+			title:  "Murder on the Orient Express",
+			author: "Agatha Christie",
+		},
+		{
+			name:   "title is a prefix of a library title",
+			title:  "The",
+			author: "J. R. R. Tolkien",
+		},
+		{
+			name:   "title extends a library title with real words",
+			title:  "The Hobbit Illustrated Companion",
+			author: "J. R. R. Tolkien",
+		},
+		{
+			name:      "right title on the wrong shelf",
+			title:     "The Hobbit",
+			author:    "J. R. R. Tolkien",
+			mediaType: "audiobook",
+		},
+		{
+			name:      "audiobook title searched as an ebook",
+			title:     "Project Hail Mary",
+			author:    "Andy Weir",
+			mediaType: "ebook",
+		},
+		{
+			name:   "hyphenated title whose lead segment is not an author",
+			title:  "Dune - The Graphic Novel",
+			author: "Frank Herbert",
+		},
+		{
+			name:  "empty title",
+			title: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if match, ok := idx.Lookup(tc.title, tc.author, tc.mediaType); ok {
+				t.Fatalf("false positive: matched item %d (%q)", match.ID, match.Title)
+			}
+		})
+	}
+}
+
+func TestLookupDefaultsMissingMediaTypeToEbook(t *testing.T) {
+	// Most ebook sources leave media_type empty; those results must still be
+	// checked against the ebook shelf rather than matching nothing.
+	idx := NewIndex([]Candidate{{ID: 7, Title: "Neuromancer", Author: "William Gibson"}})
+	if _, ok := idx.Lookup("Neuromancer", "William Gibson", ""); !ok {
+		t.Fatal("empty media type on both sides should compare as ebook")
+	}
+	if _, ok := idx.Lookup("Neuromancer", "William Gibson", "ebook"); !ok {
+		t.Fatal("explicit ebook should match a row with no media type")
+	}
+}
+
+func TestEmptyAndNilIndexAreInert(t *testing.T) {
+	// A user with no library, or a database read that failed, must leave
+	// search behaving exactly as it did before ownership detection existed.
+	var nilIdx *Index
+	if _, ok := nilIdx.Lookup("The Hobbit", "Tolkien", "ebook"); ok {
+		t.Error("nil index reported ownership")
+	}
+	if nilIdx.Len() != 0 {
+		t.Error("nil index reported a non-zero length")
+	}
+
+	empty := NewIndex(nil)
+	if _, ok := empty.Lookup("The Hobbit", "Tolkien", "ebook"); ok {
+		t.Error("empty index reported ownership")
+	}
+	if empty.Len() != 0 {
+		t.Errorf("empty index length = %d, want 0", empty.Len())
+	}
+}
+
+func TestIndexSkipsUnusableRows(t *testing.T) {
+	// Rows whose title normalizes away carry no signal and must not become a
+	// key that swallows every untitled result.
+	idx := NewIndex([]Candidate{
+		{ID: 1, Title: "   ", Author: "Nobody"},
+		{ID: 2, Title: "!!!", Author: "Nobody"},
+		{ID: 3, Title: "Real Book", Author: "Nobody"},
+	})
+	if idx.Len() != 1 {
+		t.Fatalf("index length = %d, want 1", idx.Len())
+	}
+	if _, ok := idx.Lookup("!!!", "Nobody", "ebook"); ok {
+		t.Error("punctuation-only title matched")
+	}
+}
+
+func TestLookupPrefersAnAuthorAgreeingEdition(t *testing.T) {
+	// Two library rows share a normalized title. The one whose author agrees
+	// is the honest answer to "do I own this?".
+	idx := NewIndex([]Candidate{
+		{ID: 1, Title: "The Gift", Author: "Alice Author", MediaType: "ebook"},
+		{ID: 2, Title: "The Gift", Author: "Bob Writer", MediaType: "ebook"},
+	})
+	match, ok := idx.Lookup("The Gift", "Bob Writer", "ebook")
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if match.ID != 2 {
+		t.Fatalf("matched item %d, want the row by Bob Writer (2)", match.ID)
+	}
+}
+
+func TestNormalizeTitle(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"4:50 from Paddington", "4 50 from paddington"},
+		{"4.50 From Paddington", "4 50 from paddington"},
+		{"  Mixed   CASE  ", "mixed case"},
+		{"Project Hail Mary (Unabridged)", "project hail mary"},
+		{"Émile — Or On Education", "émile or on education"},
+		{"!!!", ""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := NormalizeTitle(tc.in); got != tc.want {
+				t.Errorf("NormalizeTitle(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAuthorMatches(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		raw  string
+		ok   bool
+	}{
+		{name: "no wanted author agrees with anything", want: "", raw: "Anyone", ok: true},
+		{name: "known author versus blank library field", want: "agatha christie", raw: "", ok: false},
+		{name: "exact", want: "agatha christie", raw: "Agatha Christie", ok: true},
+		{name: "ampersand list", want: "terry pratchett", raw: "Neil Gaiman & Terry Pratchett", ok: true},
+		{name: "and list", want: "terry pratchett", raw: "Neil Gaiman and Terry Pratchett", ok: true},
+		{name: "semicolon list", want: "terry pratchett", raw: "Gaiman, Neil; Terry Pratchett", ok: true},
+		{name: "different person", want: "agatha christie", raw: "Arthur Conan Doyle", ok: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AuthorMatches(tc.want, tc.raw); got != tc.ok {
+				t.Errorf("AuthorMatches(%q, %q) = %v, want %v", tc.want, tc.raw, got, tc.ok)
+			}
+		})
+	}
+}
+
+// Importers write these when a file names nobody. Comparing them as people
+// would hide every authorless book from ownership detection.
+func TestKnownAuthorDropsPlaceholders(t *testing.T) {
+	for _, placeholder := range []string{"", "  ", "Unknown", "unknown author", "N/A", "Various", "Anonymous"} {
+		if got := KnownAuthor(placeholder); got != "" {
+			t.Errorf("KnownAuthor(%q) = %q, want empty", placeholder, got)
+		}
+	}
+	if got := KnownAuthor("Ursula K. Le Guin"); got != "ursula k le guin" {
+		t.Errorf("KnownAuthor dropped a real name: %q", got)
+	}
+}
+
+func TestAuthorlessLibraryRowStillRejectsADifferentTitle(t *testing.T) {
+	// Relaxing the author rule must not relax the title rule.
+	idx := NewIndex([]Candidate{{ID: 1, Title: "Dune", MediaType: "ebook"}})
+	if _, ok := idx.Lookup("Dune Messiah", "Frank Herbert", "ebook"); ok {
+		t.Error("a different title matched an authorless row")
+	}
+}
+
+func TestAuthorMatchesIsUnchangedForKnownNames(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		raw  string
+		ok   bool
+	}{
+		{name: "blank library author with a known wanted author", want: "agatha christie", raw: "", ok: false},
+		{name: "same person", want: "agatha christie", raw: "Agatha Christie", ok: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AuthorMatches(tc.want, tc.raw); got != tc.ok {
+				t.Errorf("AuthorMatches(%q, %q) = %v, want %v", tc.want, tc.raw, got, tc.ok)
+			}
+		})
+	}
+}

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -33,6 +33,13 @@ type SearchResult struct {
 	Publisher string `json:"publisher,omitempty"`
 	Year      string `json:"year,omitempty"`
 
+	// Ownership, resolved against library_items at response time. InLibrary is
+	// always serialized — a client checking for the field must be able to tell
+	// "not owned" from "this build does not report ownership".
+	InLibrary     bool   `json:"in_library"`
+	LibraryItemID int64  `json:"library_item_id,omitempty"`
+	LibraryTitle  string `json:"library_title,omitempty"`
+
 	// Copies counts how many results collapsed into this one because they were
 	// identical apart from their content hash. Zero or one means nothing merged.
 	Copies int `json:"copies,omitempty"`

--- a/internal/scheduler/wishlist_cleanup.go
+++ b/internal/scheduler/wishlist_cleanup.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/library"
 	"github.com/JeremiahM37/librarr/internal/models"
 )
 
@@ -314,56 +314,18 @@ func conservativeWishlistMatches(item models.WishlistItem, candidates []cleanupC
 	return matches
 }
 
+// The normalization below is shared with search/download ownership detection
+// (internal/library): the wishlist cleaner and the "already in library" badge
+// must agree on what counts as the same book, or a title would be flagged as
+// owned in search while its wishlist row survived.
 func authorMatches(wishlistAuthor, libraryAuthor string) bool {
-	if wishlistAuthor == "" {
-		return true
-	}
-	if strings.TrimSpace(libraryAuthor) == "" {
-		return false
-	}
-	if normalizePerson(libraryAuthor) == wishlistAuthor {
-		return true
-	}
-	for _, part := range splitAuthorList(libraryAuthor) {
-		if normalizePerson(part) == wishlistAuthor {
-			return true
-		}
-	}
-	return false
-}
-
-func splitAuthorList(author string) []string {
-	replacer := strings.NewReplacer("&", ",", ";", ",", " and ", ",")
-	return strings.Split(replacer.Replace(" "+strings.ToLower(author)+" "), ",")
+	return library.AuthorMatches(wishlistAuthor, libraryAuthor)
 }
 
 func normalizeTitle(s string) string {
-	normalized := normalizeWords(s)
-	for _, suffix := range []string{" unabridged", " abridged"} {
-		normalized = strings.TrimSuffix(normalized, suffix)
-	}
-	return strings.TrimSpace(normalized)
+	return library.NormalizeTitle(s)
 }
 
 func normalizePerson(s string) string {
-	return normalizeWords(s)
-}
-
-func normalizeWords(s string) string {
-	s = strings.ToLower(strings.TrimSpace(s))
-	var b strings.Builder
-	lastSpace := true
-	for _, r := range s {
-		switch {
-		case unicode.IsLetter(r) || unicode.IsNumber(r):
-			b.WriteRune(r)
-			lastSpace = false
-		case unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r):
-			if !lastSpace {
-				b.WriteByte(' ')
-				lastSpace = true
-			}
-		}
-	}
-	return strings.Join(strings.Fields(b.String()), " ")
+	return library.NormalizePerson(s)
 }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -71,6 +71,10 @@ const I18N = {
     n_leech: '{n} leech',
     n_copies: '{n} copies',
     n_copies_title: '{n} identical copies, differing only by file hash',
+    in_library: 'In Library',
+    in_library_title: 'Already in your library as "{title}"',
+    download_anyway: 'Download anyway',
+    already_in_library: 'Already in your library: {title}',
     // Library
     library_filter_placeholder: 'Filter library...',
     library_empty: 'Your library is empty',
@@ -274,6 +278,10 @@ const I18N = {
     n_leech: '{n} лич.',
     n_copies: '{n} копий',
     n_copies_title: '{n} одинаковых копий, различаются только хешем файла',
+    in_library: 'В библиотеке',
+    in_library_title: 'Уже в вашей библиотеке как «{title}»',
+    download_anyway: 'Всё равно скачать',
+    already_in_library: 'Уже в вашей библиотеке: {title}',
     // Library
     library_filter_placeholder: 'Фильтр библиотеки...',
     library_empty: 'Ваша библиотека пуста',
@@ -1172,6 +1180,13 @@ function renderBookCard(result, index) {
     ? `<img src="${escapeHtml(result.cover_url)}" alt="" class="w-full h-48 object-cover" loading="lazy" data-ph-title="${escapeHtml(result.title || '')}" data-ph-idx="${index}">`
     : makePlaceholderHtml(result.title || '?', index);
 
+  // Ownership, resolved server-side against the library. Sits on the cover
+  // rather than in the badge row so it is legible before reading the title —
+  // the whole point is to stop a download that was about to happen.
+  const ownedBadge = result.in_library
+    ? `<span class="result-in-library absolute top-2 right-2 px-2 py-0.5 rounded text-xs font-medium bg-emerald-600 text-white" title="${escapeHtml(t('in_library_title', {title: result.library_title || result.title || ''}))}">${escapeHtml(t('in_library'))}</span>`
+    : '';
+
   const seeders = result.seeders ? `<span class="text-emerald-400 text-xs font-medium">${t('n_seeds', {n: result.seeders})}</span>` : '';
   const leechers = result.leechers ? `<span class="text-amber-400 text-xs">${t('n_leech', {n: result.leechers})}</span>` : '';
   const sizeText = (result.size && result.size > 0) ? formatSize(result.size) : (result.size_human || result.sizeHuman || '');
@@ -1207,6 +1222,14 @@ function renderBookCard(result, index) {
     success: `<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>`,
     error: `<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 8v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"/></svg>`,
   };
+  // An owned book keeps a working button — a second edition is a legitimate
+  // want — but the label has to say what the click will do, because the server
+  // rejects the plain request and only honours an explicit override.
+  if (result.in_library && buttonState === 'idle') {
+    buttonStyles.idle = 'bg-amber-600 hover:bg-amber-500 text-white';
+    buttonText.idle = t('download_anyway');
+  }
+
   const displayButtonText = buttonState === 'loading' && trackedJob?.detail
     ? escapeHtml(trackedJob.detail)
     : (buttonText[buttonState] || buttonText.idle);
@@ -1216,6 +1239,7 @@ function renderBookCard(result, index) {
       <div class="relative">
         ${coverHtml}
         <span class="absolute top-2 left-2 px-2 py-0.5 rounded text-xs font-medium" style="background:${src.bg};color:${src.text}">${escapeHtml(src.label)}</span>
+        ${ownedBadge}
       </div>
       <div class="p-3 flex-1 flex flex-col">
         <h3 class="text-sm font-semibold text-white line-clamp-2 mb-1" title="${escapeHtml(result.title || '')}">${escapeHtml(result.title || 'Unknown')}</h3>
@@ -1359,12 +1383,33 @@ async function startDownload(result) {
       // is misrouted to the torrent client and silently discarded.
       media_type: result.media_type || '',
       download_protocol: result.download_protocol || '',
+      // The server refuses books already in the library. Sending force with a
+      // result the user was shown as owned is the "Download anyway" click.
+      force: !!result.in_library,
     };
 
-    const data = await apiJson('/api/download', {
+    const resp = await api('/api/download', {
       method: 'POST',
       body: JSON.stringify(body),
     });
+    let data = {};
+    try {
+      data = await resp.json();
+    } catch {
+      data = {};
+    }
+
+    // The library can gain the book between the search and the click, so a
+    // result that was not flagged can still come back owned. Flag it now: the
+    // re-render turns this button into "Download anyway".
+    if (resp.status === 409 && data.in_library) {
+      result.in_library = true;
+      if (data.library_item_id) result.library_item_id = data.library_item_id;
+      if (data.library_title) result.library_title = data.library_title;
+      showToast(t('already_in_library', {title: data.library_title || result.title}), 'warning');
+      return;
+    }
+    if (!resp.ok) throw new Error(`API error: ${resp.status}`);
 
     if (result.source === 'annas' && data.job_id) {
       setDownloadOutcome(downloadKey, 'loading', true);
@@ -2570,7 +2615,10 @@ function escapeHtml(str) {
   if (!str) return '';
   const div = document.createElement('div');
   div.textContent = str;
-  return div.innerHTML;
+  // textContent -> innerHTML escapes & < >, but not quotes, and most callers
+  // interpolate into a quoted attribute (title=, alt=). A value containing a
+  // quote would close the attribute early and drop the rest of the text.
+  return div.innerHTML.replaceAll('"', '&quot;').replaceAll("'", '&#39;');
 }
 
 function escapeJs(str) {


### PR DESCRIPTION
Closes #96.

Librarr let you download a book it already had: `/api/download` never checked `library_items`, and search results said nothing about ownership.

- **`/api/search`** (and the SSE stream) now return `in_library` on every result, plus `library_item_id` / `library_title` when owned.
- **All four download endpoints** refuse an owned book with `409 {"code": "already_in_library", "library_item_id": N}`. `"force": true` overrides it. The check is server-side because the API is also driven by scripts and Torznab clients.
- **UI**: owned results get an "In Library" badge and a "Download anyway" button (which is what sends `force`). If a book lands in the library between the search and the click, the 409 updates the card in place.

Also: `escapeHtml` now escapes quotes. It is interpolated into `title=` attributes, and a value containing a quote closed the attribute early and truncated the tooltip.

## Tests

- `internal/library/match_test.go` — normalization and the false-positive cases.
- `internal/api/ownership_test.go` — the issue's repro through `POST /api/download`, `force`, every download route, media-type separation, the JSON contract.
- `e2e/test_library_ownership.py` — real binary + real Chromium: download a book, then confirm the API flags it, the card shows the badge and "Download anyway", and a second POST is refused with nothing queued behind it.

`go test ./... -race`, `go vet`, `staticcheck`, integration tests, and all 22 e2e tests pass.
