### PR TITLE
Make keeping a torrent enough to keep it seeding (IMPORT_MODE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,10 +34,11 @@ PROWLARR_API_KEY=
 # File Organization
 FILE_ORG_ENABLED=true
 # How imported files reach the library: move | hardlink | copy.
-# move (default) empties the download folder, so torrents cannot keep seeding
-# even with REMOVE_TORRENT_AFTER_IMPORT=false. Use hardlink (same filesystem,
-# no extra disk) or copy to keep seeding. See "Seeding after import" in README.
-IMPORT_MODE=move
+# Leave it blank and it follows REMOVE_TORRENT_AFTER_IMPORT: removing torrents
+# moves (the download folder is emptied), keeping them hardlinks (the payload
+# stays put so the torrent can seed). Set it only to override that.
+# See "Seeding after import" in the README.
+IMPORT_MODE=
 EBOOK_DIR=/books/ebooks
 AUDIOBOOK_DIR=/books/audiobooks
 MANGA_DIR=/books/manga

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ PROWLARR_API_KEY=
 
 # File Organization
 FILE_ORG_ENABLED=true
+# How imported files reach the library: move | hardlink | copy.
+# move (default) empties the download folder, so torrents cannot keep seeding
+# even with REMOVE_TORRENT_AFTER_IMPORT=false. Use hardlink (same filesystem,
+# no extra disk) or copy to keep seeding. See "Seeding after import" in README.
+IMPORT_MODE=move
 EBOOK_DIR=/books/ebooks
 AUDIOBOOK_DIR=/books/audiobooks
 MANGA_DIR=/books/manga

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,20 @@ Check the [good first issue](https://github.com/JeremiahM37/librarr/labels/good%
 5. Commit and push
 6. Open a Pull Request
 
+## Test Suites
+
+| Suite | Command | Needs |
+|---|---|---|
+| Unit + race | `go test ./... -race` | nothing |
+| Integration | `go test -tags=integration ./internal/integration/...` | nothing |
+| Browser end-to-end | `pip install -r e2e/requirements.txt && playwright install chromium`, then `LIBRARR_E2E_BIN=./librarr pytest e2e/` | Chromium |
+| Import modes vs. a real torrent client | `LIBRARR_BIN=./librarr python3 e2e/manual_qbittorrent_check.py --spawn` | Docker |
+
+The last one is not part of CI. It seeds real torrents in a disposable
+qBittorrent and force-rechecks them, which is the only way to prove that an
+imported torrent is still seedable and that deleting a torrent's files leaves
+the library copy intact. Run it when you touch the import pipeline.
+
 ## Code Style
 
 - Standard Go formatting (`gofmt`)

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ which requires Transmission 3.0+).
 | `QB_MANGA_SAVE_PATH` | `/manga-incoming` | Manga download path |
 | `QB_MANGA_CATEGORY` | `manga` | Torrent category for manga |
 | `QB_PRIORITY` | `1` | Download client priority (lower = preferred) |
-| `REMOVE_TORRENT_AFTER_IMPORT` | `true` | Remove the torrent's **record** from the download client after a successful import. Set to `false` to keep the record — on its own that does *not* keep the torrent seeding, see [Seeding after import](#seeding-after-import). |
+| `REMOVE_TORRENT_AFTER_IMPORT` | `true` | Remove the torrent from the download client after a successful import. **Set it to `false` to keep seeding** — librarr then hardlinks imports instead of moving them, so the payload stays where the client can seed it. See [Seeding after import](#seeding-after-import). |
 | `TRANSMISSION_URL` | | Transmission RPC URL (e.g. `http://transmission:9091`) |
 | `TRANSMISSION_USER` | | Transmission RPC username (optional — only if RPC auth is enabled) |
 | `TRANSMISSION_PASS` | | Transmission RPC password (optional) |
@@ -294,7 +294,7 @@ which requires Transmission 3.0+).
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `FILE_ORG_ENABLED` | `true` | Auto-organize downloaded files |
-| `IMPORT_MODE` | `move` | How organized files reach the library: `move` (the download payload is consumed), `hardlink` (a second name for the same data — keeps seeding, no extra disk, same filesystem only), or `copy` (keeps seeding, uses twice the disk). See [Seeding after import](#seeding-after-import). |
+| `IMPORT_MODE` | (automatic) | How organized files reach the library: `move` (the download payload is consumed), `hardlink` (a second name for the same data — keeps seeding, no extra disk, same filesystem only), or `copy` (keeps seeding, uses twice the disk). Leave it unset and it follows `REMOVE_TORRENT_AFTER_IMPORT`: removing torrents moves, keeping them hardlinks. See [Seeding after import](#seeding-after-import). |
 | `EBOOK_DIR` | `/books/ebooks` | Organized ebook destination |
 | `AUDIOBOOK_DIR` | `/books/audiobooks` | Organized audiobook destination |
 | `MANGA_DIR` | `/books/manga` | Organized manga destination |
@@ -303,20 +303,28 @@ which requires Transmission 3.0+).
 
 #### Seeding after import
 
-Two separate things have to survive an import for a torrent to keep seeding, and
-they are controlled by two different settings:
-
-| What has to survive | Setting | Notes |
-|---|---|---|
-| The torrent's **record** in the download client | `REMOVE_TORRENT_AFTER_IMPORT=false` | Without this the torrent is removed after import and there is nothing left to seed. |
-| The torrent's **payload files**, where the client wrote them | `IMPORT_MODE=hardlink` (or `copy`) | The default `move` takes the files out of the download folder. The client keeps showing the torrent at 100%, but the data is gone: the next force-recheck drops it to 0% and re-downloads. |
-
-For private trackers with seed-time minimums, set **both**:
+**One setting.** For private trackers with seed-time minimums:
 
 ```env
-IMPORT_MODE=hardlink
 REMOVE_TORRENT_AFTER_IMPORT=false
 ```
+
+Two separate things have to survive an import for a torrent to keep seeding —
+its **record** in the client, and its **payload files** where the client wrote
+them. Keeping the record is what that setting says; keeping the payload is what
+`IMPORT_MODE` controls. Rather than make you set both, librarr infers the second
+from the first:
+
+| `REMOVE_TORRENT_AFTER_IMPORT` | `IMPORT_MODE` unset resolves to | Result |
+|---|---|---|
+| `true` (default) | `move` | Payload goes into the library; nothing is left to seed, and nothing needs to be. Unchanged from earlier releases. |
+| `false` | `hardlink` | Payload stays in the download folder, the library gets a second name for the same data, and the torrent keeps seeding. |
+
+Setting `IMPORT_MODE` explicitly always wins over that inference — use it to
+force `copy` on a filesystem without hardlinks, or `hardlink` while still
+removing torrents. `IMPORT_MODE=move` together with
+`REMOVE_TORRENT_AFTER_IMPORT=false` is the one combination that cannot seed;
+librarr logs a warning at startup if you configure it.
 
 Notes on the modes:
 
@@ -334,6 +342,11 @@ Notes on the modes:
   library — otherwise the payload would sit in the download folder with nothing
   left to clean it up. The library copy is unaffected (a hardlink keeps the data
   alive). If any file failed to organize, the payload is left alone.
+- **Seed goals belong to your torrent client, not to librarr.** Once imports
+  hardlink, qBittorrent's own share-ratio / seeding-time limits can be set to
+  "remove torrent and its files" when the goal is met: the download folder is
+  cleaned up on the tracker's schedule and the library keeps the book, because
+  the library entry is a link to the same data rather than a second copy.
 - File organization must be on (`FILE_ORG_ENABLED=true`) for any of this; with it
   off, librarr indexes files where they already are and never touches them.
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ which requires Transmission 3.0+).
 | `QB_MANGA_SAVE_PATH` | `/manga-incoming` | Manga download path |
 | `QB_MANGA_CATEGORY` | `manga` | Torrent category for manga |
 | `QB_PRIORITY` | `1` | Download client priority (lower = preferred) |
-| `REMOVE_TORRENT_AFTER_IMPORT` | `true` | Remove torrent from the torrent client after a successful import. Set to `false` to keep seeding (required for private trackers with seed-time minimums). |
+| `REMOVE_TORRENT_AFTER_IMPORT` | `true` | Remove the torrent's **record** from the download client after a successful import. Set to `false` to keep the record — on its own that does *not* keep the torrent seeding, see [Seeding after import](#seeding-after-import). |
 | `TRANSMISSION_URL` | | Transmission RPC URL (e.g. `http://transmission:9091`) |
 | `TRANSMISSION_USER` | | Transmission RPC username (optional — only if RPC auth is enabled) |
 | `TRANSMISSION_PASS` | | Transmission RPC password (optional) |
@@ -294,11 +294,51 @@ which requires Transmission 3.0+).
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `FILE_ORG_ENABLED` | `true` | Auto-organize downloaded files |
+| `IMPORT_MODE` | `move` | How organized files reach the library: `move` (the download payload is consumed), `hardlink` (a second name for the same data — keeps seeding, no extra disk, same filesystem only), or `copy` (keeps seeding, uses twice the disk). See [Seeding after import](#seeding-after-import). |
 | `EBOOK_DIR` | `/books/ebooks` | Organized ebook destination |
 | `AUDIOBOOK_DIR` | `/books/audiobooks` | Organized audiobook destination |
 | `MANGA_DIR` | `/books/manga` | Organized manga destination |
 | `INCOMING_DIR` | `/data/incoming` | Incoming file staging directory as seen by Librarr; qBittorrent paths beneath `QB_SAVE_PATH` are translated here before import |
 | `MANGA_INCOMING_DIR` | `/data/manga-incoming` | Manga incoming staging directory |
+
+#### Seeding after import
+
+Two separate things have to survive an import for a torrent to keep seeding, and
+they are controlled by two different settings:
+
+| What has to survive | Setting | Notes |
+|---|---|---|
+| The torrent's **record** in the download client | `REMOVE_TORRENT_AFTER_IMPORT=false` | Without this the torrent is removed after import and there is nothing left to seed. |
+| The torrent's **payload files**, where the client wrote them | `IMPORT_MODE=hardlink` (or `copy`) | The default `move` takes the files out of the download folder. The client keeps showing the torrent at 100%, but the data is gone: the next force-recheck drops it to 0% and re-downloads. |
+
+For private trackers with seed-time minimums, set **both**:
+
+```env
+IMPORT_MODE=hardlink
+REMOVE_TORRENT_AFTER_IMPORT=false
+```
+
+Notes on the modes:
+
+- **`hardlink`** costs no extra disk — the library entry and the download folder
+  are two names for the same data, and the space is reclaimed when both are
+  gone. It requires the download folder and the library directories to be on the
+  **same filesystem**; in Docker that usually means one volume mounted at a
+  common parent (e.g. `/data`) rather than separate `/downloads` and `/books`
+  mounts. When a link cannot be created (different filesystem, or a filesystem
+  without hardlinks such as CIFS/exFAT), librarr logs a warning and copies
+  instead, so the import still lands.
+- **`copy`** always works but stores the book twice until you delete the torrent.
+- With `hardlink` or `copy`, if you *also* leave `REMOVE_TORRENT_AFTER_IMPORT=true`,
+  librarr removes the torrent **and its files** once every file is safely in the
+  library — otherwise the payload would sit in the download folder with nothing
+  left to clean it up. The library copy is unaffected (a hardlink keeps the data
+  alive). If any file failed to organize, the payload is left alone.
+- File organization must be on (`FILE_ORG_ENABLED=true`) for any of this; with it
+  off, librarr indexes files where they already are and never touches them.
+
+`IMPORT_MODE` applies to download-client imports and manual imports. Uploads
+through the web UI always move, since their source is librarr's own temp file.
 
 ### Sources Registry
 

--- a/cmd/librarr/main.go
+++ b/cmd/librarr/main.go
@@ -95,6 +95,7 @@ func main() {
 	torrentClient := download.SelectTorrentClient(cfg, qb, transmission)
 	if torrentClient != nil {
 		slog.Info("active torrent client", "client", torrentClient.Name())
+		logImportPolicy(cfg)
 	} else {
 		slog.Info("no torrent client configured")
 	}
@@ -170,4 +171,25 @@ func main() {
 	}
 
 	slog.Info("shutdown complete")
+}
+
+// logImportPolicy states, once at startup, what happens to a torrent's files
+// after import — the thing that decides whether a kept torrent can actually
+// seed. Getting this wrong is invisible until a force-recheck drops the
+// torrent to 0%, so it is worth a line in the log.
+func logImportPolicy(cfg *config.Config) {
+	mode := cfg.EffectiveImportMode()
+	automatic := config.NormalizeImportMode(cfg.ImportMode) == config.ImportModeAuto
+	slog.Info("import policy", "mode", mode, "automatic", automatic,
+		"remove_torrent_after_import", cfg.RemoveTorrentAfterImport,
+		"payload_kept", cfg.KeepsPayload())
+
+	if !cfg.RemoveTorrentAfterImport && !cfg.KeepsPayload() {
+		slog.Warn("kept torrents will not be able to seed: IMPORT_MODE=move takes their files into the library, so a force-recheck drops them to 0%",
+			"fix", "unset IMPORT_MODE (or set it to hardlink) to keep the payload in place")
+	}
+	if !cfg.FileOrgEnabled && mode != config.ImportModeMove {
+		slog.Warn("IMPORT_MODE has no effect while FILE_ORG_ENABLED=false: librarr indexes files where they already are",
+			"mode", mode)
+	}
 }

--- a/e2e/manual_qbittorrent_check.py
+++ b/e2e/manual_qbittorrent_check.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Manual end-to-end check of librarr's import modes against a REAL qBittorrent.
+
+The automated suites cover this logic with a fake torrent client. This script
+proves the part a fake cannot: that qBittorrent itself still considers an
+imported torrent seedable, and that deleting a torrent's files does not take
+the library copy with it.
+
+For each scenario it writes a real payload, has qBittorrent hash it into a real
+torrent, seeds it, runs the real librarr binary against the real client, then
+force-rechecks the torrent through the API — the operation that exposes a
+"ghost" torrent whose data was moved away.
+
+    # disposable qBittorrent in Docker, started and removed by the script
+    LIBRARR_BIN=./librarr python3 e2e/manual_qbittorrent_check.py --spawn
+
+    # or point it at a qBittorrent you already run
+    LIBRARR_BIN=./librarr QBT_URL=http://127.0.0.1:8080 QBT_PASSWORD=secret \
+      TEST_ROOT=/data/qbt-check QBT_DOWNLOADS_MOUNT=/downloads \
+      python3 e2e/manual_qbittorrent_check.py
+
+TEST_ROOT/downloads must be the host side of the client's QBT_DOWNLOADS_MOUNT,
+and TEST_ROOT must sit on one filesystem so hardlinks are possible. Not run by
+CI: it needs a torrent client. The filename deliberately avoids pytest's
+test_*.py / *_test.py collection patterns.
+"""
+import argparse
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.parse
+import uuid
+import zipfile
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--spawn", action="store_true",
+                    help="start (and remove) a disposable qBittorrent container")
+parser.add_argument("--keep", action="store_true",
+                    help="with --spawn, leave the container running afterwards")
+args = parser.parse_args()
+
+BIN = os.path.abspath(os.environ.get("LIBRARR_BIN", "./librarr"))
+if not os.path.exists(BIN):
+    sys.exit(f"LIBRARR_BIN not found: {BIN}")
+
+ROOT = os.path.abspath(os.environ.get("TEST_ROOT", "./qbt-check"))
+DOWNLOADS = f"{ROOT}/downloads"
+MOUNT = os.environ.get("QBT_DOWNLOADS_MOUNT", "/downloads")
+QB = os.environ.get("QBT_URL", "http://127.0.0.1:18080")
+PW = os.environ.get("QBT_PASSWORD", "")
+CATEGORY = "librarr-import-check"
+CONTAINER = "librarr-qbt-import-check"
+IMAGE = os.environ.get("QBT_IMAGE", "lscr.io/linuxserver/qbittorrent:latest")
+
+_opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor())
+
+
+def spawn_qbittorrent():
+    """Run a throwaway qBittorrent and return the session's temp password."""
+    global QB
+    QB = "http://127.0.0.1:18080"
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+    subprocess.run([
+        "docker", "run", "-d", "--name", CONTAINER,
+        "-e", f"PUID={os.getuid()}", "-e", f"PGID={os.getgid()}",
+        "-e", "WEBUI_PORT=18080", "-p", "127.0.0.1:18080:18080",
+        "-v", f"{ROOT}/qbconfig:/config", "-v", f"{DOWNLOADS}:{MOUNT}",
+        IMAGE,
+    ], check=True, capture_output=True)
+
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        logs = subprocess.run(["docker", "logs", CONTAINER],
+                              capture_output=True, text=True)
+        for line in (logs.stdout + logs.stderr).splitlines():
+            if "temporary password is provided" in line:
+                return line.rsplit(":", 1)[1].strip()
+        time.sleep(2)
+    sys.exit("qBittorrent container never printed a session password")
+
+
+def stop_qbittorrent():
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+
+
+
+
+def qb(path, data=None, raw=False, files=None):
+    url = f"{QB}/api/v2/{path}"
+    if files is not None:
+        boundary = uuid.uuid4().hex
+        body = b""
+        for k, v in (data or {}).items():
+            body += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n").encode()
+        for k, (fname, content) in files.items():
+            body += (f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"; filename=\"{fname}\"\r\n"
+                     f"Content-Type: application/x-bittorrent\r\n\r\n").encode() + content + b"\r\n"
+        body += f"--{boundary}--\r\n".encode()
+        req = urllib.request.Request(url, data=body,
+                                     headers={"Content-Type": f"multipart/form-data; boundary={boundary}"})
+    elif data is not None:
+        req = urllib.request.Request(url, data=urllib.parse.urlencode(data).encode())
+    else:
+        req = urllib.request.Request(url)
+    with _opener.open(req, timeout=30) as r:
+        payload = r.read()
+    if raw:
+        return payload
+    text = payload.decode(errors="replace").strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def login():
+    # qBittorrent 4.x answers "Ok."; 5.x answers 204 with an empty body and
+    # only the session cookie. Probe an authenticated endpoint to be sure.
+    qb("auth/login", {"username": "admin", "password": PW})
+    try:
+        version = qb("app/version")
+    except Exception as err:  # noqa: BLE001 - surfaced verbatim below
+        sys.exit(f"qBittorrent login failed: {err}")
+    print(f"authenticated against qBittorrent {version} "
+          f"(WebAPI {qb('app/webapiVersion')})", flush=True)
+
+
+def minimal_epub(title):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr(zipfile.ZipInfo("mimetype"), "application/epub+zip",
+                   compress_type=zipfile.ZIP_STORED)
+        z.writestr("META-INF/container.xml",
+                   '<?xml version="1.0"?>\n<container version="1.0" '
+                   'xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+                   '<rootfiles><rootfile full-path="OEBPS/content.opf" '
+                   'media-type="application/oebps-package+xml"/></rootfiles></container>')
+        z.writestr("OEBPS/content.opf",
+                   '<?xml version="1.0" encoding="UTF-8"?>\n<package '
+                   'xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">'
+                   '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+                   '<dc:identifier id="uid">real-qbt</dc:identifier>'
+                   f'<dc:title>{title}</dc:title><dc:creator>Real Tester</dc:creator>'
+                   '<dc:language>en</dc:language></metadata>'
+                   '<manifest><item id="text" href="text.xhtml" '
+                   'media-type="application/xhtml+xml"/></manifest>'
+                   '<spine><itemref idref="text"/></spine></package>')
+        # Padding so the torrent has real content to hash.
+        z.writestr("OEBPS/text.xhtml",
+                   '<?xml version="1.0" encoding="UTF-8"?>\n<html '
+                   'xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head>'
+                   '<body><p>' + ("real qbittorrent payload " * 2000) + '</p></body></html>')
+    return buf.getvalue()
+
+
+def seed_torrent(name, title):
+    """Create a real payload + torrent and get qBittorrent seeding it at 100%."""
+    folder = f"{DOWNLOADS}/{name}"
+    os.makedirs(folder, exist_ok=True)
+    with open(f"{folder}/book.epub", "wb") as f:
+        f.write(minimal_epub(title))
+
+    task = qb("torrentcreator/addTask", {
+        "sourcePath": f"{MOUNT}/{name}",
+        "format": "v1",
+        "private": "false",
+        "startSeeding": "false",
+        "trackers": "http://127.0.0.1:6969/announce",
+    })
+    task_id = task["taskID"]
+    for _ in range(60):
+        status = qb(f"torrentcreator/status?taskID={task_id}")
+        state = status[0]["status"] if status else "?"
+        if state == "Finished":
+            break
+        if state == "Failed":
+            sys.exit(f"torrent creation failed: {status}")
+        time.sleep(1)
+    else:
+        sys.exit("torrent creation timed out")
+
+    torrent = qb(f"torrentcreator/torrentFile?taskID={task_id}", raw=True)
+    qb("torrents/add", data={"savepath": MOUNT, "category": CATEGORY,
+                             "autoTMM": "false", "skip_checking": "false"},
+       files={"torrents": (f"{name}.torrent", torrent)})
+
+    # Wait for qBittorrent to hash the existing data and report a complete seed.
+    for _ in range(60):
+        rows = qb(f"torrents/info?category={CATEGORY}")
+        for t in rows:
+            if t["name"] == name and t["progress"] == 1.0 and "checking" not in t["state"]:
+                return t["hash"]
+        time.sleep(1)
+    sys.exit(f"torrent never reached 100%: {qb(f'torrents/info?category={CATEGORY}')}")
+
+
+def torrent_by_hash(h):
+    for t in qb("torrents/info"):
+        if t["hash"] == h:
+            return t
+    return None
+
+
+def force_recheck(h):
+    """Force a hash recheck and return the torrent's state afterwards. This is
+    the exact operation that exposes a 'ghost' torrent whose data was moved."""
+    qb("torrents/recheck", {"hashes": h})
+    time.sleep(2)
+    for _ in range(60):
+        t = torrent_by_hash(h)
+        if t and "checking" not in t["state"] and t["state"] != "moving":
+            time.sleep(2)  # let the final state settle
+            return torrent_by_hash(h)
+        time.sleep(1)
+    return torrent_by_hash(h)
+
+
+def run_librarr(scenario, import_mode, remove_after):
+    data = f"{ROOT}/data/{scenario}"
+    books = f"{ROOT}/books/{scenario}"
+    os.makedirs(data, exist_ok=True)
+    os.makedirs(books, exist_ok=True)
+    registry = f"{data}/sources.json"
+    with open(registry, "w") as f:
+        json.dump({"version": 1, "annas": {"domain": ""}, "webnovels": [],
+                   "libgen_mirrors": [], "zlibrary_default": ""}, f)
+
+    env = {
+        **os.environ,
+        "LIBRARR_PORT": "15051",
+        "LIBRARR_DB_PATH": f"{data}/librarr.db",
+        "SETTINGS_FILE": f"{data}/settings.json",
+        "LIBRARR_SOURCES_PATH": registry,
+        "QB_URL": QB,
+        "QB_USER": "admin",
+        "QB_PASS": PW,
+        "QB_CATEGORY": CATEGORY,
+        "QB_SAVE_PATH": MOUNT,
+        "INCOMING_DIR": DOWNLOADS,
+        "EBOOK_DIR": books,
+        "AUDIOBOOK_DIR": f"{books}/audio",
+        "MANGA_DIR": f"{books}/manga",
+        "FILE_ORG_ENABLED": "true",
+        "REMOVE_TORRENT_AFTER_IMPORT": "true" if remove_after else "false",
+    }
+    # import_mode None means "not configured at all" — the automatic path.
+    if import_mode is not None:
+        env["IMPORT_MODE"] = import_mode
+    log = open(f"{data}/librarr.log", "w")
+    proc = subprocess.Popen([BIN], env=env, stdout=log, stderr=log)
+    return proc, log, books
+
+
+def wait_for_import(books, timeout=90):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for dirpath, _, names in os.walk(books):
+            for n in names:
+                if n.endswith(".epub"):
+                    time.sleep(2)  # let the post-import steps finish
+                    return os.path.join(dirpath, n)
+        time.sleep(2)
+    return None
+
+
+results = []
+
+
+def check(scenario, ok, detail):
+    results.append((scenario, ok, detail))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {detail}", flush=True)
+
+
+def scenario_hardlink_keeps_seeding():
+    name = "Real Hardlink Book"
+    print("\n=== A: IMPORT_MODE=hardlink, REMOVE_TORRENT_AFTER_IMPORT=false ===", flush=True)
+    h = seed_torrent(name, "Real Hardlink Book")
+    payload = f"{DOWNLOADS}/{name}/book.epub"
+    src_inode = os.stat(payload).st_ino
+
+    proc, log, books = run_librarr("hardlink", "hardlink", False)
+    try:
+        imported = wait_for_import(books)
+        check("A", imported is not None, f"librarr imported the torrent ({imported})")
+        if not imported:
+            return
+        check("A", os.path.exists(payload), "download payload still on disk after import")
+        check("A", os.stat(imported).st_ino == src_inode,
+              f"library file shares the payload's inode ({src_inode})")
+        check("A", os.stat(imported).st_nlink == 2, "inode has 2 links (download + library)")
+    finally:
+        proc.terminate(); proc.wait(timeout=10); log.close()
+
+    t = torrent_by_hash(h)
+    check("A", t is not None, "torrent still registered in qBittorrent")
+    t = force_recheck(h)
+    check("A", t["progress"] == 1.0,
+          f"after force-recheck: progress={t['progress']:.2f} state={t['state']}")
+    check("A", t["state"] not in ("missingFiles", "error"),
+          f"qBittorrent state is seedable: {t['state']}")
+    qb("torrents/delete", {"hashes": h, "deleteFiles": "true"})
+
+
+def scenario_move_reproduces_the_bug():
+    name = "Real Move Book"
+    print("\n=== B: IMPORT_MODE=move (old behavior), REMOVE_TORRENT_AFTER_IMPORT=false ===", flush=True)
+    h = seed_torrent(name, "Real Move Book")
+    payload = f"{DOWNLOADS}/{name}/book.epub"
+
+    proc, log, books = run_librarr("move", "move", False)
+    try:
+        imported = wait_for_import(books)
+        check("B", imported is not None, f"librarr imported the torrent ({imported})")
+        check("B", not os.path.exists(payload), "move mode consumed the download payload")
+    finally:
+        proc.terminate(); proc.wait(timeout=10); log.close()
+
+    t = torrent_by_hash(h)
+    check("B", t is not None and t["progress"] == 1.0,
+          f"torrent still *claims* 100% before recheck (ghost): progress={t['progress']:.2f} state={t['state']}")
+    t = force_recheck(h)
+    check("B", t["progress"] < 1.0 or t["state"] in ("missingFiles", "error"),
+          f"force-recheck exposes the reported bug: progress={t['progress']:.2f} state={t['state']}")
+    qb("torrents/delete", {"hashes": h, "deleteFiles": "true"})
+
+
+def scenario_hardlink_with_removal():
+    name = "Real Removal Book"
+    print("\n=== C: IMPORT_MODE=hardlink, REMOVE_TORRENT_AFTER_IMPORT=true ===", flush=True)
+    h = seed_torrent(name, "Real Removal Book")
+    payload = f"{DOWNLOADS}/{name}/book.epub"
+    original = open(payload, "rb").read()
+
+    proc, log, books = run_librarr("removal", "hardlink", True)
+    try:
+        imported = wait_for_import(books)
+        check("C", imported is not None, f"librarr imported the torrent ({imported})")
+        if imported:
+            time.sleep(5)  # deletion happens right after the import
+    finally:
+        proc.terminate(); proc.wait(timeout=10); log.close()
+
+    check("C", torrent_by_hash(h) is None, "torrent removed from qBittorrent")
+    check("C", not os.path.exists(payload),
+          "qBittorrent deleted the download payload (no orphan left behind)")
+    if imported:
+        check("C", os.path.exists(imported), "library file survived the client-side delete")
+        check("C", open(imported, "rb").read() == original,
+              "library file's bytes are intact after the payload link was removed")
+        check("C", os.stat(imported).st_nlink == 1, "library file is now the only link to the data")
+
+
+def scenario_copy_keeps_seeding():
+    name = "Real Copy Book"
+    print("\n=== D: IMPORT_MODE=copy, REMOVE_TORRENT_AFTER_IMPORT=false ===", flush=True)
+    h = seed_torrent(name, "Real Copy Book")
+    payload = f"{DOWNLOADS}/{name}/book.epub"
+    src_inode = os.stat(payload).st_ino
+
+    proc, log, books = run_librarr("copy", "copy", False)
+    try:
+        imported = wait_for_import(books)
+        check("D", imported is not None, f"librarr imported the torrent ({imported})")
+        if not imported:
+            return
+        check("D", os.path.exists(payload), "download payload still on disk after import")
+        check("D", os.stat(imported).st_ino != src_inode, "library file is an independent copy")
+    finally:
+        proc.terminate(); proc.wait(timeout=10); log.close()
+
+    t = force_recheck(h)
+    check("D", t["progress"] == 1.0 and t["state"] not in ("missingFiles", "error"),
+          f"after force-recheck: progress={t['progress']:.2f} state={t['state']}")
+    qb("torrents/delete", {"hashes": h, "deleteFiles": "true"})
+
+
+def scenario_single_knob():
+    """The one-config-change path: REMOVE_TORRENT_AFTER_IMPORT=false and
+    nothing else. IMPORT_MODE is not set at all."""
+    name = "Real Single Knob Book"
+    print("\n=== E: only REMOVE_TORRENT_AFTER_IMPORT=false (IMPORT_MODE unset) ===", flush=True)
+    h = seed_torrent(name, "Real Single Knob Book")
+    payload = f"{DOWNLOADS}/{name}/book.epub"
+    src_inode = os.stat(payload).st_ino
+
+    proc, log, books = run_librarr("singleknob", None, False)
+    try:
+        imported = wait_for_import(books)
+        check("E", imported is not None, f"librarr imported the torrent ({imported})")
+        if not imported:
+            return
+        policy = [l for l in open(f"{ROOT}/data/singleknob/librarr.log") if "import policy" in l]
+        check("E", any("mode=hardlink" in l and "automatic=true" in l for l in policy),
+              f"startup log resolved the mode: {policy[0].strip() if policy else 'MISSING'}")
+        check("E", os.path.exists(payload), "download payload still on disk after import")
+        check("E", os.stat(imported).st_ino == src_inode,
+              "library file shares the payload inode with IMPORT_MODE unset")
+    finally:
+        proc.terminate(); proc.wait(timeout=10); log.close()
+
+    check("E", torrent_by_hash(h) is not None, "torrent still registered in qBittorrent")
+    t = force_recheck(h)
+    check("E", t["progress"] == 1.0 and t["state"] not in ("missingFiles", "error"),
+          f"still seedable after force-recheck: progress={t['progress']:.2f} state={t['state']}")
+    qb("torrents/delete", {"hashes": h, "deleteFiles": "true"})
+
+
+os.makedirs(DOWNLOADS, exist_ok=True)
+os.makedirs(f"{ROOT}/qbconfig", exist_ok=True)
+if args.spawn:
+    PW = spawn_qbittorrent()
+    print(f"spawned {CONTAINER} (session password {PW})", flush=True)
+elif not PW:
+    sys.exit("set QBT_PASSWORD, or pass --spawn to start a disposable client")
+
+login()
+for stale in qb(f"torrents/info?category={CATEGORY}"):
+    qb("torrents/delete", {"hashes": stale["hash"], "deleteFiles": "true"})
+shutil.rmtree(f"{ROOT}/books", ignore_errors=True)
+shutil.rmtree(f"{ROOT}/data", ignore_errors=True)
+
+scenario_single_knob()
+scenario_hardlink_keeps_seeding()
+scenario_move_reproduces_the_bug()
+scenario_hardlink_with_removal()
+scenario_copy_keeps_seeding()
+
+if args.spawn and not args.keep:
+    stop_qbittorrent()
+
+failed = [r for r in results if not r[1]]
+print("\n" + "=" * 60)
+print(f"{len(results) - len(failed)}/{len(results)} checks passed")
+if failed:
+    for s, _, d in failed:
+        print(f"  FAILED [{s}] {d}")
+    sys.exit(1)
+print("ALL REAL-QBITTORRENT CHECKS PASSED")

--- a/e2e/test_user_journey.py
+++ b/e2e/test_user_journey.py
@@ -423,8 +423,8 @@ def test_import_mode_saves_from_settings_ui(ui):
     page = ui["page"]
     page.click('[data-action="switchTab"][data-arg="settings"]')
     page.wait_for_selector("#setting-import_mode")
-    assert page.input_value("#setting-import_mode") == "move", \
-        "default import mode should be move"
+    assert page.input_value("#setting-import_mode") == "", \
+        "import mode should start on Automatic"
 
     page.select_option("#setting-import_mode", "hardlink")
     page.wait_for_timeout(500)
@@ -438,8 +438,42 @@ def test_import_mode_saves_from_settings_ui(ui):
         assert page.input_value("#setting-import_mode") == "hardlink", \
             "saved import mode did not survive a reload"
     finally:
-        page.select_option("#setting-import_mode", "move")
+        page.select_option("#setting-import_mode", "")
         page.wait_for_timeout(500)
+        assert api(page, "/api/settings").get("import_mode") == "", \
+            "Automatic should clear the override"
+
+
+def test_keeping_torrents_alone_switches_imports_to_hardlink(ui):
+    """The one-knob contract: turning off "remove torrents after import" is by
+    itself enough to make imports keep the payload, with no second setting."""
+    page = ui["page"]
+    page.click('[data-action="switchTab"][data-arg="settings"]')
+    page.wait_for_selector("#setting-import_mode")
+    assert page.input_value("#setting-import_mode") == "", "expected Automatic"
+
+    settings = api(page, "/api/settings")
+    assert settings.get("effective_import_mode") == "move", \
+        "with torrents removed, imports should move"
+
+    # The checkbox is sr-only; the visible control is the styled track beside
+    # it, which the wrapping <label> forwards to the input.
+    page.click("#remove-torrent-toggle + div")
+    page.wait_for_timeout(700)
+    assert not page.is_checked("#remove-torrent-toggle"), "toggle did not flip"
+    try:
+        settings = api(page, "/api/settings")
+        assert settings.get("import_mode") == "", "no second setting should be written"
+        assert settings.get("effective_import_mode") == "hardlink", \
+            "keeping torrents must imply a payload-preserving import"
+        assert api(page, "/api/config").get("import_mode") == "hardlink"
+
+        hint = page.inner_text("#import-mode-effective")
+        assert "hardlink" in hint.lower() and "seeding" in hint.lower(), \
+            f"UI should spell out the resolved mode, got: {hint!r}"
+    finally:
+        page.click("#remove-torrent-toggle + div")
+        page.wait_for_timeout(700)
 
 
 def test_direct_download_moves_even_in_hardlink_mode(ui):

--- a/e2e/test_user_journey.py
+++ b/e2e/test_user_journey.py
@@ -397,3 +397,86 @@ def test_kavita_library_ids_save_from_settings_ui(ui):
     page.wait_for_timeout(500)
     assert page.input_value("#setting-kavita_ebook_library_id") == "4"
     assert page.input_value("#setting-kavita_manga_library_id") == "9"
+
+
+# ── Import mode / seeding (issue #59) ──────────────────────────────────────
+
+def _wait_for_download(page, title, timeout=60):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        rows = api(page, "/api/downloads").get("downloads") or []
+        ours = [j for j in rows if j.get("title") == title]
+        if ours:
+            last = ours[0]
+            if last.get("status") == "completed":
+                return last
+            assert last.get("status") not in ("error", "dead_letter"), \
+                f"download failed: {json.dumps(last)}"
+        time.sleep(2)  # gentle poll — 1/s trips the API rate limiter
+    raise AssertionError(f"job never completed: {last}")
+
+
+def test_import_mode_saves_from_settings_ui(ui):
+    """Keeping a torrent seedable needs its payload left in place, which is what
+    the import-mode select controls. It must round-trip UI → API → reload."""
+    page = ui["page"]
+    page.click('[data-action="switchTab"][data-arg="settings"]')
+    page.wait_for_selector("#setting-import_mode")
+    assert page.input_value("#setting-import_mode") == "move", \
+        "default import mode should be move"
+
+    page.select_option("#setting-import_mode", "hardlink")
+    page.wait_for_timeout(500)
+    try:
+        assert api(page, "/api/settings").get("import_mode") == "hardlink"
+        assert api(page, "/api/config").get("import_mode") == "hardlink"
+
+        page.reload(wait_until="networkidle")
+        page.click('[data-action="switchTab"][data-arg="settings"]')
+        page.wait_for_timeout(500)
+        assert page.input_value("#setting-import_mode") == "hardlink", \
+            "saved import mode did not survive a reload"
+    finally:
+        page.select_option("#setting-import_mode", "move")
+        page.wait_for_timeout(500)
+
+
+def test_direct_download_moves_even_in_hardlink_mode(ui):
+    """A direct HTTP download is librarr's own file, not a seedable payload.
+    Hardlink mode must not strand a duplicate of it in the incoming directory."""
+    page = ui["page"]
+    incoming = ui["data"] / "incoming"
+
+    page.click('[data-action="switchTab"][data-arg="settings"]')
+    page.wait_for_selector("#setting-import_mode")
+    page.select_option("#setting-import_mode", "hardlink")
+    page.wait_for_timeout(500)
+    try:
+        page.click('[data-action="switchTab"][data-arg="search"]')
+        page.fill("#search-input", "test adventure")
+        page.press("#search-input", "Enter")
+        page.wait_for_selector('[data-action="startDownload"]', timeout=30000)
+
+        # Pick the last card so this is a book the earlier download test did
+        # not already import.
+        title = page.evaluate("""() => {
+            const btns = [...document.querySelectorAll('[data-action="startDownload"]')];
+            const btn = btns[btns.length - 1];
+            return state.renderedResults[+btn.dataset.idx].title;
+        }""")
+        page.evaluate("""() => {
+            const btns = [...document.querySelectorAll('[data-action="startDownload"]')];
+            btns[btns.length - 1].click();
+        }""")
+        _wait_for_download(page, title)
+
+        assert list(ui["books_dir"].rglob("*.epub")), "nothing imported into the library"
+        leftovers = [p for p in incoming.rglob("*") if p.is_file()]
+        assert not leftovers, \
+            f"hardlink mode stranded librarr's own download in incoming: {leftovers}"
+    finally:
+        page.click('[data-action="switchTab"][data-arg="settings"]')
+        page.wait_for_timeout(200)
+        page.select_option("#setting-import_mode", "move")
+        page.wait_for_timeout(500)

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/version"
 )
 
@@ -107,6 +108,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"komga":               s.cfg.HasKomga(),
 		"sabnzbd":             configObj(s.cfg.HasSABnzbd(), s.cfg.SABnzbdURL),
 		"file_org_enabled":    s.cfg.FileOrgEnabled,
+		"import_mode":         config.NormalizeImportMode(s.cfg.ImportMode),
 		"torznab_enabled":     s.cfg.TorznabAPIKey != "",
 		"rate_limit_enabled":  s.cfg.RateLimitEnabled,
 		"metrics_enabled":     s.cfg.MetricsEnabled,

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/JeremiahM37/librarr/internal/config"
 	"github.com/JeremiahM37/librarr/internal/version"
 )
 
@@ -108,7 +107,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"komga":               s.cfg.HasKomga(),
 		"sabnzbd":             configObj(s.cfg.HasSABnzbd(), s.cfg.SABnzbdURL),
 		"file_org_enabled":    s.cfg.FileOrgEnabled,
-		"import_mode":         config.NormalizeImportMode(s.cfg.ImportMode),
+		"import_mode":         s.cfg.EffectiveImportMode(),
 		"torznab_enabled":     s.cfg.TorznabAPIKey != "",
 		"rate_limit_enabled":  s.cfg.RateLimitEnabled,
 		"metrics_enabled":     s.cfg.MetricsEnabled,

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -53,6 +53,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
 		"flibusta_url":                s.cfg.FlibustaURL,
 		"zlibrary_enabled":            s.cfg.ZLibraryEnabled,
 		"remove_torrent_after_import": s.cfg.RemoveTorrentAfterImport,
+		"import_mode":                 config.NormalizeImportMode(s.cfg.ImportMode),
 
 		// Integration URLs and credentials (sensitive ones are masked below).
 		"qb_url":                  s.cfg.QBUrl,
@@ -118,6 +119,9 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	if value, ok := data["annas_archive_domain"].(string); ok && value != "" {
 		data["annas_archive_domain"] = sources.NormalizeDomain(value)
 	}
+	if value, ok := data["import_mode"].(string); ok && value != "" {
+		data["import_mode"] = config.NormalizeImportMode(value)
+	}
 	normalizeSettingURLs(data)
 
 	// Don't save masked values (user didn't change them).
@@ -178,6 +182,11 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 			s.cfg.RemoveTorrentAfterImport = b
 			slog.Info("remove torrent after import updated", "enabled", b)
 		}
+	}
+	if v, ok := data["import_mode"].(string); ok && v != "" {
+		mode := config.NormalizeImportMode(v)
+		s.cfg.ImportMode = mode
+		slog.Info("import mode updated", "mode", mode)
 	}
 	if v, ok := data["annas_archive_domain"].(string); ok && v != "" {
 		s.cfg.AnnasArchiveDomain = sources.NormalizeDomain(v)

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -54,6 +54,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
 		"zlibrary_enabled":            s.cfg.ZLibraryEnabled,
 		"remove_torrent_after_import": s.cfg.RemoveTorrentAfterImport,
 		"import_mode":                 config.NormalizeImportMode(s.cfg.ImportMode),
+		"effective_import_mode":       s.cfg.EffectiveImportMode(),
 
 		// Integration URLs and credentials (sensitive ones are masked below).
 		"qb_url":                  s.cfg.QBUrl,
@@ -119,7 +120,9 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	if value, ok := data["annas_archive_domain"].(string); ok && value != "" {
 		data["annas_archive_domain"] = sources.NormalizeDomain(value)
 	}
-	if value, ok := data["import_mode"].(string); ok && value != "" {
+	if value, ok := data["import_mode"].(string); ok {
+		// Normalizing to "" for an unrecognized value makes the empty-string
+		// rule below delete the override, which is the automatic mode.
 		data["import_mode"] = config.NormalizeImportMode(value)
 	}
 	normalizeSettingURLs(data)
@@ -183,10 +186,12 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 			slog.Info("remove torrent after import updated", "enabled", b)
 		}
 	}
-	if v, ok := data["import_mode"].(string); ok && v != "" {
-		mode := config.NormalizeImportMode(v)
-		s.cfg.ImportMode = mode
-		slog.Info("import mode updated", "mode", mode)
+	// An empty value is the automatic mode, so it is applied like any other —
+	// the merge above has already dropped the override from settings.json.
+	if v, ok := data["import_mode"].(string); ok {
+		s.cfg.ImportMode = config.NormalizeImportMode(v)
+		slog.Info("import mode updated", "mode", s.cfg.ImportMode,
+			"effective", s.cfg.EffectiveImportMode())
 	}
 	if v, ok := data["annas_archive_domain"].(string); ok && v != "" {
 		s.cfg.AnnasArchiveDomain = sources.NormalizeDomain(v)

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -268,3 +268,47 @@ func TestSaveSettings_WhitespaceOnlyURLClearsOverride(t *testing.T) {
 		t.Error("whitespace-only URL should delete the override, not persist a value")
 	}
 }
+
+// A bad import_mode must never reach settings.json or the runtime config: an
+// unrecognized value falls back to "move" rather than disabling organization.
+func TestSaveSettings_NormalizesImportMode(t *testing.T) {
+	s, path := settingsTestServer(t)
+
+	saveSettings(t, s, map[string]interface{}{"import_mode": " HardLink "})
+
+	if got := readSettingsFile(t, path)["import_mode"]; got != config.ImportModeHardlink {
+		t.Errorf("stored import_mode = %v, want %q", got, config.ImportModeHardlink)
+	}
+	if s.cfg.ImportMode != config.ImportModeHardlink {
+		t.Errorf("runtime ImportMode = %q, want %q", s.cfg.ImportMode, config.ImportModeHardlink)
+	}
+
+	saveSettings(t, s, map[string]interface{}{"import_mode": "hardlnik"})
+
+	if got := readSettingsFile(t, path)["import_mode"]; got != config.ImportModeMove {
+		t.Errorf("stored import_mode = %v, want %q for an unrecognized value", got, config.ImportModeMove)
+	}
+	if s.cfg.ImportMode != config.ImportModeMove {
+		t.Errorf("runtime ImportMode = %q, want %q for an unrecognized value", s.cfg.ImportMode, config.ImportModeMove)
+	}
+}
+
+// The settings UI renders the select from this value, so an unset config must
+// still come back as a valid mode rather than an empty string.
+func TestGetSettings_ExposesNormalizedImportMode(t *testing.T) {
+	s, _ := settingsTestServer(t)
+
+	rr := httptest.NewRecorder()
+	s.handleGetSettings(rr, httptest.NewRequest(http.MethodGet, "/api/settings", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET returned %d", rr.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := body["import_mode"]; got != config.ImportModeMove {
+		t.Errorf("import_mode = %v, want %q", got, config.ImportModeMove)
+	}
+}

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -283,32 +283,75 @@ func TestSaveSettings_NormalizesImportMode(t *testing.T) {
 		t.Errorf("runtime ImportMode = %q, want %q", s.cfg.ImportMode, config.ImportModeHardlink)
 	}
 
+	// An unrecognized value clears the override rather than picking a mode,
+	// which returns the setting to automatic.
 	saveSettings(t, s, map[string]interface{}{"import_mode": "hardlnik"})
 
-	if got := readSettingsFile(t, path)["import_mode"]; got != config.ImportModeMove {
-		t.Errorf("stored import_mode = %v, want %q for an unrecognized value", got, config.ImportModeMove)
+	if _, present := readSettingsFile(t, path)["import_mode"]; present {
+		t.Error("an unrecognized import_mode should clear the override")
 	}
-	if s.cfg.ImportMode != config.ImportModeMove {
-		t.Errorf("runtime ImportMode = %q, want %q for an unrecognized value", s.cfg.ImportMode, config.ImportModeMove)
+	if s.cfg.ImportMode != config.ImportModeAuto {
+		t.Errorf("runtime ImportMode = %q, want automatic", s.cfg.ImportMode)
 	}
 }
 
-// The settings UI renders the select from this value, so an unset config must
-// still come back as a valid mode rather than an empty string.
-func TestGetSettings_ExposesNormalizedImportMode(t *testing.T) {
-	s, _ := settingsTestServer(t)
+// Choosing "Automatic" in the UI posts an empty value: the override must be
+// dropped from settings.json AND from the running config, or the two disagree
+// until the next restart.
+func TestSaveSettings_EmptyImportModeRestoresAutomatic(t *testing.T) {
+	s, path := settingsTestServer(t)
+	s.cfg.RemoveTorrentAfterImport = false
 
+	saveSettings(t, s, map[string]interface{}{"import_mode": config.ImportModeMove})
+	if s.cfg.EffectiveImportMode() != config.ImportModeMove {
+		t.Fatalf("setup: effective mode = %q", s.cfg.EffectiveImportMode())
+	}
+
+	saveSettings(t, s, map[string]interface{}{"import_mode": ""})
+
+	if _, present := readSettingsFile(t, path)["import_mode"]; present {
+		t.Error("empty import_mode should delete the override")
+	}
+	if s.cfg.ImportMode != config.ImportModeAuto {
+		t.Errorf("runtime ImportMode = %q, want automatic", s.cfg.ImportMode)
+	}
+	if got := s.cfg.EffectiveImportMode(); got != config.ImportModeHardlink {
+		t.Errorf("effective mode = %q, want %q now that torrents are kept", got, config.ImportModeHardlink)
+	}
+}
+
+// The settings UI renders the select from import_mode and the "this is what
+// will happen" line from effective_import_mode, so both have to be exposed —
+// on Automatic they differ, and that difference is the whole point.
+func TestGetSettings_ExposesImportModeAndItsEffect(t *testing.T) {
+	s, _ := settingsTestServer(t)
+	s.cfg.RemoveTorrentAfterImport = false // keep torrents, nothing else set
+
+	body := getSettings(t, s)
+	if got := body["import_mode"]; got != config.ImportModeAuto {
+		t.Errorf("import_mode = %v, want automatic", got)
+	}
+	if got := body["effective_import_mode"]; got != config.ImportModeHardlink {
+		t.Errorf("effective_import_mode = %v, want %q", got, config.ImportModeHardlink)
+	}
+
+	s.cfg.RemoveTorrentAfterImport = true
+	body = getSettings(t, s)
+	if got := body["effective_import_mode"]; got != config.ImportModeMove {
+		t.Errorf("effective_import_mode = %v, want %q when torrents are removed", got, config.ImportModeMove)
+	}
+}
+
+func getSettings(t *testing.T, s *Server) map[string]interface{} {
+	t.Helper()
 	rr := httptest.NewRecorder()
 	s.handleGetSettings(rr, httptest.NewRequest(http.MethodGet, "/api/settings", nil))
 	if rr.Code != http.StatusOK {
 		t.Fatalf("GET returned %d", rr.Code)
 	}
-
 	var body map[string]interface{}
 	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if got := body["import_mode"]; got != config.ImportModeMove {
-		t.Errorf("import_mode = %v, want %q", got, config.ImportModeMove)
-	}
+	return body
 }

--- a/internal/api/upload.go
+++ b/internal/api/upload.go
@@ -115,18 +115,22 @@ func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
 		title = strings.TrimSuffix(header.Filename, ext)
 	}
 
-	// Organize the file.
+	// Organize the file. An upload is librarr's own temp file, not a download
+	// client payload, so it always moves regardless of IMPORT_MODE — hardlinking
+	// or copying it would strand the temp file in the incoming directory.
 	var organizedPath string
 	var orgErr error
 
+	organizer := s.organizer.Moving()
+
 	switch mediaType {
 	case "ebook":
-		organizedPath, orgErr = s.organizer.OrganizeEbook(tmpPath, title, author)
+		organizedPath, orgErr = organizer.OrganizeEbook(tmpPath, title, author)
 		if orgErr == nil && s.targets != nil {
 			s.targets.ImportEbook(organizedPath, title, author)
 		}
 	case "audiobook":
-		organizedPath, orgErr = s.organizer.OrganizeAudiobook(tmpPath, title, author)
+		organizedPath, orgErr = organizer.OrganizeAudiobook(tmpPath, title, author)
 		if orgErr == nil && s.targets != nil {
 			s.targets.ImportAudiobook()
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,9 +115,11 @@ type Config struct {
 	// Post-import torrent handling
 	RemoveTorrentAfterImport bool
 
-	// How organized files reach the library: move, hardlink, or copy.
-	// Only "move" consumes the download payload; the other two leave it where
-	// the download client wrote it so the torrent can keep seeding.
+	// How organized files reach the library: move, hardlink, copy, or empty
+	// for automatic. Only "move" consumes the download payload; the other two
+	// leave it where the download client wrote it so the torrent can keep
+	// seeding. Read it through EffectiveImportMode, which resolves the
+	// automatic case against RemoveTorrentAfterImport.
 	ImportMode string
 
 	// Flibusta
@@ -362,7 +364,7 @@ func buildFromEnv() *Config {
 		SABPriority: getEnvInt("SAB_PRIORITY", 2),
 
 		RemoveTorrentAfterImport: getEnvBool("REMOVE_TORRENT_AFTER_IMPORT", true),
-		ImportMode:               NormalizeImportMode(getEnv("IMPORT_MODE", ImportModeMove)),
+		ImportMode:               NormalizeImportMode(getEnv("IMPORT_MODE", ImportModeAuto)),
 
 		RateLimitEnabled: getEnvBool("RATE_LIMIT_ENABLED", true),
 		MetricsEnabled:   getEnvBool("METRICS_ENABLED", true),
@@ -616,8 +618,8 @@ func (c *Config) applySettingsFileOverrides() {
 		*fieldPtr = s
 	}
 	// import_mode is normalized rather than trusted, so a typo in settings.json
-	// falls back to "move" instead of silently disabling organization.
-	if v, ok := raw["import_mode"].(string); ok && strings.TrimSpace(v) != "" {
+	// lands on the automatic default instead of silently picking a mode.
+	if v, ok := raw["import_mode"].(string); ok {
 		c.ImportMode = NormalizeImportMode(v)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,11 @@ type Config struct {
 	// Post-import torrent handling
 	RemoveTorrentAfterImport bool
 
+	// How organized files reach the library: move, hardlink, or copy.
+	// Only "move" consumes the download payload; the other two leave it where
+	// the download client wrote it so the torrent can keep seeding.
+	ImportMode string
+
 	// Flibusta
 	FlibustaURL     string
 	FlibustaEnabled bool
@@ -357,6 +362,7 @@ func buildFromEnv() *Config {
 		SABPriority: getEnvInt("SAB_PRIORITY", 2),
 
 		RemoveTorrentAfterImport: getEnvBool("REMOVE_TORRENT_AFTER_IMPORT", true),
+		ImportMode:               NormalizeImportMode(getEnv("IMPORT_MODE", ImportModeMove)),
 
 		RateLimitEnabled: getEnvBool("RATE_LIMIT_ENABLED", true),
 		MetricsEnabled:   getEnvBool("METRICS_ENABLED", true),
@@ -609,6 +615,12 @@ func (c *Config) applySettingsFileOverrides() {
 		}
 		*fieldPtr = s
 	}
+	// import_mode is normalized rather than trusted, so a typo in settings.json
+	// falls back to "move" instead of silently disabling organization.
+	if v, ok := raw["import_mode"].(string); ok && strings.TrimSpace(v) != "" {
+		c.ImportMode = NormalizeImportMode(v)
+	}
+
 	// Prefer canonical key; accept legacy alias used by some deployments.
 	if c.AnnasArchiveSecretKey == "" {
 		if s, ok := raw["annas_secret_key"].(string); ok && s != "" {

--- a/internal/config/importmode.go
+++ b/internal/config/importmode.go
@@ -14,28 +14,55 @@ import "strings"
 //     otherwise librarr falls back to a copy.
 //   - ImportModeCopy duplicates the bytes. Seeding continues at the cost of
 //     twice the disk.
+//   - ImportModeAuto (the default, and what an unrecognized value becomes)
+//     resolves from RemoveTorrentAfterImport: keeping torrents means the user
+//     wants them seedable, so imports hardlink; removing them means nothing
+//     needs the payload, so imports move.
 const (
+	ImportModeAuto     = ""
 	ImportModeMove     = "move"
 	ImportModeHardlink = "hardlink"
 	ImportModeCopy     = "copy"
 )
 
 // NormalizeImportMode maps user input onto a supported import mode. Anything
-// unrecognized (including an empty value) becomes ImportModeMove, which is the
-// historical behavior.
+// unrecognized (including an empty value) becomes ImportModeAuto, so a typo
+// lands on the default rather than silently picking a mode nobody asked for.
 func NormalizeImportMode(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case ImportModeMove:
+		return ImportModeMove
 	case ImportModeHardlink, "hard_link", "hard-link", "link":
 		return ImportModeHardlink
 	case ImportModeCopy:
 		return ImportModeCopy
 	default:
-		return ImportModeMove
+		return ImportModeAuto
 	}
+}
+
+// EffectiveImportMode is the mode imports actually run in. An explicit
+// IMPORT_MODE always wins; otherwise the mode follows the one setting whose
+// whole purpose is seeding, so keeping torrents is enough on its own to keep
+// them seedable.
+func (c *Config) EffectiveImportMode() string {
+	if mode := NormalizeImportMode(c.ImportMode); mode != ImportModeAuto {
+		return mode
+	}
+	if !c.RemoveTorrentAfterImport {
+		return ImportModeHardlink
+	}
+	return ImportModeMove
 }
 
 // ImportModeKeepsPayload reports whether mode leaves the downloaded payload in
 // place, which is what a torrent needs in order to keep seeding after import.
 func ImportModeKeepsPayload(mode string) bool {
-	return NormalizeImportMode(mode) != ImportModeMove
+	return mode == ImportModeHardlink || mode == ImportModeCopy
+}
+
+// KeepsPayload reports whether imports leave the download payload where the
+// client wrote it.
+func (c *Config) KeepsPayload() bool {
+	return ImportModeKeepsPayload(c.EffectiveImportMode())
 }

--- a/internal/config/importmode.go
+++ b/internal/config/importmode.go
@@ -1,0 +1,41 @@
+package config
+
+import "strings"
+
+// Import modes decide how an organized file gets from the download folder into
+// the library.
+//
+//   - ImportModeMove consumes the download: the payload is gone from the
+//     download folder afterwards, so the torrent can no longer be seeded even
+//     when its record is kept in the client (a force-recheck drops it to 0%).
+//   - ImportModeHardlink adds a second directory entry for the same data. The
+//     library and the download folder share the bytes, so seeding continues and
+//     no extra disk is used. Requires both paths to live on one filesystem;
+//     otherwise librarr falls back to a copy.
+//   - ImportModeCopy duplicates the bytes. Seeding continues at the cost of
+//     twice the disk.
+const (
+	ImportModeMove     = "move"
+	ImportModeHardlink = "hardlink"
+	ImportModeCopy     = "copy"
+)
+
+// NormalizeImportMode maps user input onto a supported import mode. Anything
+// unrecognized (including an empty value) becomes ImportModeMove, which is the
+// historical behavior.
+func NormalizeImportMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case ImportModeHardlink, "hard_link", "hard-link", "link":
+		return ImportModeHardlink
+	case ImportModeCopy:
+		return ImportModeCopy
+	default:
+		return ImportModeMove
+	}
+}
+
+// ImportModeKeepsPayload reports whether mode leaves the downloaded payload in
+// place, which is what a torrent needs in order to keep seeding after import.
+func ImportModeKeepsPayload(mode string) bool {
+	return NormalizeImportMode(mode) != ImportModeMove
+}

--- a/internal/config/importmode_test.go
+++ b/internal/config/importmode_test.go
@@ -10,7 +10,7 @@ func TestNormalizeImportMode(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"", ImportModeMove},
+		{"", ImportModeAuto},
 		{"move", ImportModeMove},
 		{"MOVE", ImportModeMove},
 		{"  move  ", ImportModeMove},
@@ -21,10 +21,10 @@ func TestNormalizeImportMode(t *testing.T) {
 		{"link", ImportModeHardlink},
 		{"copy", ImportModeCopy},
 		{"COPY", ImportModeCopy},
-		// A typo must not silently become something destructive or exotic;
-		// it falls back to the historical behavior.
-		{"hardlnik", ImportModeMove},
-		{"symlink", ImportModeMove},
+		// A typo must not silently pick a mode nobody asked for; it lands on
+		// the automatic default.
+		{"hardlnik", ImportModeAuto},
+		{"symlink", ImportModeAuto},
 	}
 
 	for _, tt := range tests {
@@ -36,11 +36,11 @@ func TestNormalizeImportMode(t *testing.T) {
 
 func TestImportModeKeepsPayload(t *testing.T) {
 	tests := map[string]bool{
-		"":         false,
-		"move":     false,
-		"nonsense": false,
-		"hardlink": true,
-		"copy":     true,
+		ImportModeAuto:     false,
+		ImportModeMove:     false,
+		"nonsense":         false,
+		ImportModeHardlink: true,
+		ImportModeCopy:     true,
 	}
 	for mode, want := range tests {
 		if got := ImportModeKeepsPayload(mode); got != want {
@@ -49,10 +49,66 @@ func TestImportModeKeepsPayload(t *testing.T) {
 	}
 }
 
-func TestLoad_ImportModeDefaultsToMove(t *testing.T) {
+// The single-knob contract: keeping torrents is on its own enough to keep them
+// seedable, and an explicit mode always wins over that inference.
+func TestEffectiveImportMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		configured   string
+		removeAfter  bool
+		want         string
+		keepsPayload bool
+	}{
+		{"auto + remove torrents", ImportModeAuto, true, ImportModeMove, false},
+		{"auto + keep torrents", ImportModeAuto, false, ImportModeHardlink, true},
+		{"typo + keep torrents", "hardlnik", false, ImportModeHardlink, true},
+		{"explicit move beats keep", ImportModeMove, false, ImportModeMove, false},
+		{"explicit copy beats keep", ImportModeCopy, false, ImportModeCopy, true},
+		{"explicit hardlink with removal", ImportModeHardlink, true, ImportModeHardlink, true},
+		{"explicit copy with removal", ImportModeCopy, true, ImportModeCopy, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{ImportMode: tt.configured, RemoveTorrentAfterImport: tt.removeAfter}
+			if got := cfg.EffectiveImportMode(); got != tt.want {
+				t.Errorf("EffectiveImportMode() = %q, want %q", got, tt.want)
+			}
+			if got := cfg.KeepsPayload(); got != tt.keepsPayload {
+				t.Errorf("KeepsPayload() = %v, want %v", got, tt.keepsPayload)
+			}
+		})
+	}
+}
+
+// Nothing configured behaves exactly as librarr always has: torrents are
+// removed after import, so imports move.
+func TestLoad_ImportModeDefaultsToAutomaticMove(t *testing.T) {
 	os.Unsetenv("IMPORT_MODE")
-	if cfg := Load(); cfg.ImportMode != ImportModeMove {
-		t.Errorf("ImportMode = %q, want %q", cfg.ImportMode, ImportModeMove)
+	os.Unsetenv("REMOVE_TORRENT_AFTER_IMPORT")
+	os.Unsetenv("SETTINGS_FILE")
+	cfg := Load()
+	if cfg.ImportMode != ImportModeAuto {
+		t.Errorf("ImportMode = %q, want automatic", cfg.ImportMode)
+	}
+	if got := cfg.EffectiveImportMode(); got != ImportModeMove {
+		t.Errorf("EffectiveImportMode() = %q, want %q", got, ImportModeMove)
+	}
+}
+
+// The one-setting path: keeping torrents is enough to make them seedable.
+func TestLoad_KeepingTorrentsAloneEnablesHardlink(t *testing.T) {
+	os.Unsetenv("IMPORT_MODE")
+	os.Setenv("REMOVE_TORRENT_AFTER_IMPORT", "false")
+	os.Unsetenv("SETTINGS_FILE")
+	defer os.Unsetenv("REMOVE_TORRENT_AFTER_IMPORT")
+
+	cfg := Load()
+	if got := cfg.EffectiveImportMode(); got != ImportModeHardlink {
+		t.Errorf("EffectiveImportMode() = %q, want %q", got, ImportModeHardlink)
+	}
+	if !cfg.KeepsPayload() {
+		t.Error("KeepsPayload() = false; a kept torrent needs its payload")
 	}
 }
 
@@ -64,11 +120,11 @@ func TestLoad_ImportModeFromEnv(t *testing.T) {
 	}
 }
 
-func TestLoad_ImportModeInvalidEnvFallsBackToMove(t *testing.T) {
+func TestLoad_ImportModeInvalidEnvFallsBackToAutomatic(t *testing.T) {
 	os.Setenv("IMPORT_MODE", "hardlnik")
 	defer os.Unsetenv("IMPORT_MODE")
-	if cfg := Load(); cfg.ImportMode != ImportModeMove {
-		t.Errorf("ImportMode = %q, want %q for an unrecognized value", cfg.ImportMode, ImportModeMove)
+	if cfg := Load(); cfg.ImportMode != ImportModeAuto {
+		t.Errorf("ImportMode = %q, want automatic for an unrecognized value", cfg.ImportMode)
 	}
 }
 
@@ -99,7 +155,25 @@ func TestLoad_ImportModeSettingsFileNormalizesGarbage(t *testing.T) {
 	os.Setenv("SETTINGS_FILE", settingsPath)
 	defer os.Unsetenv("SETTINGS_FILE")
 
-	if cfg := Load(); cfg.ImportMode != ImportModeMove {
-		t.Errorf("ImportMode = %q, want %q for an unrecognized settings value", cfg.ImportMode, ImportModeMove)
+	if cfg := Load(); cfg.ImportMode != ImportModeAuto {
+		t.Errorf("ImportMode = %q, want automatic for an unrecognized settings value", cfg.ImportMode)
+	}
+}
+
+// Clearing the override in the UI writes an empty value; that must return the
+// mode to automatic rather than being ignored as "no key".
+func TestLoad_ImportModeSettingsFileEmptyValueRestoresAutomatic(t *testing.T) {
+	os.Setenv("IMPORT_MODE", "copy")
+	defer os.Unsetenv("IMPORT_MODE")
+
+	settingsPath := t.TempDir() + "/settings.json"
+	if err := os.WriteFile(settingsPath, []byte(`{"import_mode": ""}`), 0600); err != nil {
+		t.Fatalf("write settings file: %v", err)
+	}
+	os.Setenv("SETTINGS_FILE", settingsPath)
+	defer os.Unsetenv("SETTINGS_FILE")
+
+	if cfg := Load(); cfg.ImportMode != ImportModeAuto {
+		t.Errorf("ImportMode = %q, want automatic", cfg.ImportMode)
 	}
 }

--- a/internal/config/importmode_test.go
+++ b/internal/config/importmode_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNormalizeImportMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ImportModeMove},
+		{"move", ImportModeMove},
+		{"MOVE", ImportModeMove},
+		{"  move  ", ImportModeMove},
+		{"hardlink", ImportModeHardlink},
+		{"Hardlink", ImportModeHardlink},
+		{"hard_link", ImportModeHardlink},
+		{"hard-link", ImportModeHardlink},
+		{"link", ImportModeHardlink},
+		{"copy", ImportModeCopy},
+		{"COPY", ImportModeCopy},
+		// A typo must not silently become something destructive or exotic;
+		// it falls back to the historical behavior.
+		{"hardlnik", ImportModeMove},
+		{"symlink", ImportModeMove},
+	}
+
+	for _, tt := range tests {
+		if got := NormalizeImportMode(tt.input); got != tt.want {
+			t.Errorf("NormalizeImportMode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestImportModeKeepsPayload(t *testing.T) {
+	tests := map[string]bool{
+		"":         false,
+		"move":     false,
+		"nonsense": false,
+		"hardlink": true,
+		"copy":     true,
+	}
+	for mode, want := range tests {
+		if got := ImportModeKeepsPayload(mode); got != want {
+			t.Errorf("ImportModeKeepsPayload(%q) = %v, want %v", mode, got, want)
+		}
+	}
+}
+
+func TestLoad_ImportModeDefaultsToMove(t *testing.T) {
+	os.Unsetenv("IMPORT_MODE")
+	if cfg := Load(); cfg.ImportMode != ImportModeMove {
+		t.Errorf("ImportMode = %q, want %q", cfg.ImportMode, ImportModeMove)
+	}
+}
+
+func TestLoad_ImportModeFromEnv(t *testing.T) {
+	os.Setenv("IMPORT_MODE", "HardLink")
+	defer os.Unsetenv("IMPORT_MODE")
+	if cfg := Load(); cfg.ImportMode != ImportModeHardlink {
+		t.Errorf("ImportMode = %q, want %q", cfg.ImportMode, ImportModeHardlink)
+	}
+}
+
+func TestLoad_ImportModeInvalidEnvFallsBackToMove(t *testing.T) {
+	os.Setenv("IMPORT_MODE", "hardlnik")
+	defer os.Unsetenv("IMPORT_MODE")
+	if cfg := Load(); cfg.ImportMode != ImportModeMove {
+		t.Errorf("ImportMode = %q, want %q for an unrecognized value", cfg.ImportMode, ImportModeMove)
+	}
+}
+
+func TestLoad_ImportModeSettingsFileOverridesEnv(t *testing.T) {
+	os.Setenv("IMPORT_MODE", "move")
+	defer os.Unsetenv("IMPORT_MODE")
+
+	settingsPath := t.TempDir() + "/settings.json"
+	if err := os.WriteFile(settingsPath, []byte(`{"import_mode": "copy"}`), 0600); err != nil {
+		t.Fatalf("write settings file: %v", err)
+	}
+	os.Setenv("SETTINGS_FILE", settingsPath)
+	defer os.Unsetenv("SETTINGS_FILE")
+
+	if cfg := Load(); cfg.ImportMode != ImportModeCopy {
+		t.Errorf("ImportMode = %q, want %q from settings file", cfg.ImportMode, ImportModeCopy)
+	}
+}
+
+func TestLoad_ImportModeSettingsFileNormalizesGarbage(t *testing.T) {
+	os.Setenv("IMPORT_MODE", "hardlink")
+	defer os.Unsetenv("IMPORT_MODE")
+
+	settingsPath := t.TempDir() + "/settings.json"
+	if err := os.WriteFile(settingsPath, []byte(`{"import_mode": "hardlinkk"}`), 0600); err != nil {
+		t.Fatalf("write settings file: %v", err)
+	}
+	os.Setenv("SETTINGS_FILE", settingsPath)
+	defer os.Unsetenv("SETTINGS_FILE")
+
+	if cfg := Load(); cfg.ImportMode != ImportModeMove {
+		t.Errorf("ImportMode = %q, want %q for an unrecognized settings value", cfg.ImportMode, ImportModeMove)
+	}
+}

--- a/internal/download/manager.go
+++ b/internal/download/manager.go
@@ -342,7 +342,10 @@ func (m *Manager) runAnnasDownload(job *models.DownloadJob) {
 		}
 	}
 
-	destPath, err := m.organizer.OrganizeEbook(filePath, job.Title, author)
+	// A direct HTTP download is librarr's own file, not a seedable payload, so
+	// it always moves regardless of IMPORT_MODE — hardlinking or copying would
+	// leave a duplicate behind in the incoming directory forever.
+	destPath, err := m.organizer.Moving().OrganizeEbook(filePath, job.Title, author)
 	if err != nil {
 		slog.Warn("organize failed, keeping in place", "error", err)
 		destPath = filePath
@@ -430,7 +433,10 @@ func (m *Manager) runDirectDownload(job *models.DownloadJob, fileURL, sourceID, 
 		}
 	}
 
-	destPath, err := m.organizer.OrganizeEbook(filePath, job.Title, author)
+	// A direct HTTP download is librarr's own file, not a seedable payload, so
+	// it always moves regardless of IMPORT_MODE — hardlinking or copying would
+	// leave a duplicate behind in the incoming directory forever.
+	destPath, err := m.organizer.Moving().OrganizeEbook(filePath, job.Title, author)
 	if err != nil {
 		slog.Warn("organize failed, keeping in place", "error", err)
 		destPath = filePath

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -174,7 +174,7 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 		}
 	} else if keepsPayload {
 		slog.Info("torrent left seeding after import", "name", t.Name, "hash", t.Hash,
-			"mode", config.NormalizeImportMode(w.cfg.ImportMode))
+			"mode", w.cfg.EffectiveImportMode())
 	} else {
 		// The record stays, but its files moved into the library, so the
 		// torrent cannot actually seed. Say so instead of implying otherwise.

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -136,13 +136,14 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 		}
 		return
 	}
+	var inLibrary bool
 	switch mediaType {
 	case "ebook":
-		importErr = w.importEbook(t, savePath, "torrent")
+		inLibrary, importErr = w.importEbook(t, savePath, "torrent")
 	case "audiobook":
-		importErr = w.importAudiobook(t, savePath, "torrent")
+		inLibrary, importErr = w.importAudiobook(t, savePath, "torrent")
 	case "manga":
-		importErr = w.importManga(t, savePath, "torrent")
+		inLibrary, importErr = w.importManga(t, savePath, "torrent")
 	}
 
 	if importErr != nil {
@@ -154,16 +155,31 @@ func (w *Watcher) importTorrent(t TorrentInfo, mediaType string) {
 		return
 	}
 
-	// Optionally remove torrent from qBit after import. Default is to remove;
-	// set REMOVE_TORRENT_AFTER_IMPORT=false to keep seeding (e.g. private trackers).
+	// Optionally remove the torrent from the client after import. Default is to
+	// remove; set REMOVE_TORRENT_AFTER_IMPORT=false to keep the torrent — which
+	// only keeps it *seeding* when IMPORT_MODE also leaves the payload in place.
+	keepsPayload := w.organizer != nil && w.organizer.KeepsPayload()
 	if w.cfg.RemoveTorrentAfterImport {
-		if err := w.torrent.DeleteTorrent(t.Hash, false); err != nil {
+		// In move mode the payload is already gone, so there is nothing to
+		// delete. In hardlink/copy mode it is still sitting in the download
+		// folder: delete it with the torrent, but only once every file is
+		// known to exist in the library under its own path — a hardlink shares
+		// the data, so the library entry survives. If any file failed to
+		// organize, the download folder still holds the only copy.
+		deleteFiles := keepsPayload && inLibrary
+		if err := w.torrent.DeleteTorrent(t.Hash, deleteFiles); err != nil {
 			slog.Warn("failed to remove torrent after import", "hash", t.Hash, "error", err)
 		} else {
-			slog.Info("removed completed torrent", "name", t.Name)
+			slog.Info("removed completed torrent", "name", t.Name, "deleted_files", deleteFiles)
 		}
+	} else if keepsPayload {
+		slog.Info("torrent left seeding after import", "name", t.Name, "hash", t.Hash,
+			"mode", config.NormalizeImportMode(w.cfg.ImportMode))
 	} else {
-		slog.Info("torrent left seeding after import", "name", t.Name, "hash", t.Hash)
+		// The record stays, but its files moved into the library, so the
+		// torrent cannot actually seed. Say so instead of implying otherwise.
+		slog.Info("torrent kept after import but cannot seed: its payload moved into the library",
+			"name", t.Name, "hash", t.Hash, "hint", "set IMPORT_MODE=hardlink to keep seeding")
 	}
 
 	// Mark as imported.
@@ -241,11 +257,11 @@ func (w *Watcher) importNZB(slot SABnzbdHistorySlot, mediaType string) {
 	var importErr error
 	switch mediaType {
 	case "audiobook":
-		importErr = w.importAudiobook(t, savePath, "nzb")
+		_, importErr = w.importAudiobook(t, savePath, "nzb")
 	case "manga":
-		importErr = w.importManga(t, savePath, "nzb")
+		_, importErr = w.importManga(t, savePath, "nzb")
 	default:
-		importErr = w.importEbook(t, savePath, "nzb")
+		_, importErr = w.importEbook(t, savePath, "nzb")
 	}
 
 	if importErr != nil {
@@ -401,12 +417,16 @@ func mapTorrentPath(reportedPath, remoteRoot, localRoot string) (string, bool) {
 	return filepath.Join(localRoot, rel), true
 }
 
-func (w *Watcher) importEbook(t TorrentInfo, savePath, source string) error {
+// importEbook organizes every ebook found under savePath. The bool reports
+// whether all of them now live in the library under a path of their own, i.e.
+// whether the download folder still holds the only copy of anything.
+func (w *Watcher) importEbook(t TorrentInfo, savePath, source string) (bool, error) {
 	bookFiles := findFilesByExt(savePath, []string{".epub", ".mobi", ".pdf", ".azw3"})
 	if len(bookFiles) == 0 {
-		return fmt.Errorf("%w: no ebook files found at %s", errTorrentContentPending, savePath)
+		return false, fmt.Errorf("%w: no ebook files found at %s", errTorrentContentPending, savePath)
 	}
 
+	inLibrary := true
 	for _, bf := range bookFiles {
 		metadata := organize.ExtractEbookMetadata(bf)
 		title := firstNonEmpty(metadata.Title, t.Name)
@@ -416,10 +436,13 @@ func (w *Watcher) importEbook(t TorrentInfo, savePath, source string) error {
 			slog.Warn("organize ebook failed", "file", bf, "error", err)
 			destPath = bf
 		}
+		if destPath == bf {
+			inLibrary = false
+		}
 
 		inserted, err := w.recordTorrentItem(source, t, "ebook", bf, destPath, title, author, metadata.Title, metadata.Author, fileFormat(destPath), t.TotalSize)
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		// Import to external libraries.
@@ -428,7 +451,7 @@ func (w *Watcher) importEbook(t TorrentInfo, savePath, source string) error {
 		}
 	}
 
-	return nil
+	return inLibrary, nil
 }
 
 func firstNonEmpty(values ...string) string {
@@ -440,10 +463,12 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func (w *Watcher) importAudiobook(t TorrentInfo, savePath, source string) error {
+// importAudiobook organizes the audiobook at savePath. See importEbook for the
+// meaning of the returned bool.
+func (w *Watcher) importAudiobook(t TorrentInfo, savePath, source string) (bool, error) {
 	// If the source path doesn't even exist, fail the import.
 	if _, statErr := os.Stat(savePath); os.IsNotExist(statErr) {
-		return fmt.Errorf("%w: source path does not exist: %s", errTorrentContentPending, savePath)
+		return false, fmt.Errorf("%w: source path does not exist: %s", errTorrentContentPending, savePath)
 	}
 
 	// Extract author from torrent name if possible.
@@ -460,37 +485,43 @@ func (w *Watcher) importAudiobook(t TorrentInfo, savePath, source string) error 
 
 	destPath, err := w.organizer.OrganizeAudiobook(savePath, title, author)
 	if err != nil {
-		return fmt.Errorf("organize audiobook %q: %w", savePath, err)
+		return false, fmt.Errorf("organize audiobook %q: %w", savePath, err)
 	}
 
 	inserted, err := w.recordTorrentItem(source, t, "audiobook", savePath, destPath, title, author, title, author, fileFormat(destPath), t.TotalSize)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if inserted && w.targets != nil {
 		w.targets.ImportAudiobook()
 	}
 
-	return nil
+	return destPath != savePath, nil
 }
 
-func (w *Watcher) importManga(t TorrentInfo, savePath, source string) error {
+// importManga organizes every manga file found under savePath. See importEbook
+// for the meaning of the returned bool.
+func (w *Watcher) importManga(t TorrentInfo, savePath, source string) (bool, error) {
 	mangaFiles := findFilesByExt(savePath, []string{".cbz", ".cbr", ".zip", ".pdf", ".epub"})
 	if len(mangaFiles) == 0 {
-		return fmt.Errorf("%w: no manga files found at %s", errTorrentContentPending, savePath)
+		return false, fmt.Errorf("%w: no manga files found at %s", errTorrentContentPending, savePath)
 	}
 
+	inLibrary := true
 	for _, mf := range mangaFiles {
 		destPath, err := w.organizer.OrganizeManga(mf, t.Name)
 		if err != nil {
 			slog.Warn("organize manga failed", "file", mf, "error", err)
 			destPath = mf
 		}
+		if destPath == mf {
+			inLibrary = false
+		}
 
 		inserted, err := w.recordTorrentItem(source, t, "manga", mf, destPath, t.Name, "", t.Name, "", fileFormat(destPath), t.TotalSize)
 		if err != nil {
-			return err
+			return false, err
 		}
 
 		if inserted && w.targets != nil {
@@ -498,7 +529,7 @@ func (w *Watcher) importManga(t TorrentInfo, savePath, source string) error {
 		}
 	}
 
-	return nil
+	return inLibrary, nil
 }
 
 func (w *Watcher) recordTorrentItem(source string, t TorrentInfo, mediaType, sourcePath, destinationPath, title, author, metadataTitle, metadataAuthor, format string, fileSize int64) (bool, error) {

--- a/internal/download/watcher_test.go
+++ b/internal/download/watcher_test.go
@@ -469,9 +469,165 @@ func TestImportMangaRejectsTraversalTorrentName(t *testing.T) {
 	w := NewWatcher(cfg, database, nil, nil, organize.NewOrganizer(cfg), nil, nil)
 
 	info := TorrentInfo{Name: "../pwned", Hash: "abc123", TotalSize: 7}
-	_ = w.importManga(info, savePath, "test")
+	_, _ = w.importManga(info, savePath, "test")
 
 	if _, err := os.Stat(outside); err == nil {
 		t.Fatalf("malicious torrent name wrote outside MangaDir: %s", outside)
+	}
+}
+
+// fakeTorrentClient records post-import deletions so tests can assert whether
+// the payload was deleted along with the torrent record.
+type fakeTorrentClient struct {
+	deletes []deleteCall
+}
+
+type deleteCall struct {
+	hash        string
+	deleteFiles bool
+}
+
+func (f *fakeTorrentClient) AddTorrent(string, string, string, string, string) error { return nil }
+func (f *fakeTorrentClient) GetTorrents(string) ([]TorrentInfo, error)               { return nil, nil }
+func (f *fakeTorrentClient) GetTorrentFiles(string) ([]TorrentFile, error)           { return nil, nil }
+func (f *fakeTorrentClient) DeleteTorrent(hash string, deleteFiles bool) error {
+	f.deletes = append(f.deletes, deleteCall{hash: hash, deleteFiles: deleteFiles})
+	return nil
+}
+func (f *fakeTorrentClient) Diagnose() map[string]interface{} { return nil }
+func (f *fakeTorrentClient) Name() string                     { return "fake" }
+
+// newImportFixture wires a watcher over a real temp filesystem holding one
+// finished ebook download, and returns the watcher, the fake client and the
+// payload path inside the download folder.
+func newImportFixture(t *testing.T, importMode string, fileOrg, removeAfterImport bool) (*Watcher, *fakeTorrentClient, string, TorrentInfo) {
+	t.Helper()
+	root := t.TempDir()
+	incoming := filepath.Join(root, "incoming", "Some Book")
+	if err := os.MkdirAll(incoming, 0755); err != nil {
+		t.Fatal(err)
+	}
+	payload := filepath.Join(incoming, "book.epub")
+	if err := os.WriteFile(payload, []byte("book payload"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.New(filepath.Join(root, "library.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	cfg := &config.Config{
+		FileOrgEnabled:           fileOrg,
+		EbookDir:                 filepath.Join(root, "books"),
+		IncomingDir:              filepath.Join(root, "incoming"),
+		QBSavePath:               filepath.Join(root, "incoming"),
+		ImportMode:               importMode,
+		RemoveTorrentAfterImport: removeAfterImport,
+	}
+	client := &fakeTorrentClient{}
+	w := NewWatcher(cfg, database, client, nil, organize.NewOrganizer(cfg), nil, nil)
+
+	info := TorrentInfo{
+		Name:        "Some Book",
+		Hash:        "hash-1",
+		Progress:    1.0,
+		ContentPath: incoming,
+		SavePath:    filepath.Join(root, "incoming"),
+	}
+	return w, client, payload, info
+}
+
+// In move mode the payload is already out of the download folder, so the
+// torrent record is removed without touching files.
+func TestImportTorrentMoveModeRemovesRecordOnly(t *testing.T) {
+	w, client, payload, info := newImportFixture(t, config.ImportModeMove, true, true)
+
+	w.importTorrent(info, "ebook")
+
+	if len(client.deletes) != 1 {
+		t.Fatalf("DeleteTorrent calls = %d, want 1", len(client.deletes))
+	}
+	if client.deletes[0].deleteFiles {
+		t.Error("move mode must not ask the client to delete files")
+	}
+	if _, err := os.Stat(payload); !os.IsNotExist(err) {
+		t.Errorf("move mode should have consumed the payload, stat err = %v", err)
+	}
+}
+
+// In hardlink mode the payload is still in the download folder. Removing the
+// torrent without its files would orphan it, so the files go too — the library
+// keeps its own link to the same data.
+func TestImportTorrentHardlinkModeRemovesTorrentWithFiles(t *testing.T) {
+	w, client, payload, info := newImportFixture(t, config.ImportModeHardlink, true, true)
+
+	w.importTorrent(info, "ebook")
+
+	if len(client.deletes) != 1 {
+		t.Fatalf("DeleteTorrent calls = %d, want 1", len(client.deletes))
+	}
+	if !client.deletes[0].deleteFiles {
+		t.Error("hardlink mode should remove the orphaned payload with the torrent")
+	}
+	if _, err := os.Stat(payload); err != nil {
+		t.Errorf("librarr itself must not remove the payload: %v", err)
+	}
+}
+
+// The fix for issue #59: with the torrent kept and a payload-preserving mode,
+// nothing touches the download folder, so the torrent can really keep seeding.
+func TestImportTorrentKeepsPayloadWhenTorrentIsKept(t *testing.T) {
+	w, client, payload, info := newImportFixture(t, config.ImportModeHardlink, true, false)
+
+	w.importTorrent(info, "ebook")
+
+	if len(client.deletes) != 0 {
+		t.Fatalf("DeleteTorrent calls = %d, want 0", len(client.deletes))
+	}
+	if _, err := os.Stat(payload); err != nil {
+		t.Errorf("payload must stay in the download folder for seeding: %v", err)
+	}
+}
+
+// With organization off the download folder holds the only copy — the library
+// row points straight at it — so its files must never be deleted.
+func TestImportTorrentNeverDeletesFilesWhenOrganizationDisabled(t *testing.T) {
+	w, client, payload, info := newImportFixture(t, config.ImportModeHardlink, false, true)
+
+	w.importTorrent(info, "ebook")
+
+	if len(client.deletes) != 1 {
+		t.Fatalf("DeleteTorrent calls = %d, want 1", len(client.deletes))
+	}
+	if client.deletes[0].deleteFiles {
+		t.Error("must not delete files that are the library's only copy")
+	}
+	if _, err := os.Stat(payload); err != nil {
+		t.Errorf("payload should be untouched: %v", err)
+	}
+}
+
+// A failed organize leaves that file in the download folder as the only copy,
+// which must veto the file deletion for the whole torrent.
+func TestImportTorrentDoesNotDeleteFilesWhenOrganizeFails(t *testing.T) {
+	w, client, payload, info := newImportFixture(t, config.ImportModeHardlink, true, true)
+	// A regular file where the library directory must go makes MkdirAll fail,
+	// so OrganizeEbook returns the source path unchanged.
+	if err := os.WriteFile(w.cfg.EbookDir, []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w.importTorrent(info, "ebook")
+
+	if len(client.deletes) != 1 {
+		t.Fatalf("DeleteTorrent calls = %d, want 1", len(client.deletes))
+	}
+	if client.deletes[0].deleteFiles {
+		t.Error("a failed organize must veto deleting the payload")
+	}
+	if _, err := os.Stat(payload); err != nil {
+		t.Errorf("payload should be untouched: %v", err)
 	}
 }

--- a/internal/download/watcher_test.go
+++ b/internal/download/watcher_test.go
@@ -2,10 +2,12 @@ package download
 
 import (
 	"encoding/json"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/JeremiahM37/librarr/internal/config"
@@ -523,7 +525,7 @@ func newImportFixture(t *testing.T, importMode string, fileOrg, removeAfterImpor
 		EbookDir:                 filepath.Join(root, "books"),
 		IncomingDir:              filepath.Join(root, "incoming"),
 		QBSavePath:               filepath.Join(root, "incoming"),
-		ImportMode:               importMode,
+		ImportMode:               importMode, // config.ImportModeAuto exercises the inferred mode
 		RemoveTorrentAfterImport: removeAfterImport,
 	}
 	client := &fakeTorrentClient{}
@@ -629,5 +631,69 @@ func TestImportTorrentDoesNotDeleteFilesWhenOrganizeFails(t *testing.T) {
 	}
 	if _, err := os.Stat(payload); err != nil {
 		t.Errorf("payload should be untouched: %v", err)
+	}
+}
+
+// The single-knob contract, end to end through the watcher: the operator turns
+// off "remove torrents" and nothing else, and the payload survives the import.
+func TestImportTorrentKeepingTorrentsAloneKeepsThePayload(t *testing.T) {
+	w, client, payload, info := newImportFixture(t, config.ImportModeAuto, true, false)
+
+	w.importTorrent(info, "ebook")
+
+	if got := w.cfg.EffectiveImportMode(); got != config.ImportModeHardlink {
+		t.Fatalf("effective import mode = %q, want %q", got, config.ImportModeHardlink)
+	}
+	if len(client.deletes) != 0 {
+		t.Fatalf("DeleteTorrent calls = %d, want 0", len(client.deletes))
+	}
+	payloadStat, err := os.Stat(payload)
+	if err != nil {
+		t.Fatalf("payload must stay in the download folder for seeding: %v", err)
+	}
+	imported := findImportedEbook(t, w.cfg.EbookDir)
+	importedStat, err := os.Stat(imported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(payloadStat, importedStat) {
+		t.Error("library file should share the payload's data (hardlink)")
+	}
+}
+
+// findImportedEbook returns the single ebook the import placed in the library.
+func findImportedEbook(t *testing.T, libraryDir string) string {
+	t.Helper()
+	var found string
+	err := filepath.WalkDir(libraryDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".epub") {
+			found = path
+		}
+		return nil
+	})
+	if err != nil || found == "" {
+		t.Fatalf("no imported ebook under %s (walk err %v)", libraryDir, err)
+	}
+	return found
+}
+
+// And the default deployment — nothing configured at all — still moves, so
+// existing installs see no change.
+func TestImportTorrentDefaultsToMoveWhenTorrentsAreRemoved(t *testing.T) {
+	w, client, payload, info := newImportFixture(t, config.ImportModeAuto, true, true)
+
+	w.importTorrent(info, "ebook")
+
+	if got := w.cfg.EffectiveImportMode(); got != config.ImportModeMove {
+		t.Fatalf("effective import mode = %q, want %q", got, config.ImportModeMove)
+	}
+	if len(client.deletes) != 1 || client.deletes[0].deleteFiles {
+		t.Fatalf("deletes = %+v, want one record-only removal", client.deletes)
+	}
+	if _, err := os.Stat(payload); !os.IsNotExist(err) {
+		t.Errorf("move mode should have consumed the payload, stat err = %v", err)
 	}
 }

--- a/internal/organize/audio_test.go
+++ b/internal/organize/audio_test.go
@@ -105,6 +105,9 @@ func TestOrganizeAudiobookMissingSourceDoesNotCreateDestDir(t *testing.T) {
 	cfg := &config.Config{
 		FileOrgEnabled: true,
 		AudiobookDir:   filepath.Join(root, "audiobooks"),
+		// Matches the shipped default: torrents are removed after import, so
+		// the automatic import mode resolves to a move.
+		RemoveTorrentAfterImport: true,
 	}
 	o := NewOrganizer(cfg)
 
@@ -142,6 +145,9 @@ func TestOrganizeAudiobookMovesNestedTreeRecursively(t *testing.T) {
 	cfg := &config.Config{
 		FileOrgEnabled: true,
 		AudiobookDir:   filepath.Join(root, "audiobooks"),
+		// Matches the shipped default: torrents are removed after import, so
+		// the automatic import mode resolves to a move.
+		RemoveTorrentAfterImport: true,
 	}
 	o := NewOrganizer(cfg)
 
@@ -187,6 +193,9 @@ func TestOrganizeAudiobookSkipsSymlinks(t *testing.T) {
 	cfg := &config.Config{
 		FileOrgEnabled: true,
 		AudiobookDir:   filepath.Join(root, "audiobooks"),
+		// Matches the shipped default: torrents are removed after import, so
+		// the automatic import mode resolves to a move.
+		RemoveTorrentAfterImport: true,
 	}
 	o := NewOrganizer(cfg)
 
@@ -228,6 +237,9 @@ func TestOrganizeAudiobookRejectsSymlinkSource(t *testing.T) {
 	cfg := &config.Config{
 		FileOrgEnabled: true,
 		AudiobookDir:   filepath.Join(root, "audiobooks"),
+		// Matches the shipped default: torrents are removed after import, so
+		// the automatic import mode resolves to a move.
+		RemoveTorrentAfterImport: true,
 	}
 	o := NewOrganizer(cfg)
 

--- a/internal/organize/importmode_test.go
+++ b/internal/organize/importmode_test.go
@@ -1,0 +1,302 @@
+package organize
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+)
+
+// sameData reports whether two paths are the same inode, i.e. a hardlink pair
+// rather than two independent copies.
+func sameData(t *testing.T, a, b string) bool {
+	t.Helper()
+	ai, err := os.Stat(a)
+	if err != nil {
+		t.Fatalf("stat %s: %v", a, err)
+	}
+	bi, err := os.Stat(b)
+	if err != nil {
+		t.Fatalf("stat %s: %v", b, err)
+	}
+	return os.SameFile(ai, bi)
+}
+
+func writeFile(t *testing.T, path string, payload []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, payload, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ebookOrganizer(t *testing.T, mode string) (*Organizer, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	incoming := filepath.Join(root, "incoming")
+	library := filepath.Join(root, "books")
+	if err := os.MkdirAll(incoming, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{FileOrgEnabled: true, EbookDir: library, ImportMode: mode}
+	return NewOrganizer(cfg), incoming, library
+}
+
+// The bug behind issue #59: with the default move mode the payload leaves the
+// download folder, so keeping the torrent record does not keep it seedable.
+func TestOrganizeEbook_MoveConsumesThePayload(t *testing.T) {
+	o, incoming, _ := ebookOrganizer(t, config.ImportModeMove)
+	src := filepath.Join(incoming, "book.epub")
+	writeFile(t, src, []byte("payload"))
+
+	dst, err := o.OrganizeEbook(src, "Title", "Author")
+	if err != nil {
+		t.Fatalf("OrganizeEbook: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("move mode should remove the source, stat err = %v", err)
+	}
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("library file missing: %v", err)
+	}
+	if o.KeepsPayload() {
+		t.Error("KeepsPayload() = true for move mode")
+	}
+}
+
+func TestOrganizeEbook_HardlinkKeepsPayloadSeedable(t *testing.T) {
+	o, incoming, _ := ebookOrganizer(t, config.ImportModeHardlink)
+	src := filepath.Join(incoming, "book.epub")
+	payload := []byte("seedable-payload")
+	writeFile(t, src, payload)
+
+	dst, err := o.OrganizeEbook(src, "Title", "Author")
+	if err != nil {
+		t.Fatalf("OrganizeEbook: %v", err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("hardlink mode must leave the download payload in place: %v", err)
+	}
+	if !sameData(t, src, dst) {
+		t.Error("library file is not a hardlink of the download payload")
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("dst content = %q, want %q", got, payload)
+	}
+	if !o.KeepsPayload() {
+		t.Error("KeepsPayload() = false for hardlink mode")
+	}
+}
+
+func TestOrganizeEbook_CopyKeepsIndependentPayload(t *testing.T) {
+	o, incoming, _ := ebookOrganizer(t, config.ImportModeCopy)
+	src := filepath.Join(incoming, "book.epub")
+	payload := []byte("copied-payload")
+	writeFile(t, src, payload)
+
+	dst, err := o.OrganizeEbook(src, "Title", "Author")
+	if err != nil {
+		t.Fatalf("OrganizeEbook: %v", err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("copy mode must leave the download payload in place: %v", err)
+	}
+	if sameData(t, src, dst) {
+		t.Error("copy mode produced a hardlink, want an independent copy")
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("dst content = %q, want %q", got, payload)
+	}
+	if !o.KeepsPayload() {
+		t.Error("KeepsPayload() = false for copy mode")
+	}
+}
+
+// A cross-filesystem or hardlink-less mount (CIFS, exFAT) must not fail the
+// import, and must not eat the source on the way to the fallback copy.
+func TestOrganizeEbook_HardlinkFallsBackToCopyWithoutLosingSource(t *testing.T) {
+	o, incoming, _ := ebookOrganizer(t, config.ImportModeHardlink)
+	src := filepath.Join(incoming, "book.epub")
+	payload := []byte("cross-device-payload")
+	writeFile(t, src, payload)
+
+	orig := linkFile
+	linkFile = func(string, string) error { return errors.New("invalid cross-device link") }
+	defer func() { linkFile = orig }()
+
+	dst, err := o.OrganizeEbook(src, "Title", "Author")
+	if err != nil {
+		t.Fatalf("OrganizeEbook: %v", err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("fallback copy must leave the source in place: %v", err)
+	}
+	if sameData(t, src, dst) {
+		t.Error("fallback should be a copy, not a link")
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("dst content = %q, want %q", got, payload)
+	}
+}
+
+// An import that repeats (re-download of the same book) must overwrite the
+// library entry the same way move and copy do, not fail on EEXIST.
+func TestHardlinkFileReplacesExistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.epub")
+	dst := filepath.Join(dir, "dst.epub")
+	writeFile(t, src, []byte("new"))
+	writeFile(t, dst, []byte("stale"))
+
+	if err := hardlinkFile(src, dst); err != nil {
+		t.Fatalf("hardlinkFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("dst content = %q, want %q", got, "new")
+	}
+	if !sameData(t, src, dst) {
+		t.Error("dst should be a hardlink of src after replacing the stale file")
+	}
+}
+
+func TestOrganizeAudiobook_DirectoryHardlinkKeepsSourceTree(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "incoming", "Book - Author")
+	writeFile(t, filepath.Join(srcDir, "01.mp3"), []byte("part one"))
+	writeFile(t, filepath.Join(srcDir, "disc2", "02.mp3"), []byte("part two"))
+
+	cfg := &config.Config{
+		FileOrgEnabled: true,
+		AudiobookDir:   filepath.Join(root, "audiobooks"),
+		ImportMode:     config.ImportModeHardlink,
+	}
+	o := NewOrganizer(cfg)
+
+	destDir, err := o.OrganizeAudiobook(srcDir, "Book", "Author")
+	if err != nil {
+		t.Fatalf("OrganizeAudiobook: %v", err)
+	}
+	if _, err := os.Stat(srcDir); err != nil {
+		t.Fatalf("hardlink mode must keep the source tree: %v", err)
+	}
+	for _, rel := range []string{"01.mp3", filepath.Join("disc2", "02.mp3")} {
+		src := filepath.Join(srcDir, rel)
+		dst := filepath.Join(destDir, rel)
+		if !sameData(t, src, dst) {
+			t.Errorf("%s is not hardlinked into the library", rel)
+		}
+	}
+}
+
+func TestOrganizeAudiobook_DirectoryMoveStillRemovesSourceTree(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "incoming", "Book - Author")
+	writeFile(t, filepath.Join(srcDir, "01.mp3"), []byte("part one"))
+
+	cfg := &config.Config{
+		FileOrgEnabled: true,
+		AudiobookDir:   filepath.Join(root, "audiobooks"),
+		ImportMode:     config.ImportModeMove,
+	}
+	destDir, err := NewOrganizer(cfg).OrganizeAudiobook(srcDir, "Book", "Author")
+	if err != nil {
+		t.Fatalf("OrganizeAudiobook: %v", err)
+	}
+	if _, err := os.Stat(srcDir); !os.IsNotExist(err) {
+		t.Fatalf("move mode should remove the source tree, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "01.mp3")); err != nil {
+		t.Fatalf("library file missing: %v", err)
+	}
+}
+
+func TestOrganizeManga_DirectoryCopyKeepsSourceDirectory(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "incoming", "Series")
+	writeFile(t, filepath.Join(srcDir, "ch1.cbz"), []byte("chapter one"))
+
+	cfg := &config.Config{
+		FileOrgEnabled: true,
+		MangaDir:       filepath.Join(root, "manga"),
+		ImportMode:     config.ImportModeCopy,
+	}
+	destDir, err := NewOrganizer(cfg).OrganizeManga(srcDir, "Series")
+	if err != nil {
+		t.Fatalf("OrganizeManga: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(srcDir, "ch1.cbz")); err != nil {
+		t.Fatalf("copy mode must keep the source directory: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, "ch1.cbz")); err != nil {
+		t.Fatalf("library file missing: %v", err)
+	}
+}
+
+func TestOrganizeManga_DirectoryMoveStillRemovesSourceDirectory(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "incoming", "Series")
+	writeFile(t, filepath.Join(srcDir, "ch1.cbz"), []byte("chapter one"))
+
+	cfg := &config.Config{
+		FileOrgEnabled: true,
+		MangaDir:       filepath.Join(root, "manga"),
+		ImportMode:     config.ImportModeMove,
+	}
+	if _, err := NewOrganizer(cfg).OrganizeManga(srcDir, "Series"); err != nil {
+		t.Fatalf("OrganizeManga: %v", err)
+	}
+	if _, err := os.Stat(srcDir); !os.IsNotExist(err) {
+		t.Fatalf("move mode should remove the source directory, stat err = %v", err)
+	}
+}
+
+// Uploads are librarr's own temp files: nothing seeds them, so they must move
+// even when the configured mode would keep the payload.
+func TestMovingOverridesConfiguredImportMode(t *testing.T) {
+	o, incoming, _ := ebookOrganizer(t, config.ImportModeHardlink)
+	src := filepath.Join(incoming, "upload.epub")
+	writeFile(t, src, []byte("uploaded"))
+
+	mover := o.Moving()
+	if mover.KeepsPayload() {
+		t.Fatal("Moving() organizer should not keep the payload")
+	}
+	if _, err := mover.OrganizeEbook(src, "Title", "Author"); err != nil {
+		t.Fatalf("OrganizeEbook: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("Moving() should remove the source, stat err = %v", err)
+	}
+	// The override must not leak back into the shared organizer.
+	if !o.KeepsPayload() {
+		t.Error("Moving() mutated the original organizer")
+	}
+}
+
+func TestKeepsPayloadTreatsUnsetModeAsMove(t *testing.T) {
+	o := NewOrganizer(&config.Config{FileOrgEnabled: true})
+	if o.KeepsPayload() {
+		t.Error("an unset ImportMode must behave as move")
+	}
+}

--- a/internal/organize/importmode_test.go
+++ b/internal/organize/importmode_test.go
@@ -43,7 +43,12 @@ func ebookOrganizer(t *testing.T, mode string) (*Organizer, string, string) {
 	if err := os.MkdirAll(incoming, 0755); err != nil {
 		t.Fatal(err)
 	}
-	cfg := &config.Config{FileOrgEnabled: true, EbookDir: library, ImportMode: mode}
+	cfg := &config.Config{
+		FileOrgEnabled:           true,
+		EbookDir:                 library,
+		ImportMode:               mode,
+		RemoveTorrentAfterImport: true, // the mode under test must win over this
+	}
 	return NewOrganizer(cfg), incoming, library
 }
 
@@ -294,9 +299,41 @@ func TestMovingOverridesConfiguredImportMode(t *testing.T) {
 	}
 }
 
-func TestKeepsPayloadTreatsUnsetModeAsMove(t *testing.T) {
-	o := NewOrganizer(&config.Config{FileOrgEnabled: true})
-	if o.KeepsPayload() {
-		t.Error("an unset ImportMode must behave as move")
+// With no explicit mode the organizer follows the seeding setting: removing
+// torrents means nothing needs the payload, keeping them means it must survive.
+func TestUnsetModeFollowsTheRemoveTorrentSetting(t *testing.T) {
+	removing := NewOrganizer(&config.Config{FileOrgEnabled: true, RemoveTorrentAfterImport: true})
+	if removing.KeepsPayload() {
+		t.Error("removing torrents should resolve to a move")
+	}
+
+	keeping := NewOrganizer(&config.Config{FileOrgEnabled: true, RemoveTorrentAfterImport: false})
+	if !keeping.KeepsPayload() {
+		t.Error("keeping torrents should resolve to a payload-preserving mode")
+	}
+}
+
+// The single-knob path all the way through the organizer: keeping torrents is
+// the only thing configured, and the file still ends up hardlinked.
+func TestKeepingTorrentsAloneHardlinksTheImport(t *testing.T) {
+	root := t.TempDir()
+	incoming := filepath.Join(root, "incoming")
+	cfg := &config.Config{
+		FileOrgEnabled:           true,
+		EbookDir:                 filepath.Join(root, "books"),
+		RemoveTorrentAfterImport: false,
+	}
+	src := filepath.Join(incoming, "book.epub")
+	writeFile(t, src, []byte("single knob"))
+
+	dst, err := NewOrganizer(cfg).OrganizeEbook(src, "Title", "Author")
+	if err != nil {
+		t.Fatalf("OrganizeEbook: %v", err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("payload must survive: %v", err)
+	}
+	if !sameData(t, src, dst) {
+		t.Error("library file should be a hardlink of the payload")
 	}
 }

--- a/internal/organize/pipeline.go
+++ b/internal/organize/pipeline.go
@@ -44,7 +44,7 @@ func (o *Organizer) importMode() string {
 	if o.forceMove || o.cfg == nil {
 		return config.ImportModeMove
 	}
-	return config.NormalizeImportMode(o.cfg.ImportMode)
+	return o.cfg.EffectiveImportMode()
 }
 
 // KeepsPayload reports whether imports leave the source files where the

--- a/internal/organize/pipeline.go
+++ b/internal/organize/pipeline.go
@@ -3,8 +3,10 @@
 package organize
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -17,11 +19,52 @@ import (
 // Organizer handles post-download file organization.
 type Organizer struct {
 	cfg *config.Config
+
+	// forceMove ignores the configured import mode. Set by Moving() for
+	// sources that are not download-client payloads.
+	forceMove bool
 }
 
 // NewOrganizer creates a new file organizer.
 func NewOrganizer(cfg *config.Config) *Organizer {
 	return &Organizer{cfg: cfg}
+}
+
+// Moving returns an organizer that always moves, whatever IMPORT_MODE says.
+// Uploads and other librarr-owned temporary files have nothing to seed, so
+// hardlinking or copying them would leave the original behind forever.
+func (o *Organizer) Moving() *Organizer {
+	clone := *o
+	clone.forceMove = true
+	return &clone
+}
+
+// importMode returns the effective import mode for this organizer.
+func (o *Organizer) importMode() string {
+	if o.forceMove || o.cfg == nil {
+		return config.ImportModeMove
+	}
+	return config.NormalizeImportMode(o.cfg.ImportMode)
+}
+
+// KeepsPayload reports whether imports leave the source files where the
+// download client put them, which is what seeding requires. Callers use it to
+// decide what to do with the download after a successful import.
+func (o *Organizer) KeepsPayload() bool {
+	return o.importMode() != config.ImportModeMove
+}
+
+// placeFile puts src at dst using the configured import mode. Only the move
+// mode removes src.
+func (o *Organizer) placeFile(src, dst string) error {
+	switch o.importMode() {
+	case config.ImportModeHardlink:
+		return hardlinkFile(src, dst)
+	case config.ImportModeCopy:
+		return copyFileForOrg(src, dst)
+	default:
+		return moveFile(src, dst)
+	}
 }
 
 // OrganizeEbook moves an ebook file into the organized directory structure: {EbookDir}/{Author}/{Title}/{file}
@@ -55,11 +98,11 @@ func (o *Organizer) OrganizeEbook(filePath, title, author string) (string, error
 	}
 
 	destPath := filepath.Join(destDir, filepath.Base(filePath))
-	if err := moveFile(filePath, destPath); err != nil {
+	if err := o.placeFile(filePath, destPath); err != nil {
 		return filePath, err
 	}
 
-	slog.Info("ebook organized", "title", title, "dest", destPath)
+	slog.Info("ebook organized", "title", title, "dest", destPath, "mode", o.importMode())
 
 	// Also copy to Kavita ebook library if configured.
 	if o.cfg.KavitaLibraryPath != "" {
@@ -104,7 +147,7 @@ func (o *Organizer) OrganizeAudiobook(filePath, title, author string) (string, e
 		return filePath, err
 	}
 	if info.IsDir() {
-		if err := moveDirTree(filePath, destDir); err != nil {
+		if err := o.placeDirTree(filePath, destDir); err != nil {
 			return filePath, err
 		}
 		return destDir, nil
@@ -115,7 +158,7 @@ func (o *Organizer) OrganizeAudiobook(filePath, title, author string) (string, e
 	}
 
 	destPath := filepath.Join(destDir, filepath.Base(filePath))
-	if err := moveFile(filePath, destPath); err != nil {
+	if err := o.placeFile(filePath, destPath); err != nil {
 		return filePath, err
 	}
 
@@ -152,13 +195,17 @@ func (o *Organizer) OrganizeManga(filePath, seriesTitle string) (string, error) 
 		for _, entry := range entries {
 			src := filepath.Join(filePath, entry.Name())
 			dst := filepath.Join(destDir, entry.Name())
-			_ = moveFile(src, dst)
+			_ = o.placeFile(src, dst)
 		}
-		_ = os.RemoveAll(filePath)
+		// Only a move consumes the download; hardlink/copy must leave the
+		// source directory intact so the torrent can keep seeding.
+		if !o.KeepsPayload() {
+			_ = os.RemoveAll(filePath)
+		}
 		resultPath = destDir
 	} else {
 		destPath := filepath.Join(destDir, filepath.Base(filePath))
-		if err := moveFile(filePath, destPath); err != nil {
+		if err := o.placeFile(filePath, destPath); err != nil {
 			return filePath, err
 		}
 		resultPath = destPath
@@ -300,7 +347,36 @@ func moveFile(src, dst string) error {
 // renameFile is os.Rename; tests swap it to force the streaming copy fallback.
 var renameFile = os.Rename
 
-func moveDirTree(srcDir, dstDir string) error {
+// linkFile is os.Link; tests swap it to force the copy fallback.
+var linkFile = os.Link
+
+// hardlinkFile points dst at the same data as src, leaving src in place. A
+// hardlink only works within one filesystem and not on every filesystem
+// (CIFS/exFAT, some FUSE mounts), so any failure falls back to a copy — the
+// import must still land, it just costs the extra disk.
+func hardlinkFile(src, dst string) error {
+	err := linkFile(src, dst)
+	if err == nil {
+		return nil
+	}
+	// An existing destination is not a reason to copy: replace it and relink,
+	// matching the overwrite behavior of the move and copy modes.
+	if errors.Is(err, fs.ErrExist) {
+		if rmErr := os.Remove(dst); rmErr == nil {
+			if relinkErr := linkFile(src, dst); relinkErr == nil {
+				return nil
+			} else {
+				err = relinkErr
+			}
+		}
+	}
+	slog.Warn("hardlink failed, copying instead", "src", src, "dst", dst, "error", err)
+	return copyFileForOrg(src, dst)
+}
+
+// placeDirTree recreates srcDir's file tree under dstDir using the configured
+// import mode, removing srcDir only when that mode is a move.
+func (o *Organizer) placeDirTree(srcDir, dstDir string) error {
 	if err := os.MkdirAll(dstDir, 0755); err != nil {
 		return err
 	}
@@ -329,12 +405,15 @@ func moveDirTree(srcDir, dstDir string) error {
 		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
 			return err
 		}
-		return moveFile(path, dstPath)
+		return o.placeFile(path, dstPath)
 	})
 	if err != nil {
 		return err
 	}
 
+	if o.KeepsPayload() {
+		return nil
+	}
 	return os.RemoveAll(srcDir)
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -654,11 +654,13 @@
         <div class="py-2">
           <label class="block text-sm text-slate-300 mb-1">Import mode</label>
           <select id="setting-import_mode" class="w-full md:w-1/3 bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200" data-action-change="saveImportMode">
+            <option value="">Automatic (follows the setting below)</option>
             <option value="move">Move (download folder is emptied)</option>
             <option value="hardlink">Hardlink (keeps seeding, no extra disk)</option>
             <option value="copy">Copy (keeps seeding, uses twice the disk)</option>
           </select>
-          <p class="text-xs text-slate-500 mt-1">How imported files reach the library. <strong>Move</strong> takes the payload out of the download folder, so the torrent can no longer seed even if you keep it. <strong>Hardlink</strong> and <strong>Copy</strong> leave the payload in place so seeding continues; hardlinks need the download folder and the library on the same filesystem, and fall back to a copy when they are not.</p>
+          <p id="import-mode-effective" class="text-xs text-indigo-300 mt-1"></p>
+          <p class="text-xs text-slate-500 mt-1">How imported files reach the library. <strong>Move</strong> takes the payload out of the download folder, so the torrent can no longer seed even if you keep it. <strong>Hardlink</strong> and <strong>Copy</strong> leave the payload in place so seeding continues; hardlinks need the download folder and the library on the same filesystem, and fall back to a copy when they are not. On <strong>Automatic</strong> you never have to think about it: keeping torrents hardlinks them, removing torrents moves them.</p>
         </div>
         <div class="flex items-center justify-between py-2 border-t border-slate-800 mt-2 pt-4">
           <div>

--- a/web/index.html
+++ b/web/index.html
@@ -651,10 +651,19 @@
       <!-- Download Behavior -->
       <div class="bg-slate-900 border border-slate-800 rounded-xl p-5 mb-6">
         <h3 class="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">Download Behavior</h3>
-        <div class="flex items-center justify-between py-2">
+        <div class="py-2">
+          <label class="block text-sm text-slate-300 mb-1">Import mode</label>
+          <select id="setting-import_mode" class="w-full md:w-1/3 bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-200" data-action-change="saveImportMode">
+            <option value="move">Move (download folder is emptied)</option>
+            <option value="hardlink">Hardlink (keeps seeding, no extra disk)</option>
+            <option value="copy">Copy (keeps seeding, uses twice the disk)</option>
+          </select>
+          <p class="text-xs text-slate-500 mt-1">How imported files reach the library. <strong>Move</strong> takes the payload out of the download folder, so the torrent can no longer seed even if you keep it. <strong>Hardlink</strong> and <strong>Copy</strong> leave the payload in place so seeding continues; hardlinks need the download folder and the library on the same filesystem, and fall back to a copy when they are not.</p>
+        </div>
+        <div class="flex items-center justify-between py-2 border-t border-slate-800 mt-2 pt-4">
           <div>
             <p class="text-sm text-slate-300">Remove torrents after import</p>
-            <p class="text-xs text-slate-500 mt-1">When enabled, torrents are removed from qBittorrent after files are imported. Disable to keep seeding.</p>
+            <p class="text-xs text-slate-500 mt-1">When enabled, the torrent's record is removed from the download client after files are imported. Disable to keep the record — which only keeps the torrent <em>seeding</em> if the import mode above is Hardlink or Copy.</p>
           </div>
           <label class="relative inline-flex items-center cursor-pointer ml-4 shrink-0">
             <input type="checkbox" id="remove-torrent-toggle" class="sr-only peer" checked data-action-change="toggleRemoveTorrent">

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2118,11 +2118,12 @@ async function loadSettingToggles() {
       removeTorrent.checked = data.remove_torrent_after_import;
     }
     const importMode = document.getElementById('setting-import_mode');
-    if (importMode && data.import_mode) {
+    if (importMode && data.import_mode !== undefined) {
       importMode.value = data.import_mode;
       // Remembered so a failed save can put the select back where it was.
       importMode.dataset.current = data.import_mode;
     }
+    renderEffectiveImportMode(data.effective_import_mode, data.remove_torrent_after_import);
     const langFilter = document.getElementById('foreign-lang-filter-toggle');
     if (langFilter && data.foreign_lang_filter !== undefined) {
       langFilter.checked = data.foreign_lang_filter;
@@ -2271,6 +2272,7 @@ async function toggleRemoveTorrent() {
     });
     if (res.success) {
       showToast(enabled ? 'Torrents will be removed after import' : 'Torrents will keep seeding after import', 'success');
+      refreshImportModeHint();
     } else {
       toggle.checked = !enabled;
       showToast('Failed to update setting', 'error');
@@ -2283,7 +2285,42 @@ async function toggleRemoveTorrent() {
   }
 }
 
+// The mode imports actually run in. On Automatic it is decided by the
+// remove-torrents setting, so spell out the result rather than leaving the
+// user to work out which of the two settings won.
+const EFFECTIVE_IMPORT_MODE_TEXT = {
+  move: 'Imports move files into the library — a kept torrent could not seed.',
+  hardlink: 'Imports hardlink into the library — kept torrents keep seeding, at no extra disk.',
+  copy: 'Imports copy into the library — kept torrents keep seeding, using twice the disk.',
+};
+
+function renderEffectiveImportMode(mode, removeAfterImport) {
+  const el = document.getElementById('import-mode-effective');
+  if (!el || !mode) return;
+  const select = document.getElementById('setting-import_mode');
+  const automatic = select && select.value === '';
+  const prefix = automatic ? `Automatic → ${mode}. ` : '';
+  const suffix = mode === 'move' && removeAfterImport === false
+    ? ' Pick Hardlink above, or turn the setting below back on.'
+    : '';
+  el.textContent = prefix + (EFFECTIVE_IMPORT_MODE_TEXT[mode] || '') + suffix;
+  el.className = mode === 'move' && removeAfterImport === false
+    ? 'text-xs text-amber-400 mt-1'
+    : 'text-xs text-indigo-300 mt-1';
+}
+
+// Re-reads what the server decided after either setting changes.
+async function refreshImportModeHint() {
+  try {
+    const data = await apiJson('/api/settings');
+    renderEffectiveImportMode(data.effective_import_mode, data.remove_torrent_after_import);
+  } catch (err) {
+    // A stale hint is not worth a toast; the next settings load fixes it.
+  }
+}
+
 const IMPORT_MODE_TOASTS = {
+  '': 'Import mode follows the remove-torrents setting',
   move: 'Imports will move files into the library (torrents cannot keep seeding)',
   hardlink: 'Imports will hardlink into the library, so torrents keep seeding',
   copy: 'Imports will copy into the library, so torrents keep seeding',
@@ -2293,7 +2330,7 @@ async function saveImportMode() {
   const select = document.getElementById('setting-import_mode');
   if (!select) return;
   const mode = select.value;
-  const previous = select.dataset.current || 'move';
+  const previous = select.dataset.current || '';
   try {
     const res = await apiJson('/api/settings', {
       method: 'POST',
@@ -2303,6 +2340,7 @@ async function saveImportMode() {
     if (res.success) {
       select.dataset.current = mode;
       showToast(IMPORT_MODE_TOASTS[mode] || 'Import mode updated', 'success');
+      refreshImportModeHint();
     } else {
       select.value = previous;
       showToast('Failed to update setting', 'error');

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -2117,6 +2117,12 @@ async function loadSettingToggles() {
     if (removeTorrent && data.remove_torrent_after_import !== undefined) {
       removeTorrent.checked = data.remove_torrent_after_import;
     }
+    const importMode = document.getElementById('setting-import_mode');
+    if (importMode && data.import_mode) {
+      importMode.value = data.import_mode;
+      // Remembered so a failed save can put the select back where it was.
+      importMode.dataset.current = data.import_mode;
+    }
     const langFilter = document.getElementById('foreign-lang-filter-toggle');
     if (langFilter && data.foreign_lang_filter !== undefined) {
       langFilter.checked = data.foreign_lang_filter;
@@ -2271,6 +2277,38 @@ async function toggleRemoveTorrent() {
     }
   } catch (err) {
     toggle.checked = !enabled;
+    if (err.message !== 'Unauthorized') {
+      showToast('Failed to save setting', 'error');
+    }
+  }
+}
+
+const IMPORT_MODE_TOASTS = {
+  move: 'Imports will move files into the library (torrents cannot keep seeding)',
+  hardlink: 'Imports will hardlink into the library, so torrents keep seeding',
+  copy: 'Imports will copy into the library, so torrents keep seeding',
+};
+
+async function saveImportMode() {
+  const select = document.getElementById('setting-import_mode');
+  if (!select) return;
+  const mode = select.value;
+  const previous = select.dataset.current || 'move';
+  try {
+    const res = await apiJson('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ import_mode: mode })
+    });
+    if (res.success) {
+      select.dataset.current = mode;
+      showToast(IMPORT_MODE_TOASTS[mode] || 'Import mode updated', 'success');
+    } else {
+      select.value = previous;
+      showToast('Failed to update setting', 'error');
+    }
+  } catch (err) {
+    select.value = previous;
     if (err.message !== 'Unauthorized') {
       showToast('Failed to save setting', 'error');
     }
@@ -2747,6 +2785,7 @@ const CHANGE_ACTIONS = {
   changeUserRole: el => changeUserRole(+el.dataset.id, el.value),
   toggleForeignLangFilter: () => toggleForeignLangFilter(),
   toggleRemoveTorrent: () => toggleRemoveTorrent(),
+  saveImportMode: () => saveImportMode(),
 };
 
 document.addEventListener('change', e => {


### PR DESCRIPTION
Closes the follow-up on #59 from @gpaumier: `REMOVE_TORRENT_AFTER_IMPORT=false` keeps the torrent's *record*, but the import pipeline moves its files into the library first. The client shows a ghost torrent at 100% with no data behind it — a force-recheck drops it to 0% and re-downloads.

## Fix

Keeping the torrent is now enough on its own:

```env
REMOVE_TORRENT_AFTER_IMPORT=false
```

A new `IMPORT_MODE` decides how files reach the library, and defaults to automatic:

| `REMOVE_TORRENT_AFTER_IMPORT` | resolves to | result |
|---|---|---|
| `true` (default) | `move` | **unchanged from today** — payload consumed, nothing seeds |
| `false` | `hardlink` | payload stays put, torrent keeps seeding, no extra disk |

Set `IMPORT_MODE` explicitly to override: `hardlink`, `copy` (filesystems without hardlinks), or `move`. Hardlinks need the download folder and library on one filesystem; otherwise librarr warns and copies so the import still lands. Explicit `move` while keeping torrents is the one combination that can't seed — it warns at startup, next to an `import policy` line stating the resolved mode.

Two smaller behaviors: in a payload-preserving mode, `REMOVE_TORRENT_AFTER_IMPORT=true` deletes the torrent *with* its files once every file is confirmed in the library (otherwise the payload would pile up with nothing to clean it); and uploads plus direct HTTP downloads always move, since they're librarr's own files, not seedable payloads.

README gains a **Seeding after import** section; the UI copy and log lines now say the same thing.

## Tests

CI: config resolution matrix, organizer modes (inode identity, hardlink→copy fallback, directory trees), watcher deletion decisions, API round-trip, browser e2e.

Plus `e2e/manual_qbittorrent_check.py` (added here, `--spawn` starts a disposable client, not run by CI) — real payloads, real torrents, real force-rechecks against qBittorrent 5.2.3. 27/27, including the bug itself:

```
only REMOVE_TORRENT_AFTER_IMPORT=false  → recheck: progress=1.00 stalledUP   (fixed)
IMPORT_MODE=move + keep (old behavior)  → recheck: progress=0.00 stalledDL   (the bug)
hardlink + remove                       → qBit deleted its copy, library file intact
```
