### PR TITLE
Correct the settings-UI copy for the automatic import mode

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -665,7 +665,7 @@
         <div class="flex items-center justify-between py-2 border-t border-slate-800 mt-2 pt-4">
           <div>
             <p class="text-sm text-slate-300">Remove torrents after import</p>
-            <p class="text-xs text-slate-500 mt-1">When enabled, the torrent's record is removed from the download client after files are imported. Disable to keep the record — which only keeps the torrent <em>seeding</em> if the import mode above is Hardlink or Copy.</p>
+            <p class="text-xs text-slate-500 mt-1">When enabled, the torrent is removed from the download client after its files are imported. <strong>Disable it to keep seeding</strong>: the torrent's record stays in the client, and on Automatic its files stay in the download folder too — hardlinked into the library rather than moved, which is what seeding actually needs.</p>
           </div>
           <label class="relative inline-flex items-center cursor-pointer ml-4 shrink-0">
             <input type="checkbox" id="remove-torrent-toggle" class="sr-only peer" checked data-action-change="toggleRemoveTorrent">


### PR DESCRIPTION
Follow-up to #105 — a sentence in the settings UI that the merged design made wrong.

The toggle's description still told users that keeping a torrent only keeps it seeding "if the import mode above is Hardlink or Copy". That was true of the two-knob version, but #105 made `REMOVE_TORRENT_AFTER_IMPORT=false` imply a hardlink import on its own — so the text points at exactly the second setting that change removed, which is the confusion reported in #59.

```diff
-Disable to keep the record — which only keeps the torrent seeding if the import mode above is Hardlink or Copy.
+Disable it to keep seeding: the torrent's record stays in the client, and on Automatic its files stay in the
+download folder too — hardlinked into the library rather than moved, which is what seeding actually needs.
```

Copy only; no behavior change. e2e suite passes (27).
