### PR TITLE
Stream cross-filesystem organize copies to avoid OOM

### DIFF
--- a/internal/organize/pipeline.go
+++ b/internal/organize/pipeline.go
@@ -222,20 +222,21 @@ func cleanSeriesTitle(name string) string {
 
 func moveFile(src, dst string) error {
 	// Try rename first (same filesystem).
-	if err := os.Rename(src, dst); err == nil {
+	if err := renameFile(src, dst); err == nil {
 		return nil
 	}
 
-	// Fall back to copy + delete.
-	data, err := os.ReadFile(src)
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(dst, data, 0644); err != nil {
+	// Cross-filesystem (and other rename failures): stream copy then delete.
+	// Never os.ReadFile the whole payload — large audiobooks OOM small containers
+	// when organizing from local downloads onto CIFS/NFS library mounts.
+	if err := copyFileForOrg(src, dst); err != nil {
 		return err
 	}
 	return os.Remove(src)
 }
+
+// renameFile is os.Rename; tests swap it to force the streaming copy fallback.
+var renameFile = os.Rename
 
 func moveDirTree(srcDir, dstDir string) error {
 	if err := os.MkdirAll(dstDir, 0755); err != nil {
@@ -275,7 +276,8 @@ func moveDirTree(srcDir, dstDir string) error {
 	return os.RemoveAll(srcDir)
 }
 
-// copyFileForOrg copies a file without removing the source.
+// copyFileForOrg copies a file without removing the source, streaming in
+// chunks so memory use stays bounded regardless of file size.
 func copyFileForOrg(src, dst string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
@@ -283,12 +285,24 @@ func copyFileForOrg(src, dst string) error {
 	}
 	defer srcFile.Close()
 
-	dstFile, err := os.Create(dst)
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}
-	defer dstFile.Close()
+	ok := false
+	defer func() {
+		_ = dstFile.Close()
+		if !ok {
+			_ = os.Remove(dst)
+		}
+	}()
 
-	_, err = io.Copy(dstFile, srcFile)
-	return err
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return err
+	}
+	if err := dstFile.Sync(); err != nil {
+		return err
+	}
+	ok = true
+	return nil
 }

--- a/internal/organize/pipeline.go
+++ b/internal/organize/pipeline.go
@@ -226,10 +226,13 @@ func moveFile(src, dst string) error {
 		return nil
 	}
 
-	// Cross-filesystem (and other rename failures): stream copy then delete.
-	// Never os.ReadFile the whole payload — large audiobooks OOM small containers
-	// when organizing from local downloads onto CIFS/NFS library mounts.
+	// Rename failed (often EXDEV onto CIFS/NFS): stream copy then delete.
+	// Avoid os.ReadFile — large audiobooks OOM small container mem_limits.
 	if err := copyFileForOrg(src, dst); err != nil {
+		return err
+	}
+	// Flush before removing the only complete source on cross-FS moves.
+	if err := syncFile(dst); err != nil {
 		return err
 	}
 	return os.Remove(src)
@@ -276,15 +279,27 @@ func moveDirTree(srcDir, dstDir string) error {
 	return os.RemoveAll(srcDir)
 }
 
-// copyFileForOrg copies a file without removing the source, streaming in
-// chunks so memory use stays bounded regardless of file size.
+func syncFile(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
+// copyFileForOrg copies a file without removing the source (streaming).
 func copyFileForOrg(src, dst string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer srcFile.Close()
+	return copyReaderToFile(srcFile, dst)
+}
 
+// copyReaderToFile streams r into dst; removes a partial dst on failure.
+func copyReaderToFile(r io.Reader, dst string) error {
 	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
@@ -297,10 +312,7 @@ func copyFileForOrg(src, dst string) error {
 		}
 	}()
 
-	if _, err := io.Copy(dstFile, srcFile); err != nil {
-		return err
-	}
-	if err := dstFile.Sync(); err != nil {
+	if _, err := io.Copy(dstFile, r); err != nil {
 		return err
 	}
 	ok = true

--- a/internal/organize/pipeline_test.go
+++ b/internal/organize/pipeline_test.go
@@ -1,16 +1,15 @@
 package organize
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/JeremiahM37/librarr/internal/config"
 )
-
-// errCrossDevice stands in for EXDEV so tests can force moveFile's copy fallback.
-var errCrossDevice = syscall.EXDEV
 
 func TestSanitizePath(t *testing.T) {
 	tests := []struct {
@@ -80,116 +79,133 @@ func TestOrganizer_DisabledDoesNothing(t *testing.T) {
 	}
 }
 
-func TestMoveFileSameFilesystem(t *testing.T) {
-	dir := t.TempDir()
-	src := filepath.Join(dir, "src.m4b")
-	dst := filepath.Join(dir, "dst.m4b")
-	payload := []byte("librarr-move-test")
-	if err := os.WriteFile(src, payload, 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := moveFile(src, dst); err != nil {
-		t.Fatalf("moveFile: %v", err)
-	}
-	if _, err := os.Stat(src); !os.IsNotExist(err) {
-		t.Fatalf("source still present after move: %v", err)
-	}
-	got, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != string(payload) {
-		t.Fatalf("dst content = %q, want %q", got, payload)
-	}
-}
-
-func TestMoveFileStreamsWhenRenameFails(t *testing.T) {
-	dir := t.TempDir()
-	src := filepath.Join(dir, "src.m4b")
-	dst := filepath.Join(dir, "dst.m4b")
-	payload := []byte("forced-fallback-copy")
-	if err := os.WriteFile(src, payload, 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	orig := renameFile
-	renameFile = func(string, string) error {
-		return &os.LinkError{Op: "rename", Old: src, New: dst, Err: errCrossDevice}
-	}
-	defer func() { renameFile = orig }()
-
-	if err := moveFile(src, dst); err != nil {
-		t.Fatalf("moveFile: %v", err)
-	}
-	if _, err := os.Stat(src); !os.IsNotExist(err) {
-		t.Fatalf("source still present after fallback move: %v", err)
-	}
-	got, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != string(payload) {
-		t.Fatalf("dst content = %q, want %q", got, payload)
-	}
-}
-
-func TestCopyFileForOrgStreamsLargeFile(t *testing.T) {
-	dir := t.TempDir()
-	src := filepath.Join(dir, "big.m4b")
-	dst := filepath.Join(dir, "big-copy.m4b")
-
-	// Large enough that a ReadFile fallback would be obviously wrong under a
-	// small container mem_limit; still cheap for CI.
-	const size = 32 << 20 // 32 MiB
-	f, err := os.Create(src)
-	if err != nil {
-		t.Fatal(err)
-	}
-	chunk := make([]byte, 1<<20)
-	for i := range chunk {
-		chunk[i] = byte(i)
-	}
-	written := 0
-	for written < size {
-		n, err := f.Write(chunk)
-		if err != nil {
-			f.Close()
+func TestMoveFile(t *testing.T) {
+	t.Run("same filesystem rename", func(t *testing.T) {
+		dir := t.TempDir()
+		src := filepath.Join(dir, "src.m4b")
+		dst := filepath.Join(dir, "dst.m4b")
+		payload := []byte("librarr-move-test")
+		if err := os.WriteFile(src, payload, 0644); err != nil {
 			t.Fatal(err)
 		}
-		written += n
-	}
-	if err := f.Close(); err != nil {
+
+		if err := moveFile(src, dst); err != nil {
+			t.Fatalf("moveFile: %v", err)
+		}
+		if _, err := os.Stat(src); !os.IsNotExist(err) {
+			t.Fatalf("source still present after move: %v", err)
+		}
+		got, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("dst content = %q, want %q", got, payload)
+		}
+	})
+
+	t.Run("streams when rename fails", func(t *testing.T) {
+		dir := t.TempDir()
+		src := filepath.Join(dir, "src.m4b")
+		dst := filepath.Join(dir, "dst.m4b")
+		payload := []byte("forced-fallback-copy")
+		if err := os.WriteFile(src, payload, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		orig := renameFile
+		renameFile = func(string, string) error {
+			return errors.New("rename forced fail")
+		}
+		defer func() { renameFile = orig }()
+
+		if err := moveFile(src, dst); err != nil {
+			t.Fatalf("moveFile: %v", err)
+		}
+		if _, err := os.Stat(src); !os.IsNotExist(err) {
+			t.Fatalf("source still present after fallback move: %v", err)
+		}
+		got, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("dst content = %q, want %q", got, payload)
+		}
+	})
+}
+
+func TestCopyFileForOrg(t *testing.T) {
+	t.Run("large file size and content", func(t *testing.T) {
+		dir := t.TempDir()
+		src := filepath.Join(dir, "big.m4b")
+		dst := filepath.Join(dir, "big-copy.m4b")
+
+		// Larger than a naive ReadFile would comfortably fit in a 256MiB
+		// cgroup alongside the process; still cheap for CI.
+		const size = 32 << 20 // 32 MiB
+		payload := bytes.Repeat([]byte{0x5a}, size)
+		if err := os.WriteFile(src, payload, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := copyFileForOrg(src, dst); err != nil {
+			t.Fatalf("copyFileForOrg: %v", err)
+		}
+
+		got, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("content mismatch: len=%d want=%d", len(got), len(payload))
+		}
+	})
+
+	t.Run("removes partial dst on mid-copy failure", func(t *testing.T) {
+		dir := t.TempDir()
+		dst := filepath.Join(dir, "partial.m4b")
+		r := io.MultiReader(
+			bytes.NewReader(bytes.Repeat([]byte("x"), 4096)),
+			&errReader{err: errors.New("injected read failure")},
+		)
+
+		err := copyReaderToFile(r, dst)
+		if err == nil {
+			t.Fatal("expected mid-copy error")
+		}
+		if _, err := os.Stat(dst); !os.IsNotExist(err) {
+			t.Fatalf("partial dst should be removed, stat err=%v", err)
+		}
+	})
+}
+
+func TestCopyFileUsesStreamingPath(t *testing.T) {
+	// targets.copyFile must share copyFileForOrg so library imports don't
+	// reintroduce the ReadFile OOM on network mounts.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "book.epub")
+	dst := filepath.Join(dir, "book-out.epub")
+	payload := []byte("ebook-bytes")
+	if err := os.WriteFile(src, payload, 0644); err != nil {
 		t.Fatal(err)
 	}
-
-	if err := copyFileForOrg(src, dst); err != nil {
-		t.Fatalf("copyFileForOrg: %v", err)
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
 	}
-
-	srcInfo, err := os.Stat(src)
+	got, err := os.ReadFile(dst)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dstInfo, err := os.Stat(dst)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if srcInfo.Size() != dstInfo.Size() {
-		t.Fatalf("size mismatch: src=%d dst=%d", srcInfo.Size(), dstInfo.Size())
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("dst content = %q, want %q", got, payload)
 	}
 }
 
-func TestCopyFileForOrgCleansPartialOnFailure(t *testing.T) {
-	dir := t.TempDir()
-	src := filepath.Join(dir, "missing-src.m4b")
-	dst := filepath.Join(dir, "should-not-remain.m4b")
+type errReader struct {
+	err error
+}
 
-	err := copyFileForOrg(src, dst)
-	if err == nil {
-		t.Fatal("expected error for missing source")
-	}
-	if _, err := os.Stat(dst); !os.IsNotExist(err) {
-		t.Fatalf("partial dst should be removed, stat err=%v", err)
-	}
+func (e *errReader) Read([]byte) (int, error) {
+	return 0, e.err
 }

--- a/internal/organize/pipeline_test.go
+++ b/internal/organize/pipeline_test.go
@@ -1,10 +1,16 @@
 package organize
 
 import (
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/JeremiahM37/librarr/internal/config"
 )
+
+// errCrossDevice stands in for EXDEV so tests can force moveFile's copy fallback.
+var errCrossDevice = syscall.EXDEV
 
 func TestSanitizePath(t *testing.T) {
 	tests := []struct {
@@ -71,5 +77,119 @@ func TestOrganizer_DisabledDoesNothing(t *testing.T) {
 
 	if o.cfg.FileOrgEnabled {
 		t.Error("expected FileOrgEnabled to be false")
+	}
+}
+
+func TestMoveFileSameFilesystem(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.m4b")
+	dst := filepath.Join(dir, "dst.m4b")
+	payload := []byte("librarr-move-test")
+	if err := os.WriteFile(src, payload, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := moveFile(src, dst); err != nil {
+		t.Fatalf("moveFile: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("source still present after move: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("dst content = %q, want %q", got, payload)
+	}
+}
+
+func TestMoveFileStreamsWhenRenameFails(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.m4b")
+	dst := filepath.Join(dir, "dst.m4b")
+	payload := []byte("forced-fallback-copy")
+	if err := os.WriteFile(src, payload, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := renameFile
+	renameFile = func(string, string) error {
+		return &os.LinkError{Op: "rename", Old: src, New: dst, Err: errCrossDevice}
+	}
+	defer func() { renameFile = orig }()
+
+	if err := moveFile(src, dst); err != nil {
+		t.Fatalf("moveFile: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("source still present after fallback move: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("dst content = %q, want %q", got, payload)
+	}
+}
+
+func TestCopyFileForOrgStreamsLargeFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "big.m4b")
+	dst := filepath.Join(dir, "big-copy.m4b")
+
+	// Large enough that a ReadFile fallback would be obviously wrong under a
+	// small container mem_limit; still cheap for CI.
+	const size = 32 << 20 // 32 MiB
+	f, err := os.Create(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk := make([]byte, 1<<20)
+	for i := range chunk {
+		chunk[i] = byte(i)
+	}
+	written := 0
+	for written < size {
+		n, err := f.Write(chunk)
+		if err != nil {
+			f.Close()
+			t.Fatal(err)
+		}
+		written += n
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFileForOrg(src, dst); err != nil {
+		t.Fatalf("copyFileForOrg: %v", err)
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if srcInfo.Size() != dstInfo.Size() {
+		t.Fatalf("size mismatch: src=%d dst=%d", srcInfo.Size(), dstInfo.Size())
+	}
+}
+
+func TestCopyFileForOrgCleansPartialOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "missing-src.m4b")
+	dst := filepath.Join(dir, "should-not-remain.m4b")
+
+	err := copyFileForOrg(src, dst)
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("partial dst should be removed, stat err=%v", err)
 	}
 }

--- a/internal/organize/targets.go
+++ b/internal/organize/targets.go
@@ -392,7 +392,5 @@ func (lt *LibraryTargets) ABSCleanupDuplicateEbooks(title string) {
 }
 
 func copyFile(src, dst string) error {
-	// Same streaming path as organize moves — library targets often sit on
-	// network mounts and must not load whole audiobooks/ebooks into RAM.
 	return copyFileForOrg(src, dst)
 }

--- a/internal/organize/targets.go
+++ b/internal/organize/targets.go
@@ -392,9 +392,7 @@ func (lt *LibraryTargets) ABSCleanupDuplicateEbooks(title string) {
 }
 
 func copyFile(src, dst string) error {
-	data, err := os.ReadFile(src)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(dst, data, 0644)
+	// Same streaming path as organize moves — library targets often sit on
+	// network mounts and must not load whole audiobooks/ebooks into RAM.
+	return copyFileForOrg(src, dst)
 }


### PR DESCRIPTION
When organizing downloads onto a different filesystem (e.g. local torrents → CIFS library), `moveFile` fell back from `os.Rename` to `os.ReadFile` + `os.WriteFile`. Large audiobooks (hundreds of MB) were loaded entirely into memory and OOM-killed containers with modest `mem_limit`s in a restart loop. `targets.copyFile` had the same `ReadFile` pattern.

`moveFile` and `copyFile` now stream via `io.Copy`. Partial destinations are removed on mid-copy failure. `Sync` runs only on the cross-FS move path before deleting the source.

**Tests** — `TestMoveFile` (rename + forced fallback), `TestCopyFileForOrg` (large file content + partial cleanup), `TestCopyFileUsesStreamingPath`.