### PR TITLE
Fail an Anna's Archive search when every variant fails

### DIFF
--- a/internal/search/annas.go
+++ b/internal/search/annas.go
@@ -168,13 +168,24 @@ func (a *AnnasArchive) Search(ctx context.Context, query string) ([]models.Searc
 		{query, ""},
 	}
 
+	// A variant failing on its own is tolerable — the other may still return
+	// hits. Every variant failing is not: returning (nil, nil) there reports a
+	// successful, empty search, so the circuit breaker never trips and the
+	// source's health keeps reading OK while it silently produces nothing.
+	// That is exactly how Anna's going behind a DDoS-Guard challenge showed up:
+	// zero results, score 100, no error anywhere.
+	var lastErr error
 	for _, s := range searches {
 		res, err := a.doSearch(ctx, s.q, s.ext, seenMD5)
 		if err != nil {
+			lastErr = err
 			slog.Warn("anna's archive search variant failed", "query", s.q, "ext", s.ext, "error", err)
 			continue
 		}
 		results = append(results, res...)
+	}
+	if lastErr != nil && len(results) == 0 {
+		return nil, fmt.Errorf("all anna's archive search variants failed: %w", lastErr)
 	}
 
 	// Sort by size descending.

--- a/internal/search/annas_test.go
+++ b/internal/search/annas_test.go
@@ -462,3 +462,82 @@ func TestAnnasCardLink_IgnoresAmbiguousContainers(t *testing.T) {
 		}
 	}
 }
+
+// TestAnnasArchive_SearchAllVariantsFailReturnsError covers the failure shape
+// that hid a real outage: when Anna's Archive moved behind a DDoS-Guard
+// challenge, every search variant failed, but Search returned (nil, nil). The
+// source therefore reported a successful empty search — its health score stayed
+// at 100 with search_ok climbing — while it produced no results at all. An
+// empty success is indistinguishable from "this query has no matches", so
+// nothing surfaced the breakage.
+func TestAnnasArchive_SearchAllVariantsFailReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	a := &AnnasArchive{
+		cfg:    &config.Config{AnnasArchiveDomain: "example.com", UserAgent: "test"},
+		client: &http.Client{Transport: &rewriteTransport{serverURL: server.URL}},
+	}
+
+	results, err := a.Search(context.Background(), "dune")
+	if err == nil {
+		t.Fatal("every variant failed but Search reported success — the circuit breaker never trips and the source looks healthy while returning nothing")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected no results alongside the error, got %d", len(results))
+	}
+}
+
+// A genuinely empty result set is still a success: "no matches for this query"
+// must not be reported as a source failure, or the circuit breaker would open
+// on obscure searches.
+func TestAnnasArchive_SearchEmptyButHealthyIsNotAnError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html><body>no results</body></html>`))
+	}))
+	defer server.Close()
+
+	a := &AnnasArchive{
+		cfg:    &config.Config{AnnasArchiveDomain: "example.com", UserAgent: "test"},
+		client: &http.Client{Transport: &rewriteTransport{serverURL: server.URL}},
+	}
+
+	results, err := a.Search(context.Background(), "zzzz-no-such-book")
+	if err != nil {
+		t.Fatalf("an empty but healthy search must not error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+// One variant failing while the other succeeds must still return the hits.
+func TestAnnasArchive_SearchPartialFailureStillReturnsResults(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`<html><body>
+			<a href="/md5/abc123def456789012345678901234ab">Dune</a>
+		</body></html>`))
+	}))
+	defer server.Close()
+
+	a := &AnnasArchive{
+		cfg:    &config.Config{AnnasArchiveDomain: "example.com", UserAgent: "test"},
+		client: &http.Client{Transport: &rewriteTransport{serverURL: server.URL}},
+	}
+
+	results, err := a.Search(context.Background(), "dune")
+	if err != nil {
+		t.Fatalf("a partial failure must not fail the whole search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected the surviving variant's results to come through")
+	}
+}


### PR DESCRIPTION
## The bug

`AnnasArchive.Search` runs two variants (epub-filtered, then unfiltered) and tolerates one failing — the other may still return hits. But it returned `(results, nil)` unconditionally, so when **both** failed it reported a *successful, empty* search.

An empty success is indistinguishable from "this query has no matches". Nothing surfaced the breakage:

- the circuit breaker never tripped,
- the source's health score stayed at **100** with `search_ok` climbing,
- the UI just showed no Anna's results.

## Why it matters now

Anna's Archive moved behind a **DDoS-Guard** JavaScript challenge. `/search` 302s to the same path with `?check=1` and serves the challenge instead of results, so both variants fail on every query. The source reported perfect health while returning nothing at all — which is how it went unnoticed.

Measured on a live instance, before and after this change:

| | before | after |
|---|---|---|
| `score` | **100** | **0** |
| `search_ok` / `search_fail` | 23 / 0 | 0 / 1 |
| `last_error` | *(empty)* | `all anna's archive search variants failed: HTTP 403 from annas-archive` |

## The change

Return the last error when every variant failed *and* nothing was collected. Deliberately narrow:

- **partial failure still succeeds** — whatever the surviving variant found is returned;
- **a genuinely empty result set is still a success** — an obscure query must not open the circuit.

## Tests

Three cases in `annas_test.go`, one per failure shape:

- `SearchAllVariantsFailReturnsError` — the bug. Verified it **fails on `main`** with the message *"every variant failed but Search reported success…"* and passes with the fix.
- `SearchEmptyButHealthyIsNotAnError` — guards against over-correcting into false circuit trips.
- `SearchPartialFailureStillReturnsResults` — guards the surviving-variant path.

`go vet ./...` clean, `gofmt` clean, full suite: 15 packages ok, 0 failures.

## Scope

This makes the failure **visible**; it does not make Anna's work again. FlareSolverr was tried and **cannot** solve DDoS-Guard (times out at 180s), unlike Cloudflare which it handles fine — so no source-level workaround is included here.

Verified end-to-end on a live instance: with Anna's now erroring, a user-facing book search still returns results normally from the remaining sources.