### PR TITLE
Apply the import mode to torrents only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,8 @@ FILE_ORG_ENABLED=true
 # How imported files reach the library: move | hardlink | copy.
 # Leave it blank and it follows REMOVE_TORRENT_AFTER_IMPORT: removing torrents
 # moves (the download folder is emptied), keeping them hardlinks (the payload
-# stays put so the torrent can seed). Set it only to override that.
+# stays put so the torrent can seed). Set it only to override that. Applies to
+# torrent and manual imports; usenet, uploads and direct downloads always move.
 # See "Seeding after import" in the README.
 IMPORT_MODE=
 EBOOK_DIR=/books/ebooks

--- a/README.md
+++ b/README.md
@@ -337,6 +337,11 @@ Notes on the modes:
   without hardlinks such as CIFS/exFAT), librarr logs a warning and copies
   instead, so the import still lands.
 - **`copy`** always works but stores the book twice until you delete the torrent.
+  It is also the mode to pick when something else writes to your library files:
+  a hardlinked file *is* the seeded data, so a tool that rewrites tags in place
+  (some audiobook taggers do) changes the torrent's bytes underneath it and the
+  next recheck fails. Tools that write a new file and rename it are safe, as is
+  librarr itself — it only ever reads imported files or copies them onward.
 - With `hardlink` or `copy`, if you *also* leave `REMOVE_TORRENT_AFTER_IMPORT=true`,
   librarr removes the torrent **and its files** once every file is safely in the
   library — otherwise the payload would sit in the download folder with nothing
@@ -350,8 +355,12 @@ Notes on the modes:
 - File organization must be on (`FILE_ORG_ENABLED=true`) for any of this; with it
   off, librarr indexes files where they already are and never touches them.
 
-`IMPORT_MODE` applies to download-client imports and manual imports. Uploads
-through the web UI always move, since their source is librarr's own temp file.
+**Scope.** `IMPORT_MODE` applies to torrent imports and manual imports — the
+cases where the source may be a live torrent payload. Everything else always
+moves, because nothing is seeding it and leaving a second copy behind would just
+accumulate: SABnzbd/usenet imports (librarr never removes anything from the
+completed folder), web UI uploads, and direct HTTP downloads from sources like
+Anna's Archive, all of which are librarr's own files.
 
 ### Sources Registry
 

--- a/internal/download/watcher.go
+++ b/internal/download/watcher.go
@@ -417,6 +417,18 @@ func mapTorrentPath(reportedPath, remoteRoot, localRoot string) (string, bool) {
 	return filepath.Join(localRoot, rel), true
 }
 
+// organizerFor returns the organizer to use for a completed download. Only a
+// torrent can seed, so only a torrent honors a payload-preserving IMPORT_MODE.
+// A usenet download has nothing to keep its payload for, and librarr never
+// deletes anything from SABnzbd's completed folder — leaving the payload there
+// would grow that folder without bound.
+func (w *Watcher) organizerFor(source string) *organize.Organizer {
+	if source == "torrent" || w.organizer == nil {
+		return w.organizer
+	}
+	return w.organizer.Moving()
+}
+
 // importEbook organizes every ebook found under savePath. The bool reports
 // whether all of them now live in the library under a path of their own, i.e.
 // whether the download folder still holds the only copy of anything.
@@ -426,12 +438,13 @@ func (w *Watcher) importEbook(t TorrentInfo, savePath, source string) (bool, err
 		return false, fmt.Errorf("%w: no ebook files found at %s", errTorrentContentPending, savePath)
 	}
 
+	organizer := w.organizerFor(source)
 	inLibrary := true
 	for _, bf := range bookFiles {
 		metadata := organize.ExtractEbookMetadata(bf)
 		title := firstNonEmpty(metadata.Title, t.Name)
 		author := metadata.Author
-		destPath, err := w.organizer.OrganizeEbook(bf, title, author)
+		destPath, err := organizer.OrganizeEbook(bf, title, author)
 		if err != nil {
 			slog.Warn("organize ebook failed", "file", bf, "error", err)
 			destPath = bf
@@ -483,7 +496,7 @@ func (w *Watcher) importAudiobook(t TorrentInfo, savePath, source string) (bool,
 		author = "Unknown"
 	}
 
-	destPath, err := w.organizer.OrganizeAudiobook(savePath, title, author)
+	destPath, err := w.organizerFor(source).OrganizeAudiobook(savePath, title, author)
 	if err != nil {
 		return false, fmt.Errorf("organize audiobook %q: %w", savePath, err)
 	}
@@ -508,9 +521,10 @@ func (w *Watcher) importManga(t TorrentInfo, savePath, source string) (bool, err
 		return false, fmt.Errorf("%w: no manga files found at %s", errTorrentContentPending, savePath)
 	}
 
+	organizer := w.organizerFor(source)
 	inLibrary := true
 	for _, mf := range mangaFiles {
-		destPath, err := w.organizer.OrganizeManga(mf, t.Name)
+		destPath, err := organizer.OrganizeManga(mf, t.Name)
 		if err != nil {
 			slog.Warn("organize manga failed", "file", mf, "error", err)
 			destPath = mf

--- a/internal/download/watcher_test.go
+++ b/internal/download/watcher_test.go
@@ -697,3 +697,59 @@ func TestImportTorrentDefaultsToMoveWhenTorrentsAreRemoved(t *testing.T) {
 		t.Errorf("move mode should have consumed the payload, stat err = %v", err)
 	}
 }
+
+// Usenet cannot seed, and librarr never removes anything from SABnzbd's
+// completed folder — so a payload-preserving import mode must not apply there,
+// or that folder grows forever. Regression guard for the mode leaking out of
+// the torrent path it was built for.
+func TestNZBImportAlwaysMovesEvenInHardlinkMode(t *testing.T) {
+	for _, tc := range []struct {
+		source     string
+		sourceKept bool
+	}{
+		{"torrent", true}, // seedable: hardlink mode keeps the payload
+		{"nzb", false},    // nothing seeds usenet: always a move
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			root := t.TempDir()
+			incoming := filepath.Join(root, "incoming")
+			if err := os.MkdirAll(incoming, 0755); err != nil {
+				t.Fatal(err)
+			}
+			payload := filepath.Join(incoming, "book.epub")
+			if err := os.WriteFile(payload, []byte("payload"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			database, err := db.New(filepath.Join(root, "library.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer database.Close()
+
+			cfg := &config.Config{
+				FileOrgEnabled: true,
+				EbookDir:       filepath.Join(root, "books"),
+				IncomingDir:    incoming,
+				ImportMode:     config.ImportModeHardlink,
+			}
+			w := NewWatcher(cfg, database, nil, nil, organize.NewOrganizer(cfg), nil, nil)
+
+			info := TorrentInfo{Name: "Some Book", Hash: "hash-" + tc.source}
+			if _, err := w.importEbook(info, incoming, tc.source); err != nil {
+				t.Fatalf("importEbook: %v", err)
+			}
+
+			_, statErr := os.Stat(payload)
+			if tc.sourceKept && statErr != nil {
+				t.Errorf("%s payload should stay in place for seeding: %v", tc.source, statErr)
+			}
+			if !tc.sourceKept && !os.IsNotExist(statErr) {
+				t.Errorf("%s payload should have been moved, stat err = %v", tc.source, statErr)
+			}
+			if _, err := os.Stat(findImportedEbook(t, cfg.EbookDir)); err != nil {
+				t.Errorf("library file missing: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #105. Two things I got wrong there, one behavioral and one missing from the docs.

## Import modes leaked into the usenet path

`importNZB` shares the import functions with torrents, so SABnzbd downloads obeyed `IMPORT_MODE` too — and nothing in that path ever deletes SAB's completed files (`importNZB` only sets a DB flag). Combined with the automatic mode, that meant:

`REMOVE_TORRENT_AFTER_IMPORT=false` — a setting named for **torrents** — silently changed **usenet** behavior, and SABnzbd's completed folder went from "emptied on import" to growing without bound.

Usenet has nothing to seed, so there is no payload worth preserving. NZB imports now always move, matching the web UI uploads and direct HTTP downloads that already did. The choice keys off the `source` argument the import functions already take:

```go
func (w *Watcher) organizerFor(source string) *organize.Organizer {
	if source == "torrent" || w.organizer == nil {
		return w.organizer
	}
	return w.organizer.Moving()
}
```

## Why you would pick `copy`, which the docs never said

`copy` looked redundant — hardlink already falls back to copying when a link can't be made. It isn't: a hardlinked library file **is** the seeded data, so anything that rewrites it in place (some audiobook taggers) changes the torrent's bytes and fails its next recheck. Tools that write a new file and rename are safe, as is librarr, which only reads imported files or copies them onward. That's now in the README, along with an explicit scope note: modes apply to torrent and manual imports; usenet, uploads and direct downloads always move.

## Tests

New table test: the same ebook import under `IMPORT_MODE=hardlink` keeps the payload for `source="torrent"` and moves it for `source="nzb"`.

Full local matrix: gofmt, vet, staticcheck, `go test ./... -race`, integration tags, `pytest e2e/` (27). Re-ran `e2e/manual_qbittorrent_check.py` against real qBittorrent 5.2.3 — 27/27, torrent path unchanged.
