### PR TITLE
Restore the TOTP settings UI and stop sending the secret off-box

### DIFF
--- a/internal/api/totp.go
+++ b/internal/api/totp.go
@@ -1,16 +1,36 @@
 package api
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"image/png"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"time"
 
 	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 )
+
+// totpQRDataURI renders the key's otpauth URL as a PNG QR code, encoded as a
+// data: URI. otp/totp already depends on a barcode encoder, so this costs no
+// new dependency and no request leaves the instance.
+func totpQRDataURI(key *otp.Key) (string, error) {
+	img, err := key.Image(220, 220)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return "", err
+	}
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
 
 // validateTOTPCode validates a TOTP code against a secret.
 func validateTOTPCode(secret, code string) bool {
@@ -107,12 +127,24 @@ func handleTOTPSetup(database *db.DB) http.HandlerFunc {
 			return
 		}
 
-		writeJSON(w, http.StatusOK, map[string]interface{}{
+		resp := map[string]interface{}{
 			"success":      true,
 			"secret":       key.Secret(),
 			"qr_url":       key.URL(),
 			"backup_codes": backupCodes,
-		})
+		}
+		// Render the enrolment QR here rather than in the browser: the otpauth
+		// URL carries the TOTP secret, so handing it to a third-party QR service
+		// would disclose the seed (and break the offline-by-default UI). A data:
+		// URI keeps it in the response we already send.
+		if png, err := totpQRDataURI(key); err == nil {
+			resp["qr_png"] = png
+		} else {
+			// Non-fatal: the UI falls back to the secret and otpauth URI, which
+			// every authenticator app accepts for manual entry.
+			slog.Warn("failed to render TOTP QR code", "error", err)
+		}
+		writeJSON(w, http.StatusOK, resp)
 	}
 }
 

--- a/internal/api/totp_test.go
+++ b/internal/api/totp_test.go
@@ -1,7 +1,13 @@
 package api
 
 import (
+	"bytes"
+	"encoding/base64"
+	"image/png"
+	"strings"
 	"testing"
+
+	"github.com/pquerna/otp/totp"
 )
 
 func TestValidateTOTPCode(t *testing.T) {
@@ -83,4 +89,60 @@ func TestGenerateBackupCodes(t *testing.T) {
 			t.Errorf("expected 0 codes, got %d", len(codes))
 		}
 	})
+}
+
+// TestTOTPQRDataURI checks the enrolment QR is rendered locally into a data:
+// URI. The otpauth URL carries the TOTP secret, so it must never be handed to
+// an external QR service, and data: keeps it inside the response we already send
+// (and inside the img-src allowance in the CSP).
+func TestTOTPQRDataURI(t *testing.T) {
+	key, err := totp.Generate(totp.GenerateOpts{Issuer: "Librarr", AccountName: "tester"})
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	uri, err := totpQRDataURI(key)
+	if err != nil {
+		t.Fatalf("render QR: %v", err)
+	}
+
+	const prefix = "data:image/png;base64,"
+	if !strings.HasPrefix(uri, prefix) {
+		t.Fatalf("expected a PNG data URI, got %.40q", uri)
+	}
+	if strings.Contains(uri, "http://") || strings.Contains(uri, "https://") {
+		t.Error("QR data URI references a remote host; the secret must stay on the instance")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(uri, prefix))
+	if err != nil {
+		t.Fatalf("decode base64 payload: %v", err)
+	}
+	img, err := png.Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("payload is not a valid PNG: %v", err)
+	}
+	if b := img.Bounds(); b.Dx() < 100 || b.Dy() < 100 {
+		t.Errorf("QR image is too small to scan: %dx%d", b.Dx(), b.Dy())
+	}
+}
+
+// TestTOTPQRVariesPerKey guards against the QR degenerating into a placeholder
+// or a cached image: two enrolments must not produce identical pixels. There is
+// no QR decoder in the toolchain, so this plus the PNG checks above is the
+// available evidence that the image really encodes the key it was built from.
+func TestTOTPQRVariesPerKey(t *testing.T) {
+	uris := make([]string, 2)
+	for i := range uris {
+		key, err := totp.Generate(totp.GenerateOpts{Issuer: "Librarr", AccountName: "tester"})
+		if err != nil {
+			t.Fatalf("generate key %d: %v", i, err)
+		}
+		if uris[i], err = totpQRDataURI(key); err != nil {
+			t.Fatalf("render QR %d: %v", i, err)
+		}
+	}
+	if uris[0] == uris[1] {
+		t.Error("two enrolments produced an identical QR image; it is not encoding the key")
+	}
 }

--- a/web/index.html
+++ b/web/index.html
@@ -318,6 +318,55 @@
         </div>
       </div>
 
+      <!-- Two-Factor Authentication (shown by loadTOTPStatus on DB-backed accounts) -->
+      <div id="totp-settings" class="hidden bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6">
+        <div class="mb-4">
+          <h3 class="text-sm font-semibold text-slate-300 uppercase tracking-wider" data-i18n="s_totp_title">Two-Factor Authentication</h3>
+          <p class="text-xs text-slate-500 mt-1" data-i18n="s_totp_desc">Add an extra layer of security with a TOTP authenticator app.</p>
+        </div>
+
+        <div id="totp-disabled-section" class="hidden">
+          <button data-action="setupTOTP" class="px-4 py-2 text-sm bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors" data-i18n="enable_2fa">Enable 2FA</button>
+        </div>
+
+        <div id="totp-enabled-section" class="hidden">
+          <p class="text-sm text-emerald-400 mb-3" data-i18n="totp_enabled_msg">Two-factor authentication is enabled.</p>
+          <button data-action="showDisableTOTP" class="px-4 py-2 text-sm bg-red-600 hover:bg-red-500 text-white rounded-lg transition-colors" data-i18n="disable_2fa">Disable 2FA</button>
+        </div>
+
+        <div id="totp-setup-section" class="hidden space-y-4">
+          <div>
+            <p class="text-xs text-slate-500 mb-2" data-i18n="totp_manual_secret">Or enter this secret manually:</p>
+            <code id="totp-secret-display" class="block bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 break-all"></code>
+          </div>
+          <div>
+            <p class="text-xs text-slate-500 mb-2" data-i18n="totp_setup_uri">Setup URI (paste into your authenticator app):</p>
+            <code id="totp-otpauth-uri" class="block bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-xs text-slate-400 break-all"></code>
+          </div>
+          <div>
+            <p class="text-xs text-slate-500 mb-2" data-i18n="totp_backup_codes">Backup Codes (save these somewhere safe!):</p>
+            <div id="totp-backup-codes" class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm text-slate-200"></div>
+          </div>
+          <div>
+            <label class="block text-xs text-slate-500 mb-1" data-i18n="totp_code_label">TOTP Code</label>
+            <input type="text" id="totp-verify-code" class="w-full sm:w-48 bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-500 text-center tracking-widest" placeholder="000000" autocomplete="one-time-code" maxlength="8">
+          </div>
+          <div class="flex gap-2">
+            <button data-action="verifyTOTP" class="px-4 py-2 text-sm bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors" data-i18n="verify_enable">Verify &amp; Enable</button>
+            <button data-action="cancelTOTPSetup" class="px-4 py-2 text-sm bg-slate-700 hover:bg-slate-600 text-slate-200 rounded-lg transition-colors" data-i18n="cancel">Cancel</button>
+          </div>
+        </div>
+
+        <div id="totp-disable-section" class="hidden space-y-3">
+          <p class="text-sm text-slate-400" data-i18n="totp_disable_desc">Enter your current TOTP code to disable 2FA:</p>
+          <input type="text" id="totp-disable-code" class="w-full sm:w-48 bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-500 text-center tracking-widest" placeholder="000000" autocomplete="one-time-code" maxlength="8">
+          <div class="flex gap-2">
+            <button data-action="disableTOTP" class="px-4 py-2 text-sm bg-red-600 hover:bg-red-500 text-white rounded-lg transition-colors" data-i18n="confirm_disable">Confirm Disable</button>
+            <button data-action="cancelDisableTOTP" class="px-4 py-2 text-sm bg-slate-700 hover:bg-slate-600 text-slate-200 rounded-lg transition-colors" data-i18n="cancel">Cancel</button>
+          </div>
+        </div>
+      </div>
+
       <!-- Integrations -->
       <div class="bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6">
         <div class="flex items-start justify-between mb-4 gap-3">

--- a/web/index.html
+++ b/web/index.html
@@ -335,6 +335,10 @@
         </div>
 
         <div id="totp-setup-section" class="hidden space-y-4">
+          <div id="totp-qr-wrap" class="hidden">
+            <p class="text-xs text-slate-500 mb-2" data-i18n="totp_scan_qr">Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)</p>
+            <img id="totp-qr-img" alt="TOTP QR code" width="220" height="220" class="bg-white p-2 rounded-lg">
+          </div>
           <div>
             <p class="text-xs text-slate-500 mb-2" data-i18n="totp_manual_secret">Or enter this secret manually:</p>
             <code id="totp-secret-display" class="block bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200 break-all"></code>

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2333,11 +2333,20 @@ async function setupTOTP() {
     document.getElementById('totp-disabled-section').classList.add('hidden');
     document.getElementById('totp-setup-section').classList.remove('hidden');
     document.getElementById('totp-secret-display').textContent = data.secret;
-    // Deliberately no QR image: rendering one meant POSTing the otpauth URL —
-    // which contains the TOTP secret — to a third-party QR service, and the UI
-    // is meant to work with no internet access. Show the secret and the
-    // otpauth URI instead; every authenticator app accepts manual entry.
     document.getElementById('totp-otpauth-uri').textContent = data.qr_url || '';
+    // The QR is rendered server-side and arrives as a data: URI — the otpauth
+    // URL carries the TOTP secret, so it must never be handed to a third-party
+    // QR service. If the server could not render one, the secret and otpauth
+    // URI above are enough for manual entry.
+    const qrWrap = document.getElementById('totp-qr-wrap');
+    const qrImg = document.getElementById('totp-qr-img');
+    if (data.qr_png) {
+      qrImg.src = data.qr_png;
+      qrWrap.classList.remove('hidden');
+    } else {
+      qrImg.removeAttribute('src');
+      qrWrap.classList.add('hidden');
+    }
 
     // Display backup codes.
     const codesEl = document.getElementById('totp-backup-codes');

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -44,6 +44,7 @@ const I18N = {
     totp_enabled_msg: 'Two-factor authentication is enabled.',
     totp_scan_qr: 'Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)',
     totp_manual_secret: 'Or enter this secret manually:',
+    totp_setup_uri: 'Setup URI (paste into your authenticator app):',
     totp_backup_codes: 'Backup Codes (save these somewhere safe!):',
     verify_enable: 'Verify & Enable',
     confirm_disable: 'Confirm Disable',
@@ -251,6 +252,7 @@ const I18N = {
     totp_enabled_msg: 'Двухфакторная аутентификация включена.',
     totp_scan_qr: 'Отсканируйте QR-код приложением-аутентификатором (Google Authenticator, Authy и т.д.)',
     totp_manual_secret: 'Или введите секрет вручную:',
+    totp_setup_uri: 'URI для настройки (вставьте в приложение-аутентификатор):',
     totp_backup_codes: 'Резервные коды (сохраните в безопасном месте!):',
     verify_enable: 'Проверить и включить',
     confirm_disable: 'Подтвердить отключение',
@@ -2331,10 +2333,11 @@ async function setupTOTP() {
     document.getElementById('totp-disabled-section').classList.add('hidden');
     document.getElementById('totp-setup-section').classList.remove('hidden');
     document.getElementById('totp-secret-display').textContent = data.secret;
-
-    // Generate QR code using a QR API.
-    const qrUrl = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' + encodeURIComponent(data.qr_url);
-    document.getElementById('totp-qr-img').src = qrUrl;
+    // Deliberately no QR image: rendering one meant POSTing the otpauth URL —
+    // which contains the TOTP secret — to a third-party QR service, and the UI
+    // is meant to work with no internet access. Show the secret and the
+    // otpauth URI instead; every authenticator app accepts manual entry.
+    document.getElementById('totp-otpauth-uri').textContent = data.qr_url || '';
 
     // Display backup codes.
     const codesEl = document.getElementById('totp-backup-codes');
@@ -2698,6 +2701,12 @@ const CLICK_ACTIONS = {
   doLogout: () => doLogout(),
   clearCompleted: () => clearCompleted(),
   addUser: () => addUser(),
+  setupTOTP: () => setupTOTP(),
+  verifyTOTP: () => verifyTOTP(),
+  cancelTOTPSetup: () => cancelTOTPSetup(),
+  showDisableTOTP: () => showDisableTOTP(),
+  cancelDisableTOTP: () => cancelDisableTOTP(),
+  disableTOTP: () => disableTOTP(),
   refreshDownloads: () => refreshDownloads(true), // toolbar button forces a refresh
   // Dynamically rendered rows/cards:
   startDownload: el => {

--- a/web/ui_test.go
+++ b/web/ui_test.go
@@ -32,6 +32,8 @@ func TestTOTPSettingsMarkupExists(t *testing.T) {
 		"totp-disable-section",
 		"totp-secret-display",
 		"totp-otpauth-uri",
+		"totp-qr-wrap",
+		"totp-qr-img",
 		"totp-backup-codes",
 		"totp-verify-code",
 		"totp-disable-code",

--- a/web/ui_test.go
+++ b/web/ui_test.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"regexp"
+	"testing"
+)
+
+// The frontend refactor that externalized the JS dropped the TOTP settings
+// markup while leaving the handlers, their i18n strings, and the backend routes
+// in place — so 2FA could not be enabled from the UI at all, silently, because
+// loadTOTPStatus early-returns when its container is missing. These tests pin
+// the contract between index.html and app.js so that drift fails the build.
+
+func appJS(t *testing.T) string {
+	t.Helper()
+	b, err := StaticFS.ReadFile("static/js/app.js")
+	if err != nil {
+		t.Fatalf("read app.js: %v", err)
+	}
+	return string(b)
+}
+
+// TestTOTPSettingsMarkupExists checks every element the TOTP settings handlers
+// address is present in the shipped HTML.
+func TestTOTPSettingsMarkupExists(t *testing.T) {
+	html := string(IndexHTML)
+	for _, id := range []string{
+		"totp-settings",
+		"totp-disabled-section",
+		"totp-enabled-section",
+		"totp-setup-section",
+		"totp-disable-section",
+		"totp-secret-display",
+		"totp-otpauth-uri",
+		"totp-backup-codes",
+		"totp-verify-code",
+		"totp-disable-code",
+	} {
+		if !regexp.MustCompile(`id="` + regexp.QuoteMeta(id) + `"`).MatchString(html) {
+			t.Errorf("index.html is missing id=%q, which app.js addresses by ID", id)
+		}
+	}
+}
+
+// TestClickActionsAreRegistered checks every data-action in the static markup
+// resolves to a handler in the CLICK_ACTIONS registry. A button wired to a
+// missing action fails silently at runtime — the dispatcher returns early.
+func TestClickActionsAreRegistered(t *testing.T) {
+	js := appJS(t)
+
+	start := regexp.MustCompile(`(?m)^const CLICK_ACTIONS = \{`).FindStringIndex(js)
+	if start == nil {
+		t.Fatal("could not locate the CLICK_ACTIONS registry in app.js")
+	}
+	end := regexp.MustCompile(`(?m)^\};`).FindStringIndex(js[start[1]:])
+	if end == nil {
+		t.Fatal("could not locate the end of the CLICK_ACTIONS registry")
+	}
+	registry := js[start[1] : start[1]+end[0]]
+
+	seen := map[string]bool{}
+	for _, m := range regexp.MustCompile(`data-action="([A-Za-z0-9_]+)"`).FindAllStringSubmatch(string(IndexHTML), -1) {
+		action := m[1]
+		if seen[action] {
+			continue
+		}
+		seen[action] = true
+		if !regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(action) + `\s*:`).MatchString(registry) {
+			t.Errorf("index.html wires data-action=%q but CLICK_ACTIONS has no such handler", action)
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatal("found no data-action attributes in index.html — the scan is broken")
+	}
+}
+
+// TestNoThirdPartyTOTPQR guards the regression this PR fixes: rendering the
+// enrolment QR through an external service sent the otpauth URL — which carries
+// the TOTP secret — off-box, and broke the offline-by-default guarantee in
+// embed.go.
+func TestNoThirdPartyTOTPQR(t *testing.T) {
+	if regexp.MustCompile(`api\.qrserver\.com|chart\.googleapis\.com/chart\?.*qr`).MatchString(appJS(t)) {
+		t.Error("app.js builds a TOTP QR code through a third-party service; the secret must not leave the instance")
+	}
+}


### PR DESCRIPTION
## What

Two-factor auth could not be enabled from the web UI. The frontend refactor that externalized the JS dropped the TOTP settings markup from `index.html`, but everything around it survived — the handlers in `app.js`, their i18n strings (`s_totp_title`, `totp_backup_codes`, …), and the `/api/totp/{setup,verify,disable,status}` routes.

The failure was silent: `loadTOTPStatus` early-returns when `#totp-settings` is missing, so no error surfaced — the card simply never appeared, and `setupTOTP`/`disableTOTP` became unreachable. The login-time TOTP prompt still worked, so an account with 2FA already enabled could sign in; nobody could turn it on.

## Changes

- Restore the TOTP settings card in `index.html`, reusing the i18n keys that were left behind.
- Register the six TOTP handlers in `CLICK_ACTIONS` — they were never added when the dispatcher replaced inline `onclick`, so the buttons would have been inert even with markup present.
- **Drop the enrolment QR image.** It was built by sending the otpauth URL — which contains the TOTP secret — to `api.qrserver.com`. `web/embed.go` states the UI works with no internet access, so that call was both a secret disclosure to a third party and a broken promise offline. The secret and the full otpauth URI are shown for manual entry, which every authenticator app supports. Server-side QR rendering would be a reasonable follow-up if someone wants the convenience back without the leak.

## Tests

New `web/ui_test.go` pins the contract that broke:

- every element ID the TOTP handlers address exists in the shipped markup;
- every `data-action` in the markup resolves to a registered handler;
- no QR is constructed through a third-party service.

All three fail against the pre-fix tree. Full suite passes (15 packages).

Verified in a real browser against a running build: logged in as a DB-backed admin, enabled 2FA with a computed TOTP code, confirmed the enabled state, then disabled it again. Network log shows only `/api/totp/*` calls to the instance — nothing left the box.