### PR TITLE
Fix BookTracker login form field names

### DIFF
--- a/internal/search/booktracker.go
+++ b/internal/search/booktracker.go
@@ -90,10 +90,10 @@ func (b *BookTracker) login() error {
 
 	loginURL := strings.TrimRight(b.cfg.BookTrackerURL, "/") + "/login.php"
 	form := url.Values{
-		"username":  {b.cfg.BookTrackerUser},
-		"password":  {b.cfg.BookTrackerPass},
-		"autologin": {"1"},
-		"login":     {"1"},
+		"login_username": {b.cfg.BookTrackerUser},
+		"login_password": {b.cfg.BookTrackerPass},
+		"autologin":      {"1"},
+		"login":          {"1"},
 	}
 
 	resp, err := b.authClient.PostForm(loginURL, form)

--- a/internal/search/booktracker_test.go
+++ b/internal/search/booktracker_test.go
@@ -38,6 +38,22 @@ func newBookTrackerTestServer(t *testing.T, authCookie bool) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/login.php", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("login method = %s, want POST", r.Method)
+		}
+		if got := r.PostFormValue("login_username"); got != "u" {
+			t.Errorf("login_username = %q, want u", got)
+		}
+		if got := r.PostFormValue("login_password"); got == "" {
+			t.Error("login_password is empty")
+		}
+		if got := r.PostFormValue("username"); got != "" {
+			t.Errorf("legacy username field unexpectedly sent: %q", got)
+		}
+		if got := r.PostFormValue("password"); got != "" {
+			t.Error("legacy password field unexpectedly sent")
+		}
+
 		if authCookie {
 			// Mimic a phpBB persistent-login cookie (value is a serialized blob).
 			http.SetCookie(w, &http.Cookie{Name: "phpbb2mysql_data", Value: "a%3A2%3A%7Bi%3A0%3Bs%3A1%3A%221%22%3B%7D", Path: "/"})


### PR DESCRIPTION
## Summary

BookTracker's current login form expects `login_username` and
`login_password`. The BookTracker source currently posts the legacy
`username` and `password` field names, so valid credentials are rejected and
the source returns no results.
<img width="902" height="540" alt="image" src="https://github.com/user-attachments/assets/81ff1c50-39d2-4d46-a0a5-7d5fc82087c1" />


This updates the submitted form keys and adds a regression check to the
existing `httptest` server to ensure the current fields are sent.

## Validation

- `gofmt -w internal/search/booktracker.go internal/search/booktracker_test.go`
- `go test ./internal/search -run TestBookTracker -count=1`
- `go test ./...`

## Notes

The test uses only local test values and does not require BookTracker
credentials or network access.