### PR TITLE
Allow cover art from configured media services in the CSP

### DIFF
--- a/internal/api/csp_test.go
+++ b/internal/api/csp_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+)
+
+func cspHeader(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+	s := &Server{cfg: cfg}
+	rr := httptest.NewRecorder()
+	s.securityHeadersMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).
+		ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+	return rr.Header().Get("Content-Security-Policy")
+}
+
+func imgSrc(t *testing.T, csp string) string {
+	t.Helper()
+	for _, d := range strings.Split(csp, ";") {
+		if d = strings.TrimSpace(d); strings.HasPrefix(d, "img-src ") {
+			return d
+		}
+	}
+	t.Fatalf("no img-src directive in %q", csp)
+	return ""
+}
+
+// TestCSPAllowsConfiguredHTTPMediaOrigins covers issue #103: a self-hosted
+// Audiobookshelf on the LAN is plain http, so its cover images were blocked by
+// "img-src 'self' data: https:".
+func TestCSPAllowsConfiguredHTTPMediaOrigins(t *testing.T) {
+	got := imgSrc(t, cspHeader(t, &config.Config{
+		ABSURL:     "http://192.168.0.225:13378",
+		KavitaURL:  "http://192.168.0.225:5005/",
+		CalibreURL: "http://calibre.lan:8083/#/library",
+	}))
+
+	for _, want := range []string{
+		"'self'", "data:", "https:",
+		"http://192.168.0.225:13378",
+		"http://192.168.0.225:5005",
+		"http://calibre.lan:8083",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("img-src missing %q\ngot: %s", want, got)
+		}
+	}
+	// Paths and fragments are not valid CSP sources.
+	if strings.Contains(got, "#") || strings.Contains(got, "/library") {
+		t.Errorf("img-src leaked a path or fragment into a source: %s", got)
+	}
+}
+
+// TestCSPStaysStrictWithoutIntegrations pins the default: no configuration must
+// not widen the policy.
+func TestCSPStaysStrictWithoutIntegrations(t *testing.T) {
+	if got, want := imgSrc(t, cspHeader(t, &config.Config{})), "img-src 'self' data: https:"; got != want {
+		t.Errorf("default img-src = %q, want %q", got, want)
+	}
+}
+
+// TestCSPDoesNotAllowHTTPWholesale is the point of deriving the list from
+// configuration: an unconfigured http origin must still be blocked.
+func TestCSPDoesNotAllowHTTPWholesale(t *testing.T) {
+	got := imgSrc(t, cspHeader(t, &config.Config{ABSURL: "http://192.168.0.225:13378"}))
+	for _, src := range strings.Fields(strings.TrimPrefix(got, "img-src ")) {
+		if src == "http:" {
+			t.Errorf("img-src allows all http origins, not just configured ones: %s", got)
+		}
+	}
+	if strings.Contains(got, "http://evil.example") {
+		t.Errorf("img-src contains an origin that was never configured: %s", got)
+	}
+}
+
+// TestCSPRejectsMalformedIntegrationURLs — configured values are operator input,
+// but a stray space or quote must not be able to inject a directive.
+func TestCSPRejectsMalformedIntegrationURLs(t *testing.T) {
+	csp := cspHeader(t, &config.Config{
+		ABSURL:    "http://good.lan:13378",
+		KavitaURL: "http://bad.lan:5005; script-src 'unsafe-inline'",
+		KomgaURL:  "not a url",
+	})
+	if strings.Contains(csp, "unsafe-inline'; script-src") || strings.Count(csp, "script-src") != 1 {
+		t.Errorf("malformed integration URL altered the policy: %s", csp)
+	}
+	if !strings.Contains(imgSrc(t, csp), "http://good.lan:13378") {
+		t.Errorf("valid origin was dropped alongside the malformed ones: %s", csp)
+	}
+}
+
+// TestCSPSkipsRedundantHTTPSOrigins keeps the header short: https origins are
+// already covered by the blanket https: source.
+func TestCSPSkipsRedundantHTTPSOrigins(t *testing.T) {
+	got := imgSrc(t, cspHeader(t, &config.Config{ABSURL: "https://abs.example.com"}))
+	if strings.Contains(got, "abs.example.com") {
+		t.Errorf("https origin needlessly duplicated into img-src: %s", got)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -497,6 +498,53 @@ func (s *Server) requestSizeLimitMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// imgSrcDirective builds the img-src source list. Covers served over https are
+// already allowed, but a self-hosted Audiobookshelf, Kavita, Calibre-Web, or
+// Komga is normally reached over plain http on the LAN, and the browser blocks
+// those covers. Rather than allowing http: wholesale, allow exactly the origins
+// the operator configured — attacker-supplied URLs still cannot widen it.
+func (s *Server) imgSrcDirective() string {
+	sources := []string{"'self'", "data:", "https:"}
+	if s.cfg == nil {
+		return strings.Join(sources, " ")
+	}
+	seen := map[string]bool{}
+	for _, raw := range []string{
+		s.cfg.ABSURL, s.cfg.ABSPublicURL,
+		s.cfg.KavitaURL, s.cfg.KavitaPublicURL,
+		s.cfg.CalibreURL, s.cfg.KomgaURL,
+	} {
+		origin := httpOrigin(raw)
+		// https origins are already covered by the blanket https: source.
+		if origin == "" || seen[origin] || strings.HasPrefix(origin, "https://") {
+			continue
+		}
+		seen[origin] = true
+		sources = append(sources, origin)
+	}
+	return strings.Join(sources, " ")
+}
+
+// httpOrigin reduces a configured service URL to a bare CSP origin
+// (scheme://host[:port]), or "" if it is not a usable http(s) URL. A CSP source
+// cannot contain a path, userinfo, or wildcard host, so anything unparseable is
+// dropped rather than emitted into the header.
+func httpOrigin(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return ""
+	}
+	// Reject anything that would inject extra directives or sources.
+	if strings.ContainsAny(u.Host, " ;,'\"") {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
+}
+
 func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -509,10 +557,12 @@ func (s *Server) securityHeadersMiddleware(next http.Handler) http.Handler {
 		//     <style> element at load; style injection, unlike script, is not
 		//     an XSS vector on its own.
 		//   img-src https: data: — book/audiobook cover art is hotlinked from
-		//     external sources (Open Library, Anna's Archive, indexers).
+		//     external sources (Open Library, Anna's Archive, indexers), plus
+		//     the operator's own media services, which on a LAN are usually
+		//     plain http and would otherwise be blocked.
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "+
-				"img-src 'self' data: https:; font-src 'self'; connect-src 'self'; "+
+				"img-src "+s.imgSrcDirective()+"; font-src 'self'; connect-src 'self'; "+
 				"object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'")
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
Fixes #103.

`img-src` was `'self' data: https:`, so a self-hosted Audiobookshelf — normally plain http on the LAN — had its covers blocked:

> Loading the image 'http://<ip>:13378/api/items/<id>/cover' violates the following Content Security Policy directive: "img-src 'self' data: https:".

Kavita, Calibre-Web, and Komga hit the same wall.

## Approach

Rather than allowing `http:` wholesale, the source list is derived from the operator's own configuration: the configured ABS, Kavita, Calibre, and Komga URLs are reduced to `scheme://host[:port]` and added to `img-src`. Unparseable values are dropped rather than emitted, https origins are skipped since `https:` already covers them, and an unconfigured http origin stays blocked.

## Tests

`internal/api/csp_test.go` covers the configured-origin case, the unchanged strict default, that `http:` is never allowed wholesale, that a malformed URL can't inject a directive, and that https origins aren't duplicated.

Verified in a browser against a running build with a stub ABS on http:

- before: reproduced the reporter's exact console error;
- after: the configured origin loads (`img-src 'self' data: https: http://127.0.0.1:13378`), while an unconfigured http origin is still refused with a CSP violation.