### PR TITLE
fix(search): stop dropping usenet results on Books and Manga tabs

### DIFF
--- a/internal/search/filter.go
+++ b/internal/search/filter.go
@@ -72,21 +72,30 @@ func FilterAndSortResults(results []models.SearchResult, query string, minSize, 
 			continue
 		}
 
-		// Torrent-specific filters. Prowlarr can return usenet results under a
-		// torrent source label (books/manga tabs), so trust the protocol the
-		// driver already resolved rather than the source string alone.
-		isTorrent := (r.Source == "torrent" || r.Source == "prowlarr_manga" || r.Source == "nyaa_manga" ||
+		// Prowlarr returns usenet results under a torrent source label on the
+		// books and manga tabs, so the source string alone cannot decide which
+		// filters apply. Keep the two questions separate: the source says which
+		// bucket a result belongs to, the protocol says whether the checks that
+		// are genuinely about torrents apply to it.
+		isTorrentSource := r.Source == "torrent" || r.Source == "prowlarr_manga" || r.Source == "nyaa_manga" ||
 			r.Source == "tpb" || r.Source == "tpb_audiobook" ||
-			r.Source == "booktracker" || r.Source == "booktracker_audiobook") &&
-			r.DownloadProtocol != "nzb"
+			r.Source == "booktracker" || r.Source == "booktracker_audiobook"
+		isTorrent := isTorrentSource && r.DownloadProtocol != "nzb"
 		isABB := r.Source == "audiobook"
 
-		if isTorrent {
-			// Seed count threshold (ABB may have 0 seeders with valid magnets).
-			if r.Seeders < 1 {
-				continue
-			}
-			// Size bounds.
+		// Seed count threshold, torrents only (ABB may have 0 seeders with
+		// valid magnets). Usenet has no seeders at all: Prowlarr omits the key,
+		// r.Seeders unmarshals to 0, and applying this to an NZB silently drops
+		// every usenet result the indexers returned.
+		if isTorrent && r.Seeders < 1 {
+			continue
+		}
+
+		// Size bounds. Despite the config names these are a sanity check on
+		// what an indexer returned rather than a torrent property, so they hold
+		// for usenet too - an NZB below MinTorrentSizeBytes is the same junk a
+		// torrent that size would be.
+		if isTorrentSource {
 			size := r.Size
 			if size == 0 {
 				size = int64(parseSizeBytes(r.SizeHuman))
@@ -103,8 +112,11 @@ func FilterAndSortResults(results []models.SearchResult, query string, minSize, 
 			}
 		}
 
-		// Deduplication by first 60 chars of normalized title, keeping highest seeders.
-		if isTorrent || isABB {
+		// Deduplication by first 60 chars of normalized title, keeping highest
+		// seeders. Usenet results are deduplicated on the same terms: one
+		// release carried by several indexers is the normal case there, and
+		// they all arrive with 0 seeders, so the first copy seen wins.
+		if isTorrentSource || isABB {
 			norm := normalizeForDedup(r.Title)
 			if idx, exists := seenTitles[norm]; exists {
 				if r.Seeders > filtered[idx].Seeders {
@@ -156,7 +168,12 @@ func sourcePriority(r models.SearchResult) int {
 	case "annas", "annas_manga":
 		return 0
 	case "torrent", "audiobook", "prowlarr_manga", "nyaa_manga":
-		if r.Seeders > 0 {
+		// Seeders stand in for "is this still retrievable", which is why a
+		// zero-seeder torrent ranks below a live one. A usenet result carries
+		// no seeders by definition, so reading its 0 the same way would rank
+		// every NZB as if it were a dead torrent. An indexer still listing it
+		// is the usenet equivalent of that signal.
+		if r.Seeders > 0 || r.DownloadProtocol == "nzb" {
 			return 1
 		}
 		return 2

--- a/internal/search/filter.go
+++ b/internal/search/filter.go
@@ -72,10 +72,13 @@ func FilterAndSortResults(results []models.SearchResult, query string, minSize, 
 			continue
 		}
 
-		// Torrent-specific filters.
-		isTorrent := r.Source == "torrent" || r.Source == "prowlarr_manga" || r.Source == "nyaa_manga" ||
+		// Torrent-specific filters. Prowlarr can return usenet results under a
+		// torrent source label (books/manga tabs), so trust the protocol the
+		// driver already resolved rather than the source string alone.
+		isTorrent := (r.Source == "torrent" || r.Source == "prowlarr_manga" || r.Source == "nyaa_manga" ||
 			r.Source == "tpb" || r.Source == "tpb_audiobook" ||
-			r.Source == "booktracker" || r.Source == "booktracker_audiobook"
+			r.Source == "booktracker" || r.Source == "booktracker_audiobook") &&
+			r.DownloadProtocol != "nzb"
 		isABB := r.Source == "audiobook"
 
 		if isTorrent {

--- a/internal/search/filter_test.go
+++ b/internal/search/filter_test.go
@@ -166,6 +166,56 @@ func TestFilterAndSortResults(t *testing.T) {
 		}
 	})
 
+	// The size bounds are a sanity check on what an indexer returned, not a
+	// torrent property, so exempting usenet from them would open a hole the
+	// torrent path does not have.
+	t.Run("applies size bounds to usenet results", func(t *testing.T) {
+		results := []models.SearchResult{
+			{Source: "torrent", Title: "Tiny NZB", Seeders: 0, Size: 100, DownloadProtocol: "nzb"},
+			{Source: "torrent", Title: "Sane NZB", Seeders: 0, Size: 500000, DownloadProtocol: "nzb"},
+			{Source: "torrent", Title: "Huge NZB", Seeders: 0, Size: 5000000000, DownloadProtocol: "nzb"},
+		}
+		filtered := FilterAndSortResults(results, "nzb", 10000, 2000000000)
+		if len(filtered) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(filtered))
+		}
+		if filtered[0].Title != "Sane NZB" {
+			t.Errorf("expected Sane NZB, got %s", filtered[0].Title)
+		}
+	})
+
+	// One release carried by several usenet indexers is the normal case, so
+	// skipping dedup for them would fill the grid with copies of one book.
+	t.Run("deduplicates usenet results", func(t *testing.T) {
+		results := []models.SearchResult{
+			{Source: "torrent", Title: "Same Book", Seeders: 0, Size: 50000, DownloadProtocol: "nzb", Indexer: "one"},
+			{Source: "torrent", Title: "Same Book", Seeders: 0, Size: 50000, DownloadProtocol: "nzb", Indexer: "two"},
+		}
+		filtered := FilterAndSortResults(results, "same book", 10000, 2000000000)
+		if len(filtered) != 1 {
+			t.Fatalf("expected 1 result after dedup, got %d", len(filtered))
+		}
+		if filtered[0].Indexer != "one" {
+			t.Errorf("expected the first copy seen to win, got %s", filtered[0].Indexer)
+		}
+	})
+
+	// A usenet result outranks a dead torrent: it has no seeders to report, so
+	// reading its 0 as a torrent's would bury it.
+	t.Run("ranks a usenet result above a zero-seeder torrent", func(t *testing.T) {
+		results := []models.SearchResult{
+			{Source: "audiobook", Title: "Some Book B", Seeders: 0, Size: 50000, AbbURL: "/x"},
+			{Source: "torrent", Title: "Some Book A", Seeders: 0, Size: 50000, DownloadProtocol: "nzb"},
+		}
+		filtered := FilterAndSortResults(results, "some book", 10000, 2000000000)
+		if len(filtered) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(filtered))
+		}
+		if filtered[0].Title != "Some Book A" {
+			t.Errorf("expected the usenet result first, got %s", filtered[0].Title)
+		}
+	})
+
 	t.Run("sorts by relevance then source priority", func(t *testing.T) {
 		results := []models.SearchResult{
 			{Source: "gutenberg", Title: "Other Book"},
@@ -211,6 +261,8 @@ func TestSourcePriority(t *testing.T) {
 		{models.SearchResult{Source: "annas_manga"}, 0},
 		{models.SearchResult{Source: "torrent", Seeders: 5}, 1},
 		{models.SearchResult{Source: "torrent", Seeders: 0}, 2},
+		{models.SearchResult{Source: "torrent", Seeders: 0, DownloadProtocol: "nzb"}, 1},
+		{models.SearchResult{Source: "prowlarr_manga", Seeders: 0, DownloadProtocol: "nzb"}, 1},
 		{models.SearchResult{Source: "gutenberg"}, 3},
 		{models.SearchResult{Source: "openlibrary"}, 3},
 		{models.SearchResult{Source: "mangadex"}, 2},

--- a/internal/search/filter_test.go
+++ b/internal/search/filter_test.go
@@ -145,6 +145,27 @@ func TestFilterAndSortResults(t *testing.T) {
 		}
 	})
 
+	// Prowlarr labels usenet results with a torrent source string on the books
+	// and manga tabs, and usenet carries no seeders, so the seed threshold used
+	// to discard every one of them while the search still reported success.
+	t.Run("keeps usenet results that carry a torrent source label", func(t *testing.T) {
+		results := []models.SearchResult{
+			{Source: "torrent", Title: "Book On Usenet", Seeders: 0, Size: 50000, DownloadProtocol: "nzb"},
+			{Source: "prowlarr_manga", Title: "Manga On Usenet", Seeders: 0, Size: 50000, DownloadProtocol: "nzb"},
+			{Source: "torrent", Title: "Live Torrent", Seeders: 5, Size: 50000, DownloadProtocol: "torrent"},
+			{Source: "torrent", Title: "Dead Torrent", Seeders: 0, Size: 50000, DownloadProtocol: "torrent"},
+		}
+		filtered := FilterAndSortResults(results, "usenet", 10000, 2000000000)
+		if len(filtered) != 3 {
+			t.Fatalf("expected 3 results, got %d", len(filtered))
+		}
+		for _, r := range filtered {
+			if r.Title == "Dead Torrent" {
+				t.Error("zero-seeder torrent survived the seed threshold")
+			}
+		}
+	})
+
 	t.Run("sorts by relevance then source priority", func(t *testing.T) {
 		results := []models.SearchResult{
 			{Source: "gutenberg", Title: "Other Book"},

--- a/internal/torznab/xml.go
+++ b/internal/torznab/xml.go
@@ -55,6 +55,17 @@ func ResultToItem(r models.SearchResult, baseURL string) models.TorznabItem {
 		item.Attrs = append(item.Attrs, models.TorznabAttr{Name: "peers", Value: fmt.Sprintf("%d", r.Leechers)})
 	}
 
+	// A usenet result reaches this feed on the books and manga tabs, where
+	// Prowlarr labels it with a torrent source string. Announcing its .nzb as
+	// application/x-bittorrent would hand a downstream *arr app an NZB to feed
+	// to its torrent client, so the enclosure follows the protocol the driver
+	// resolved rather than the source label. The magnet branches below are
+	// torrents by construction and are left alone.
+	enclosureType := "application/x-bittorrent"
+	if r.DownloadProtocol == "nzb" {
+		enclosureType = "application/x-nzb"
+	}
+
 	// Set the download link.
 	if r.MagnetURL != "" {
 		item.Link = r.MagnetURL
@@ -68,7 +79,7 @@ func ResultToItem(r models.SearchResult, baseURL string) models.TorznabItem {
 		item.Enclosure = &models.TorznabEnclosure{
 			URL:    r.DownloadURL,
 			Length: r.Size,
-			Type:   "application/x-bittorrent",
+			Type:   enclosureType,
 		}
 	} else if r.InfoHash != "" {
 		magnet := fmt.Sprintf("magnet:?xt=urn:btih:%s&dn=%s", r.InfoHash, r.Title)

--- a/internal/torznab/xml_test.go
+++ b/internal/torznab/xml_test.go
@@ -42,6 +42,49 @@ func TestResultToItem(t *testing.T) {
 		}
 	})
 
+	// The books and manga tabs label usenet results with a torrent source
+	// string, so the enclosure has to follow the resolved protocol or a
+	// downstream *arr app hands the .nzb to its torrent client.
+	t.Run("usenet result announces an nzb enclosure", func(t *testing.T) {
+		r := models.SearchResult{
+			Source:           "torrent",
+			Title:            "Test Book Usenet",
+			DownloadURL:      "http://prowlarr/api/v1/indexer/1/download?apikey=x&link=y",
+			Size:             1000000,
+			DownloadProtocol: "nzb",
+			GUID:             "guid-nzb",
+		}
+
+		item := ResultToItem(r, baseURL)
+		if item.Enclosure == nil {
+			t.Fatal("expected enclosure")
+		}
+		if item.Enclosure.Type != "application/x-nzb" {
+			t.Errorf("expected application/x-nzb, got %s", item.Enclosure.Type)
+		}
+	})
+
+	// A magnet is a torrent whatever else the row says, so the protocol must
+	// not be able to relabel one.
+	t.Run("magnet keeps its bittorrent enclosure", func(t *testing.T) {
+		r := models.SearchResult{
+			Source:           "torrent",
+			Title:            "Mislabeled",
+			MagnetURL:        "magnet:?xt=urn:btih:def456",
+			Size:             1000000,
+			DownloadProtocol: "nzb",
+			GUID:             "guid-magnet",
+		}
+
+		item := ResultToItem(r, baseURL)
+		if item.Enclosure == nil {
+			t.Fatal("expected enclosure")
+		}
+		if item.Enclosure.Type != "application/x-bittorrent" {
+			t.Errorf("expected application/x-bittorrent, got %s", item.Enclosure.Type)
+		}
+	})
+
 	t.Run("audiobook result", func(t *testing.T) {
 		r := models.SearchResult{
 			Source:      "audiobook",


### PR DESCRIPTION
Fixes #110.

## Problem

`Prowlarr.doSearch` labels every result on the Books tab `Source: "torrent"`, and on the Manga tab `Source: "prowlarr_manga"`, regardless of the actual protocol — even though the same loop correctly resolves `DownloadProtocol` to `"nzb"` a few lines later.

`FilterAndSortResults` then derives `isTorrent` from `r.Source`, and both of those strings are in the list. That gates a seed-count threshold:

```go
if isTorrent {
    if r.Seeders < 1 {
        continue
    }
    ...
}
```

Usenet results have no seeders. Prowlarr omits the `seeders` key entirely, so `r.Seeders` unmarshals to `0`, the threshold trips, and every NZB is silently discarded.

Audiobooks were never affected because `prowlarr_audiobooks` is not in the `isTorrent` list.

The same block applies `MAX_TORRENT_SIZE_BYTES` bounds to NZBs, which is a second, milder consequence of the same mislabelling.

## Fix

Derive `isTorrent` from the `DownloadProtocol` the driver has already resolved, rather than from the source string alone. One expression, no config or API changes, and every genuine torrent path behaves exactly as before.

## Verification

Built and run against a Prowlarr instance with mixed usenet and torrent indexers, same queries before and after:

| Tab | Before | After |
|---|---:|---:|
| Books | 1 | **101** (100 nzb, 1 torrent) |
| Manga | 0 | **113** (87 nzb, 26 direct-source) |
| Audiobooks | 84 | 84 (unchanged) |

The single Books result before the patch was the only torrent the indexers returned.

## Notes

An alternative would be to give the Books tab its own source string (e.g. `prowlarr_books`) and leave it out of the `isTorrent` list, mirroring how `prowlarr_audiobooks` is already handled. I went with the protocol check because it also covers any future indexer that returns both protocols under one source label.