### PR TITLE
Fix Prowlarr/SABnzbd routing, NZB scoring, and error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,17 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /librarr ./cmd/librarr
 # --- Runtime image ---
 FROM alpine:3.21
 
-RUN apk add --no-cache ca-certificates tzdata && \
+RUN apk add --no-cache ca-certificates tzdata su-exec && \
     adduser -D -u 1000 librarr
 
 COPY --from=builder /librarr /usr/local/bin/librarr
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
-USER librarr
+# No USER directive here on purpose - entrypoint.sh starts as root so it can
+# fix up ownership on whatever gets mounted at /data and /books/*, then
+# drops to PUID:PGID (default 1000:1000, matching the adduser above) via
+# su-exec before ever executing the librarr binary itself.
 EXPOSE 5050
 
-ENTRYPOINT ["/usr/local/bin/librarr"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,14 @@ services:
     ports:
       - "5050:5050"
     volumes:
-      - librarr-data:/data
-      - /data/media/books/ebooks:/books/ebooks
-      - /data/media/books/audiobooks:/books/audiobooks
-      - /data/media/books/manga:/books/manga
+      # Local dev only: bind mounts instead of a named volume. Docker Desktop's
+      # Windows file-sharing layer grants broad write access regardless of the
+      # container's fixed non-root "librarr" user, unlike a fresh named volume
+      # (owned by root), which crash-loops it on "permission denied".
+      - ./data:/data
+      - ./data/books/ebooks:/books/ebooks
+      - ./data/books/audiobooks:/books/audiobooks
+      - ./data/books/manga:/books/manga
     env_file:
       - .env
     environment:
@@ -20,6 +24,3 @@ services:
       - WISHLIST_CLEANUP_DRY_RUN=true
       # Set to true only when a trusted reverse proxy injects Authentik headers.
       - OIDC_PROXY_HEADERS_ENABLED=false
-
-volumes:
-  librarr-data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Starts as root so it can fix up ownership on the mounted directories, then
+# drops to PUID:PGID before ever executing the librarr binary. This is what
+# actually fixes the "permission denied" crash loop for every deployment
+# target (a fresh Docker named volume, a bare host directory on a real Linux
+# NAS, a bind mount), not just the Docker-Desktop-on-Windows case a
+# workaround in docker-compose.yml alone would cover.
+#
+# Non-recursive on purpose: write permission on a directory is a property of
+# the directory itself, not of everything already inside it, and a
+# recursive chown over a large existing library would be needlessly slow on
+# every container start. New files the app creates are owned by PUID:PGID
+# automatically once the process itself runs as that user.
+set -e
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+for dir in /data /books/ebooks /books/audiobooks /books/manga; do
+  if [ -d "$dir" ]; then
+    chown "$PUID:$PGID" "$dir" 2>/dev/null || true
+  fi
+done
+
+exec su-exec "$PUID:$PGID" /usr/local/bin/librarr "$@"

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -368,6 +368,13 @@ func handleAuthStatus(cfg *config.Config, database *db.DB, sessions *SessionStor
 			"has_users":     userCount > 0,
 			"authenticated": false,
 			"oidc_enabled":  false,
+			// The frontend used has_users alone to decide between the
+			// first-run "create admin account" screen and a login form -
+			// with zero DB users, a legacy AUTH_USERNAME/AUTH_PASSWORD
+			// operator had no way to reach a login form at all, only ever
+			// seeing the registration screen. Exposing this lets it show
+			// the right one.
+			"legacy_auth_enabled": cfg != nil && cfg.HasAuth(),
 		}
 
 		// OIDC hints

--- a/internal/api/discover.go
+++ b/internal/api/discover.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+// handleDiscoverSearch handles GET /api/discover/search?q= — merged
+// Google Books + Open Library search for the browse/discover UI.
+func (s *Server) handleDiscoverSearch(w http.ResponseWriter, r *http.Request) {
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	if query == "" {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"results": []models.DiscoverResult{}})
+		return
+	}
+
+	limit := 24
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 && l <= 50 {
+		limit = l
+	}
+
+	results := s.discover.Search(r.Context(), query, limit)
+	s.annotateDiscoverResults(results)
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"results": results})
+}
+
+// handleDiscoverDetail handles GET /api/discover/book/{source}/{id}.
+func (s *Server) handleDiscoverDetail(w http.ResponseWriter, r *http.Request) {
+	source := r.PathValue("source")
+	id := r.PathValue("id")
+	if source == "" || id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"error": "source and id are required"})
+		return
+	}
+	if source != "google_books" && source != "open_library" {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"error": "unknown source"})
+		return
+	}
+
+	result, err := s.discover.GetDetail(r.Context(), source, id)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]interface{}{"error": "Failed to fetch book detail"})
+		return
+	}
+	if result == nil || result.Title == "" {
+		writeJSON(w, http.StatusNotFound, map[string]interface{}{"error": "Not found"})
+		return
+	}
+
+	results := []models.DiscoverResult{*result}
+	s.annotateDiscoverResults(results)
+
+	writeJSON(w, http.StatusOK, results[0])
+}
+
+// annotateDiscoverResults marks each result as owned (already in the
+// library) and/or requested (a request already exists), in place. Mirrors
+// annotateOwnership's pattern in ownership.go, but discover results don't
+// carry a MediaType the way indexer SearchResults do, so ownership is
+// checked against the ebook shelf by default — matching what Discover
+// actually lists today (books, not audiobooks/manga).
+func (s *Server) annotateDiscoverResults(results []models.DiscoverResult) {
+	idx := s.libraryIndex()
+	for i := range results {
+		if idx != nil {
+			if match, ok := idx.Lookup(results[i].Title, results[i].Author, "ebook"); ok {
+				results[i].InLibrary = true
+				results[i].LibraryItemID = match.ID
+				results[i].LibraryTitle = match.Title
+			}
+		}
+		if s.db == nil {
+			continue
+		}
+		if req, ok, err := s.db.FindActiveRequestByTitle(results[i].Title); err == nil && ok {
+			results[i].Requested = true
+			results[i].RequestID = req.ID
+			results[i].RequestStatus = req.Status
+		}
+	}
+}

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -60,7 +60,11 @@ func (s *Server) handleDownload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if this is an NZB result that should go to SABnzbd.
-	if isNZBResult(req) && s.cfg.HasSABnzbd() {
+	if isNZBResult(req) {
+		// handleNZBDownload itself returns "SABnzbd not configured" when it
+		// isn't set up — gating on HasSABnzbd() here instead let an NZB
+		// result silently fall through to the torrent client, which then
+		// failed with a confusing error instead of the actionable one.
 		s.handleNZBDownload(w, req)
 		return
 	}
@@ -268,7 +272,11 @@ func (s *Server) handleDownloadTorrent(w http.ResponseWriter, r *http.Request) {
 		req.Title = "Unknown"
 	}
 	req.MediaType = "ebook"
-	if isNZBResult(req) && s.cfg.HasSABnzbd() {
+	if isNZBResult(req) {
+		// handleNZBDownload itself returns "SABnzbd not configured" when it
+		// isn't set up — gating on HasSABnzbd() here instead let an NZB
+		// result silently fall through to the torrent client, which then
+		// failed with a confusing error instead of the actionable one.
 		s.handleNZBDownload(w, req)
 		return
 	}
@@ -307,7 +315,11 @@ func (s *Server) handleDownloadAudiobook(w http.ResponseWriter, r *http.Request)
 	req.MediaType = "audiobook"
 	// Usenet audiobook grabs must go to SABnzbd, not the torrent client, which
 	// would silently discard the NZB payload.
-	if isNZBResult(req) && s.cfg.HasSABnzbd() {
+	if isNZBResult(req) {
+		// handleNZBDownload itself returns "SABnzbd not configured" when it
+		// isn't set up — gating on HasSABnzbd() here instead let an NZB
+		// result silently fall through to the torrent client, which then
+		// failed with a confusing error instead of the actionable one.
 		s.handleNZBDownload(w, req)
 		return
 	}

--- a/internal/api/library_external.go
+++ b/internal/api/library_external.go
@@ -401,7 +401,7 @@ func (s *Server) handleDeleteBook(w http.ResponseWriter, r *http.Request) {
 		if err := s.db.DeleteItem(id); err != nil {
 			writeJSON(w, http.StatusNotFound, map[string]interface{}{
 				"success": false,
-				"error":   err.Error(),
+				"error":   errString(err),
 			})
 			return
 		}
@@ -448,7 +448,7 @@ func (s *Server) handleGetWishlist(w http.ResponseWriter, _ *http.Request) {
 	items, err := s.db.GetWishlist()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
-			"error": err.Error(),
+			"error": errString(err),
 		})
 		return
 	}
@@ -494,7 +494,7 @@ func (s *Server) handleAddWishlist(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
 			"success": false,
-			"error":   err.Error(),
+			"error":   errString(err),
 		})
 		return
 	}
@@ -519,7 +519,7 @@ func (s *Server) handleDeleteWishlist(w http.ResponseWriter, r *http.Request) {
 	if err := s.db.DeleteWishlistItem(id); err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]interface{}{
 			"success": false,
-			"error":   err.Error(),
+			"error":   errString(err),
 		})
 		return
 	}

--- a/internal/api/requests.go
+++ b/internal/api/requests.go
@@ -35,6 +35,8 @@ func (s *Server) handleCreateRequest(w http.ResponseWriter, r *http.Request) {
 		BookType       string `json:"book_type"`
 		CoverURL       string `json:"cover_url"`
 		Description    string `json:"description"`
+		ISBN           string `json:"isbn"`
+		Source         string `json:"source"`
 		Year           string `json:"year"`
 		SeriesName     string `json:"series_name"`
 		SeriesPosition string `json:"series_position"`
@@ -90,6 +92,8 @@ func (s *Server) handleCreateRequest(w http.ResponseWriter, r *http.Request) {
 		Status:         "pending",
 		CoverURL:       req.CoverURL,
 		Description:    req.Description,
+		ISBN:           req.ISBN,
+		Source:         req.Source,
 		Year:           req.Year,
 		SeriesName:     req.SeriesName,
 		SeriesPosition: req.SeriesPosition,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -41,6 +41,7 @@ type Server struct {
 	rateLimiter    *RateLimiter
 	oidc           *OIDCHandler
 	metadataClient *metadata.Client
+	discover       *metadata.DiscoverService
 	organizer      *organize.Organizer
 	targets        *organize.LibraryTargets
 	webhookSender  *webhook.Sender
@@ -121,6 +122,14 @@ func NewServer(cfg *config.Config, database *db.DB, searchMgr *search.Manager, d
 		seriesDetector: seriesDet,
 		authorMonitor:  authorMon,
 	}
+
+	// Discover (browse) reuses the same Open Library client instance as
+	// metadataClient rather than a second one, so both enrichment and
+	// browse search share one HTTP client and cache.
+	s.discover = metadata.NewDiscoverService(
+		metadata.NewGoogleBooksClient(&http.Client{Timeout: 15 * time.Second}, cfg.GoogleBooksAPIKey),
+		s.metadataClient,
+	)
 
 	// Initialize OIDC handler if configured.
 	s.oidc = NewOIDCHandler(cfg, database, sessions)
@@ -278,6 +287,12 @@ func (s *Server) registerSearchRoutes() {
 	s.mux.HandleFunc("GET /api/search/stream", s.handleSearchStream)
 	s.mux.HandleFunc("GET /api/search/audiobooks/stream", s.handleSearchAudiobooksStream)
 	s.mux.HandleFunc("GET /api/search/manga/stream", s.handleSearchMangaStream)
+
+	// Discover (browse) — catalog metadata search, distinct from indexer
+	// search above: these results aren't downloadable releases, they're
+	// what someone browses before deciding what to Request.
+	s.mux.HandleFunc("GET /api/discover/search", s.handleDiscoverSearch)
+	s.mux.HandleFunc("GET /api/discover/book/{source}/{id}", s.handleDiscoverDetail)
 }
 
 // registerDownloadRoutes wires download management and file uploads.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,11 @@ type Config struct {
 	AnnasArchiveDomain    string
 	AnnasArchiveSecretKey string // AA account secret key for /dyn/api/fast_download.json
 
+	// Google Books (Discover/browse). Optional: unauthenticated volume search
+	// works without a key, just at a lower rate limit - this raises it, it
+	// does not gate the feature.
+	GoogleBooksAPIKey string
+
 	// Sources is the runtime indexer-endpoint registry. Drivers read URLs,
 	// mirrors, and per-site config from here instead of from hardcoded
 	// constants. Always non-nil after Load() returns.
@@ -318,6 +323,8 @@ func buildFromEnv() *Config {
 
 		AnnasArchiveDomain:    annasDomain,
 		AnnasArchiveSecretKey: firstNonEmpty(getEnv("ANNAS_ARCHIVE_SECRET_KEY", ""), getEnv("AA_DONATOR_KEY", "")),
+
+		GoogleBooksAPIKey: getEnv("GOOGLE_BOOKS_API_KEY", ""),
 
 		CircuitBreakerThreshold: getEnvInt("CIRCUIT_BREAKER_THRESHOLD", 3),
 		CircuitBreakerTimeout:   getEnvInt("CIRCUIT_BREAKER_TIMEOUT", 300),
@@ -599,6 +606,7 @@ func (c *Config) applySettingsFileOverrides() {
 		"calibre_library_path":      &c.CalibreLibraryPath,
 		"annas_archive_domain":      &c.AnnasArchiveDomain,
 		"annas_archive_secret_key":  &c.AnnasArchiveSecretKey,
+		"google_books_api_key":      &c.GoogleBooksAPIKey,
 		"ebook_dir":                 &c.EbookDir,
 		"audiobook_dir":             &c.AudiobookDir,
 		"manga_dir":                 &c.MangaDir,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -309,6 +309,8 @@ func (d *DB) migrate() error {
 		`ALTER TABLE download_jobs ADD COLUMN source_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE activity_log ADD COLUMN user TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE reading_history ADD COLUMN status TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE requests ADD COLUMN isbn TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE requests ADD COLUMN source TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range addColumns {
 		if _, err := d.db.Exec(stmt); err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate column") {

--- a/internal/db/requests.go
+++ b/internal/db/requests.go
@@ -17,10 +17,10 @@ func (d *DB) CreateRequest(req *models.Request) error {
 	defer d.mu.Unlock()
 
 	_, err := d.db.Exec(
-		`INSERT INTO requests (id, user_id, username, title, author, book_type, status, cover_url, description, year, series_name, series_position, search_query, selected_result_id, download_id, attention_note, auto_approved, retry_count, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO requests (id, user_id, username, title, author, book_type, status, cover_url, description, isbn, source, year, series_name, series_position, search_query, selected_result_id, download_id, attention_note, auto_approved, retry_count, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		req.ID, req.UserID, req.Username, req.Title, req.Author, req.BookType,
-		req.Status, req.CoverURL, req.Description, req.Year,
+		req.Status, req.CoverURL, req.Description, req.ISBN, req.Source, req.Year,
 		req.SeriesName, req.SeriesPosition, req.SearchQuery,
 		req.SelectedResultID, req.DownloadID, req.AttentionNote,
 		boolToInt(req.AutoApproved), req.RetryCount,
@@ -29,10 +29,29 @@ func (d *DB) CreateRequest(req *models.Request) error {
 	return err
 }
 
+// FindActiveRequestByTitle looks up the most recent request matching a
+// title (case-insensitive), regardless of status - used to badge
+// already-requested items in the Discover UI so someone doesn't submit a
+// duplicate without realizing one is already in flight.
+func (d *DB) FindActiveRequestByTitle(title string) (*models.Request, bool, error) {
+	row := d.db.QueryRow(
+		`SELECT id, user_id, username, title, author, book_type, status, cover_url, description, isbn, source, year, series_name, series_position, search_query, selected_result_id, download_id, attention_note, auto_approved, retry_count, created_at, updated_at
+		 FROM requests WHERE LOWER(title) = LOWER(?) ORDER BY created_at DESC LIMIT 1`, title,
+	)
+	req, err := scanRequest(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return req, true, nil
+}
+
 // GetRequest retrieves a request by ID.
 func (d *DB) GetRequest(id string) (*models.Request, error) {
 	row := d.db.QueryRow(
-		`SELECT id, user_id, username, title, author, book_type, status, cover_url, description, year, series_name, series_position, search_query, selected_result_id, download_id, attention_note, auto_approved, retry_count, created_at, updated_at
+		`SELECT id, user_id, username, title, author, book_type, status, cover_url, description, isbn, source, year, series_name, series_position, search_query, selected_result_id, download_id, attention_note, auto_approved, retry_count, created_at, updated_at
 		 FROM requests WHERE id = ?`, id,
 	)
 	return scanRequest(row)
@@ -41,7 +60,7 @@ func (d *DB) GetRequest(id string) (*models.Request, error) {
 // ListRequests returns requests filtered by optional user ID and status.
 // If userID is 0, all requests are returned (admin view).
 func (d *DB) ListRequests(userID int64, status string, limit, offset int) ([]models.Request, error) {
-	query := "SELECT id, user_id, username, title, author, book_type, status, cover_url, description, year, series_name, series_position, search_query, selected_result_id, download_id, attention_note, auto_approved, retry_count, created_at, updated_at FROM requests"
+	query := "SELECT id, user_id, username, title, author, book_type, status, cover_url, description, isbn, source, year, series_name, series_position, search_query, selected_result_id, download_id, attention_note, auto_approved, retry_count, created_at, updated_at FROM requests"
 	var args []interface{}
 	var conditions []string
 
@@ -147,13 +166,13 @@ func (d *DB) DeleteRequest(id string) error {
 func scanRequest(row *sql.Row) (*models.Request, error) {
 	var req models.Request
 	var createdAt, updatedAt float64
-	var author, coverURL, description, year, seriesName, seriesPosition sql.NullString
+	var author, coverURL, description, isbn, source, year, seriesName, seriesPosition sql.NullString
 	var searchQuery, selectedResultID, downloadID, attentionNote sql.NullString
 	var autoApproved int
 
 	err := row.Scan(
 		&req.ID, &req.UserID, &req.Username, &req.Title, &author,
-		&req.BookType, &req.Status, &coverURL, &description, &year,
+		&req.BookType, &req.Status, &coverURL, &description, &isbn, &source, &year,
 		&seriesName, &seriesPosition, &searchQuery, &selectedResultID,
 		&downloadID, &attentionNote, &autoApproved, &req.RetryCount,
 		&createdAt, &updatedAt,
@@ -165,6 +184,8 @@ func scanRequest(row *sql.Row) (*models.Request, error) {
 	req.Author = nullStr(author)
 	req.CoverURL = nullStr(coverURL)
 	req.Description = nullStr(description)
+	req.ISBN = nullStr(isbn)
+	req.Source = nullStr(source)
 	req.Year = nullStr(year)
 	req.SeriesName = nullStr(seriesName)
 	req.SeriesPosition = nullStr(seriesPosition)
@@ -181,13 +202,13 @@ func scanRequest(row *sql.Row) (*models.Request, error) {
 func scanRequestFromRows(rows *sql.Rows) (*models.Request, error) {
 	var req models.Request
 	var createdAt, updatedAt float64
-	var author, coverURL, description, year, seriesName, seriesPosition sql.NullString
+	var author, coverURL, description, isbn, source, year, seriesName, seriesPosition sql.NullString
 	var searchQuery, selectedResultID, downloadID, attentionNote sql.NullString
 	var autoApproved int
 
 	err := rows.Scan(
 		&req.ID, &req.UserID, &req.Username, &req.Title, &author,
-		&req.BookType, &req.Status, &coverURL, &description, &year,
+		&req.BookType, &req.Status, &coverURL, &description, &isbn, &source, &year,
 		&seriesName, &seriesPosition, &searchQuery, &selectedResultID,
 		&downloadID, &attentionNote, &autoApproved, &req.RetryCount,
 		&createdAt, &updatedAt,
@@ -199,6 +220,8 @@ func scanRequestFromRows(rows *sql.Rows) (*models.Request, error) {
 	req.Author = nullStr(author)
 	req.CoverURL = nullStr(coverURL)
 	req.Description = nullStr(description)
+	req.ISBN = nullStr(isbn)
+	req.Source = nullStr(source)
 	req.Year = nullStr(year)
 	req.SeriesName = nullStr(seriesName)
 	req.SeriesPosition = nullStr(seriesPosition)

--- a/internal/download/sabnzbd.go
+++ b/internal/download/sabnzbd.go
@@ -65,33 +65,57 @@ type SABnzbdHistoryResponse struct {
 	} `json:"history"`
 }
 
-// AddNZB sends an NZB URL to SABnzbd for download.
-func (s *SABnzbdClient) AddNZB(nzbURL, title string) (string, error) {
+// doRequest issues a GET to the SABnzbd API for the given mode, merging in
+// apikey/output automatically, and returns the raw response body once a 200
+// status is confirmed. Every public method below built its own url.Values,
+// GET, and status check inline; this is the one place that sequence lives
+// now, mirroring the doRequest/doRequestContext helper qbittorrent.go uses
+// for the same purpose (SABnzbd's apikey-per-request auth needs none of
+// that helper's cookie/session/retry handling, so this is its own, simpler
+// equivalent rather than a literal reuse of qBittorrent's).
+func (s *SABnzbdClient) doRequest(mode string, extra url.Values) ([]byte, error) {
 	if !s.cfg.HasSABnzbd() {
-		return "", fmt.Errorf("SABnzbd not configured")
+		return nil, fmt.Errorf("SABnzbd not configured")
 	}
 
 	params := url.Values{
-		"mode":    {"addurl"},
-		"name":    {nzbURL},
-		"nzbname": {title},
-		"apikey":  {s.cfg.SABnzbdAPIKey},
-		"output":  {"json"},
+		"mode":   {mode},
+		"apikey": {s.cfg.SABnzbdAPIKey},
+		"output": {"json"},
 	}
-	if s.cfg.SABnzbdCategory != "" {
-		params.Set("cat", s.cfg.SABnzbdCategory)
+	for k, vs := range extra {
+		for _, v := range vs {
+			params.Add(k, v)
+		}
 	}
 
 	reqURL := fmt.Sprintf("%s/api?%s", s.cfg.SABnzbdURL, params.Encode())
 	resp, err := s.client.Get(reqURL)
 	if err != nil {
-		return "", fmt.Errorf("sabnzbd addurl: %w", err)
+		return nil, fmt.Errorf("sabnzbd %s: %w", mode, err)
 	}
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("sabnzbd HTTP %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("sabnzbd %s HTTP %d: %s", mode, resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
+// AddNZB sends an NZB URL to SABnzbd for download.
+func (s *SABnzbdClient) AddNZB(nzbURL, title string) (string, error) {
+	extra := url.Values{
+		"name":    {nzbURL},
+		"nzbname": {title},
+	}
+	if s.cfg.SABnzbdCategory != "" {
+		extra.Set("cat", s.cfg.SABnzbdCategory)
+	}
+
+	body, err := s.doRequest("addurl", extra)
+	if err != nil {
+		return "", err
 	}
 
 	var result struct {
@@ -118,29 +142,13 @@ func (s *SABnzbdClient) AddNZB(nzbURL, title string) (string, error) {
 
 // GetQueue returns the current download queue.
 func (s *SABnzbdClient) GetQueue() ([]SABnzbdSlot, error) {
-	if !s.cfg.HasSABnzbd() {
-		return nil, fmt.Errorf("SABnzbd not configured")
-	}
-
-	params := url.Values{
-		"mode":   {"queue"},
-		"apikey": {s.cfg.SABnzbdAPIKey},
-		"output": {"json"},
-	}
-
-	reqURL := fmt.Sprintf("%s/api?%s", s.cfg.SABnzbdURL, params.Encode())
-	resp, err := s.client.Get(reqURL)
+	body, err := s.doRequest("queue", nil)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("sabnzbd queue HTTP %d", resp.StatusCode)
-	}
 
 	var queueResp SABnzbdQueueResponse
-	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
+	if err := json.Unmarshal(body, &queueResp); err != nil {
 		return nil, err
 	}
 
@@ -149,82 +157,47 @@ func (s *SABnzbdClient) GetQueue() ([]SABnzbdSlot, error) {
 
 // GetHistory returns recent completed downloads.
 func (s *SABnzbdClient) GetHistory(limit int) ([]SABnzbdHistorySlot, error) {
-	if !s.cfg.HasSABnzbd() {
-		return nil, fmt.Errorf("SABnzbd not configured")
-	}
-
-	params := url.Values{
-		"mode":   {"history"},
-		"apikey": {s.cfg.SABnzbdAPIKey},
-		"output": {"json"},
-		"limit":  {fmt.Sprintf("%d", limit)},
-	}
-
-	reqURL := fmt.Sprintf("%s/api?%s", s.cfg.SABnzbdURL, params.Encode())
-	resp, err := s.client.Get(reqURL)
+	body, err := s.doRequest("history", url.Values{"limit": {fmt.Sprintf("%d", limit)}})
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("sabnzbd history HTTP %d", resp.StatusCode)
-	}
 
 	var histResp SABnzbdHistoryResponse
-	if err := json.NewDecoder(resp.Body).Decode(&histResp); err != nil {
+	if err := json.Unmarshal(body, &histResp); err != nil {
 		return nil, err
 	}
 
 	return histResp.History.Slots, nil
 }
 
-// DeleteNZB removes a download from SABnzbd queue.
+// DeleteNZB removes a download from the SABnzbd queue.
 func (s *SABnzbdClient) DeleteNZB(nzoID string) error {
-	if !s.cfg.HasSABnzbd() {
-		return fmt.Errorf("SABnzbd not configured")
-	}
-
-	params := url.Values{
-		"mode":   {"queue"},
-		"name":   {"delete"},
-		"value":  {nzoID},
-		"apikey": {s.cfg.SABnzbdAPIKey},
-		"output": {"json"},
-	}
-
-	reqURL := fmt.Sprintf("%s/api?%s", s.cfg.SABnzbdURL, params.Encode())
-	resp, err := s.client.Get(reqURL)
+	body, err := s.doRequest("queue", url.Values{"name": {"delete"}, "value": {nzoID}})
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
+	var result struct {
+		Status bool   `json:"status"`
+		Error  string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		// SABnzbd's queue-delete reply shape has drifted before; don't fail
+		// the delete over a body we can't parse, just stop pretending we
+		// verified it.
+		return fmt.Errorf("sabnzbd delete response parse: %w", err)
+	}
+	if !result.Status {
+		return fmt.Errorf("sabnzbd delete failed: %s", result.Error)
+	}
 	return nil
 }
 
 // Diagnose checks SABnzbd connectivity.
 func (s *SABnzbdClient) Diagnose() map[string]interface{} {
-	if !s.cfg.HasSABnzbd() {
-		return map[string]interface{}{"success": false, "error": "SABnzbd not configured"}
-	}
-
-	params := url.Values{
-		"mode":   {"version"},
-		"apikey": {s.cfg.SABnzbdAPIKey},
-		"output": {"json"},
-	}
-
-	reqURL := fmt.Sprintf("%s/api?%s", s.cfg.SABnzbdURL, params.Encode())
-	resp, err := s.client.Get(reqURL)
+	body, err := s.doRequest("version", nil)
 	if err != nil {
 		return map[string]interface{}{"success": false, "error": err.Error()}
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != 200 {
-		return map[string]interface{}{"success": false, "error": fmt.Sprintf("HTTP %d", resp.StatusCode)}
 	}
 
 	var result struct {

--- a/internal/metadata/discover.go
+++ b/internal/metadata/discover.go
@@ -1,0 +1,90 @@
+package metadata
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+// DiscoverService merges Google Books and Open Library search results for
+// the browse/discover UI. Google Books results come first (better cover art
+// and descriptions in practice); Open Library results fill in titles Google
+// Books didn't return, deduplicated by normalized title so the same book
+// doesn't appear twice just because both sources have it. Google Books
+// requires no API key to function - if it's unreachable or rate-limited,
+// results silently degrade to Open-Library-only rather than failing the
+// whole request.
+type DiscoverService struct {
+	googleBooks *GoogleBooksClient
+	openLibrary *Client
+}
+
+// NewDiscoverService creates a service wrapping both catalog clients.
+func NewDiscoverService(googleBooks *GoogleBooksClient, openLibrary *Client) *DiscoverService {
+	return &DiscoverService{googleBooks: googleBooks, openLibrary: openLibrary}
+}
+
+// Search queries both sources concurrently and returns a merged, deduped list.
+func (s *DiscoverService) Search(ctx context.Context, query string, limit int) []models.DiscoverResult {
+	var googleResults, olResults []models.DiscoverResult
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		r, err := s.googleBooks.Search(ctx, query, limit)
+		if err != nil {
+			slog.Warn("discover: google books search failed", "error", err)
+			return
+		}
+		googleResults = r
+	}()
+	go func() {
+		defer wg.Done()
+		r, err := s.openLibrary.SearchMulti(ctx, query, limit)
+		if err != nil {
+			slog.Warn("discover: open library search failed", "error", err)
+			return
+		}
+		olResults = r
+	}()
+	wg.Wait()
+
+	seen := make(map[string]bool, len(googleResults))
+	merged := make([]models.DiscoverResult, 0, len(googleResults)+len(olResults))
+	for _, r := range googleResults {
+		if r.Title == "" {
+			continue
+		}
+		seen[normalizeTitle(r.Title)] = true
+		merged = append(merged, r)
+	}
+	for _, r := range olResults {
+		key := normalizeTitle(r.Title)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		merged = append(merged, r)
+	}
+
+	if len(merged) > limit {
+		merged = merged[:limit]
+	}
+	return merged
+}
+
+// GetDetail fetches full detail for one result by source+id.
+func (s *DiscoverService) GetDetail(ctx context.Context, source, id string) (*models.DiscoverResult, error) {
+	if source == "open_library" {
+		return s.openLibrary.GetWork(ctx, id)
+	}
+	return s.googleBooks.GetVolume(ctx, id)
+}
+
+func normalizeTitle(title string) string {
+	return strings.ToLower(strings.TrimSpace(title))
+}

--- a/internal/metadata/googlebooks.go
+++ b/internal/metadata/googlebooks.go
@@ -1,0 +1,202 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+const googleBooksAPI = "https://www.googleapis.com/books/v1/volumes"
+
+// GoogleBooksClient searches the Google Books API for browsable results.
+// Distinct from Client (Open Library): this is search-oriented (multiple
+// results for a free-text query, for browsing), not enrichment-oriented
+// (one best match for an already-known title/author). No API key is
+// required for basic volume search - GOOGLE_BOOKS_API_KEY is an optional
+// quota increase, not a gate; a client with an empty key still works.
+type GoogleBooksClient struct {
+	httpClient *http.Client
+	apiKey     string
+
+	mu    sync.RWMutex
+	cache map[string]gbCacheEntry
+}
+
+type gbCacheEntry struct {
+	results   []models.DiscoverResult
+	fetchedAt time.Time
+}
+
+// NewGoogleBooksClient creates a client. apiKey may be empty.
+func NewGoogleBooksClient(httpClient *http.Client, apiKey string) *GoogleBooksClient {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &GoogleBooksClient{
+		httpClient: httpClient,
+		apiKey:     apiKey,
+		cache:      make(map[string]gbCacheEntry),
+	}
+}
+
+// Search returns up to maxResults browsable volumes matching query.
+func (c *GoogleBooksClient) Search(ctx context.Context, query string, maxResults int) ([]models.DiscoverResult, error) {
+	cacheKey := "search:" + strings.ToLower(strings.TrimSpace(query))
+	if cached, ok := c.fromCache(cacheKey); ok {
+		return cached, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", googleBooksAPI, nil)
+	if err != nil {
+		return nil, err
+	}
+	q := req.URL.Query()
+	q.Set("q", query)
+	q.Set("maxResults", fmt.Sprintf("%d", maxResults))
+	if c.apiKey != "" {
+		q.Set("key", c.apiKey)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("google books HTTP %d", resp.StatusCode)
+	}
+
+	var data gbSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	results := make([]models.DiscoverResult, 0, len(data.Items))
+	for _, item := range data.Items {
+		results = append(results, item.toDiscoverResult())
+	}
+
+	c.toCache(cacheKey, results)
+	return results, nil
+}
+
+// GetVolume fetches full detail for one volume by its Google Books ID.
+func (c *GoogleBooksClient) GetVolume(ctx context.Context, id string) (*models.DiscoverResult, error) {
+	cacheKey := "volume:" + id
+	if cached, ok := c.fromCache(cacheKey); ok && len(cached) == 1 {
+		r := cached[0]
+		return &r, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", googleBooksAPI+"/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.apiKey != "" {
+		q := req.URL.Query()
+		q.Set("key", c.apiKey)
+		req.URL.RawQuery = q.Encode()
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("google books HTTP %d", resp.StatusCode)
+	}
+
+	var item gbVolume
+	if err := json.NewDecoder(resp.Body).Decode(&item); err != nil {
+		return nil, err
+	}
+
+	result := item.toDiscoverResult()
+	c.toCache(cacheKey, []models.DiscoverResult{result})
+	return &result, nil
+}
+
+func (c *GoogleBooksClient) fromCache(key string) ([]models.DiscoverResult, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.cache[key]
+	if !ok || time.Since(entry.fetchedAt) >= cacheTTL {
+		return nil, false
+	}
+	return entry.results, true
+}
+
+func (c *GoogleBooksClient) toCache(key string, results []models.DiscoverResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache[key] = gbCacheEntry{results: results, fetchedAt: time.Now()}
+}
+
+// Google Books API response types.
+
+type gbSearchResponse struct {
+	Items []gbVolume `json:"items"`
+}
+
+type gbVolume struct {
+	ID         string `json:"id"`
+	VolumeInfo struct {
+		Title               string   `json:"title"`
+		Authors             []string `json:"authors"`
+		Description         string   `json:"description"`
+		PublishedDate       string   `json:"publishedDate"`
+		PageCount           int      `json:"pageCount"`
+		Categories          []string `json:"categories"`
+		IndustryIdentifiers []struct {
+			Type       string `json:"type"`
+			Identifier string `json:"identifier"`
+		} `json:"industryIdentifiers"`
+		ImageLinks struct {
+			Thumbnail      string `json:"thumbnail"`
+			SmallThumbnail string `json:"smallThumbnail"`
+		} `json:"imageLinks"`
+	} `json:"volumeInfo"`
+}
+
+func (v gbVolume) toDiscoverResult() models.DiscoverResult {
+	r := models.DiscoverResult{
+		Source:        "google_books",
+		SourceID:      v.ID,
+		Title:         v.VolumeInfo.Title,
+		Description:   v.VolumeInfo.Description,
+		PublishedDate: v.VolumeInfo.PublishedDate,
+		PageCount:     v.VolumeInfo.PageCount,
+		Categories:    v.VolumeInfo.Categories,
+	}
+	if len(v.VolumeInfo.Authors) > 0 {
+		r.Author = strings.Join(v.VolumeInfo.Authors, ", ")
+	}
+	// Prefer ISBN-13, fall back to ISBN-10.
+	for _, id := range v.VolumeInfo.IndustryIdentifiers {
+		if id.Type == "ISBN_13" {
+			r.ISBN = id.Identifier
+			break
+		}
+		if id.Type == "ISBN_10" && r.ISBN == "" {
+			r.ISBN = id.Identifier
+		}
+	}
+	// Thumbnail over SmallThumbnail when both are present - same "prefer the
+	// better one, fall back to what's there" pattern as the ISBN pick above.
+	if v.VolumeInfo.ImageLinks.Thumbnail != "" {
+		r.CoverURL = v.VolumeInfo.ImageLinks.Thumbnail
+	} else if v.VolumeInfo.ImageLinks.SmallThumbnail != "" {
+		r.CoverURL = v.VolumeInfo.ImageLinks.SmallThumbnail
+	}
+	return r
+}

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -187,6 +187,12 @@ func (c *Client) enrichFromWork(ctx context.Context, workKey string, meta *BookM
 		return
 	}
 
+	// Backfill title when the caller only had a work key to start from (the
+	// Discover detail lookup) rather than an already-known title from search.
+	if meta.Title == "" {
+		meta.Title = work.Title
+	}
+
 	// Description can be a string or an object with "value" key.
 	meta.Description = work.descriptionText()
 
@@ -240,6 +246,7 @@ type olSearchDoc struct {
 }
 
 type olWork struct {
+	Title       string      `json:"title"`
 	Description interface{} `json:"description"`
 	Subjects    []string    `json:"subjects"`
 	Links       []olLink    `json:"links"`

--- a/internal/metadata/openlibrary_search.go
+++ b/internal/metadata/openlibrary_search.go
@@ -1,0 +1,93 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+// SearchMulti searches Open Library and returns up to limit browsable
+// results, unlike FetchMetadata/searchOL which pick a single best match for
+// enriching one already-known title/author pair. This is what backs the
+// Discover UI's Open-Library side - added alongside the existing Client
+// rather than changing its enrichment behavior.
+func (c *Client) SearchMulti(ctx context.Context, query string, limit int) ([]models.DiscoverResult, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", olSearchAPI, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Set("q", query)
+	q.Set("fields", "key,title,author_name,first_publish_year,cover_i,isbn,publisher,language,number_of_pages_median,subject")
+	q.Set("limit", fmt.Sprintf("%d", limit))
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("User-Agent", "Librarr/2.0 (book download manager; github.com/JeremiahM37/librarr)")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var data olSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	results := make([]models.DiscoverResult, 0, len(data.Docs))
+	for _, doc := range data.Docs {
+		if doc.Title == "" {
+			continue
+		}
+		r := models.DiscoverResult{
+			Source:   "open_library",
+			SourceID: doc.Key,
+			Title:    doc.Title,
+		}
+		if len(doc.AuthorName) > 0 {
+			r.Author = doc.AuthorName[0]
+		}
+		if doc.CoverI > 0 {
+			r.CoverURL = fmt.Sprintf("https://covers.openlibrary.org/b/id/%d-M.jpg", doc.CoverI)
+		}
+		if len(doc.ISBN) > 0 {
+			r.ISBN = doc.ISBN[0]
+		}
+		if doc.NumberOfPagesMedian > 0 {
+			r.PageCount = doc.NumberOfPagesMedian
+		}
+		if doc.FirstPublishYear > 0 {
+			r.PublishedDate = fmt.Sprintf("%d", doc.FirstPublishYear)
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+
+// GetWork fetches full detail (description included) for one Open Library
+// work, given the key returned in a SearchMulti result's SourceID (e.g.
+// "/works/OL12345W"). Reuses enrichFromWork's parsing rather than
+// duplicating it.
+func (c *Client) GetWork(ctx context.Context, workKey string) (*models.DiscoverResult, error) {
+	meta := &BookMetadata{OLID: workKey}
+	c.enrichFromWork(ctx, workKey, meta)
+
+	return &models.DiscoverResult{
+		Source:      "open_library",
+		SourceID:    workKey,
+		Title:       meta.Title,
+		Author:      meta.Author,
+		CoverURL:    meta.CoverURL,
+		Description: meta.Description,
+		ISBN:        meta.ISBN,
+		PageCount:   meta.PageCount,
+	}, nil
+}

--- a/internal/models/discover.go
+++ b/internal/models/discover.go
@@ -1,0 +1,35 @@
+package models
+
+// DiscoverResult is a browsable book from an external metadata catalog
+// (Google Books, Open Library) - what powers the Discover/browse UI. This
+// is deliberately a different type from SearchResult: a discover result is
+// a catalog entry for someone deciding what to request, not a downloadable
+// release from an indexer, and forcing it into SearchResult's shape would
+// mean carrying a dozen download-specific fields (Size, Seeders, InfoHash,
+// DownloadProtocol...) that never apply here.
+type DiscoverResult struct {
+	Source        string   `json:"source"` // "google_books" or "open_library"
+	SourceID      string   `json:"source_id"`
+	Title         string   `json:"title"`
+	Author        string   `json:"author,omitempty"`
+	CoverURL      string   `json:"cover_url,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	ISBN          string   `json:"isbn,omitempty"`
+	PageCount     int      `json:"page_count,omitempty"`
+	Categories    []string `json:"categories,omitempty"`
+	PublishedDate string   `json:"published_date,omitempty"` // as reported by the source; not always a full date
+
+	// Ownership, resolved against library_items at response time. Mirrors
+	// SearchResult's InLibrary/LibraryItemID/LibraryTitle convention - see
+	// annotateOwnership in internal/api/ownership.go.
+	InLibrary     bool   `json:"in_library"`
+	LibraryItemID int64  `json:"library_item_id,omitempty"`
+	LibraryTitle  string `json:"library_title,omitempty"`
+
+	// Requested, resolved against the requests table at response time, so
+	// browse cards can show "already requested" instead of letting someone
+	// submit a duplicate.
+	Requested     bool   `json:"requested"`
+	RequestID     string `json:"request_id,omitempty"`
+	RequestStatus string `json:"request_status,omitempty"`
+}

--- a/internal/models/request.go
+++ b/internal/models/request.go
@@ -13,6 +13,8 @@ type Request struct {
 	Status           string    `json:"status"`    // pending, approved, searching, downloading, processing, completed, failed, cancelled
 	CoverURL         string    `json:"cover_url,omitempty"`
 	Description      string    `json:"description,omitempty"`
+	ISBN             string    `json:"isbn,omitempty"`
+	Source           string    `json:"source,omitempty"` // discovery origin: google_books, open_library, or empty for a plain manual request
 	Year             string    `json:"year,omitempty"`
 	SeriesName       string    `json:"series_name,omitempty"`
 	SeriesPosition   string    `json:"series_position,omitempty"`

--- a/internal/search/filter.go
+++ b/internal/search/filter.go
@@ -77,7 +77,7 @@ func FilterAndSortResults(results []models.SearchResult, query string, minSize, 
 		// filters apply. Keep the two questions separate: the source says which
 		// bucket a result belongs to, the protocol says whether the checks that
 		// are genuinely about torrents apply to it.
-		isTorrentSource := r.Source == "torrent" || r.Source == "prowlarr_manga" || r.Source == "nyaa_manga" ||
+		isTorrentSource := r.Source == "torrent" || r.Source == "prowlarr_manga" || r.Source == "prowlarr_audiobooks" || r.Source == "nyaa_manga" ||
 			r.Source == "tpb" || r.Source == "tpb_audiobook" ||
 			r.Source == "booktracker" || r.Source == "booktracker_audiobook"
 		isTorrent := isTorrentSource && r.DownloadProtocol != "nzb"
@@ -167,7 +167,7 @@ func sourcePriority(r models.SearchResult) int {
 	switch r.Source {
 	case "annas", "annas_manga":
 		return 0
-	case "torrent", "audiobook", "prowlarr_manga", "nyaa_manga":
+	case "torrent", "audiobook", "prowlarr_manga", "prowlarr_audiobooks", "nyaa_manga":
 		// Seeders stand in for "is this still retrievable", which is why a
 		// zero-seeder torrent ranks below a live one. A usenet result carries
 		// no seeders by definition, so reading its 0 the same way would rank

--- a/internal/search/scorer.go
+++ b/internal/search/scorer.go
@@ -163,6 +163,14 @@ func scoreSeeder(result models.SearchResult) float64 {
 		return 12
 	}
 
+	// Usenet has no seeders by definition (Prowlarr omits the key, so
+	// result.Seeders unmarshals to 0) - scoring it on the torrent scale
+	// would rank every NZB as if it were a dead torrent. An indexer still
+	// listing it is the usenet equivalent of a live, well-seeded torrent.
+	if result.DownloadProtocol == "nzb" {
+		return 15
+	}
+
 	switch {
 	case result.Seeders >= 20:
 		return 15

--- a/web/index.html
+++ b/web/index.html
@@ -96,6 +96,20 @@
   </div>
 </div>
 
+<!-- Discover Book Detail Modal -->
+<div id="discover-modal" class="fixed inset-0 z-40 modal-backdrop hidden items-center justify-center p-4">
+  <div class="bg-slate-900 border border-slate-700 rounded-xl w-full max-w-lg mx-4 shadow-2xl max-h-[90vh] overflow-y-auto">
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-4">
+        <div id="discover-modal-body" class="flex gap-4 flex-1"></div>
+        <button data-action="hideDiscoverModal" class="text-slate-500 hover:text-white text-2xl leading-none ml-3" aria-label="Close">&times;</button>
+      </div>
+      <p id="discover-modal-description" class="text-sm text-slate-400 whitespace-pre-line"></p>
+      <div id="discover-modal-actions" class="mt-5"></div>
+    </div>
+  </div>
+</div>
+
 <!-- Main App -->
 <div id="app" class="min-h-screen flex flex-col">
 
@@ -136,6 +150,9 @@
       <nav class="flex gap-1 -mb-px overflow-x-auto" id="main-nav">
         <button data-action="switchTab" data-arg="search" class="nav-tab active px-4 py-2.5 text-sm font-medium border-b-2 border-transparent text-slate-400 hover:text-slate-200 transition-colors whitespace-nowrap" data-tab="search">
           <svg class="w-4 h-4 inline mr-1.5 -mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg><span data-i18n="nav_search">Search</span>
+        </button>
+        <button data-action="switchTab" data-arg="discover" class="nav-tab px-4 py-2.5 text-sm font-medium border-b-2 border-transparent text-slate-400 hover:text-slate-200 transition-colors whitespace-nowrap" data-tab="discover">
+          <svg class="w-4 h-4 inline mr-1.5 -mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg><span data-i18n="nav_discover">Discover</span>
         </button>
         <button data-action="switchTab" data-arg="library" class="nav-tab px-4 py-2.5 text-sm font-medium border-b-2 border-transparent text-slate-400 hover:text-slate-200 transition-colors whitespace-nowrap" data-tab="library">
           <svg class="w-4 h-4 inline mr-1.5 -mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 14v3m4-3v3m4-3v3M3 21h18M3 10h18M3 7l9-4 9 4M4 10h16v11H4V10z"/></svg><span data-i18n="nav_library">Library</span>
@@ -205,6 +222,37 @@
 
       <!-- Search spinner / loading more -->
       <div id="search-loading-more" class="hidden text-center py-4 text-slate-500 text-sm" data-i18n="loading">Loading...</div>
+    </div>
+
+    <!-- ==================== DISCOVER TAB ==================== -->
+    <!-- Browse catalog metadata (Google Books + Open Library) to find and
+         Request books, distinct from the Search tab above (which searches
+         indexers for downloadable releases of a book you already know you
+         want). -->
+    <div id="tab-discover" class="tab-content">
+      <!-- Search Bar -->
+      <div class="relative mb-6">
+        <svg class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+        <input type="text" id="discover-input" class="w-full bg-slate-900 border border-slate-700 rounded-xl pl-12 pr-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-base" placeholder="Search for books to discover..." data-i18n-placeholder="discover_placeholder">
+        <div id="discover-spinner" class="absolute right-4 top-1/2 -translate-y-1/2 hidden">
+          <svg class="w-5 h-5 text-indigo-400 spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+        </div>
+      </div>
+
+      <!-- Empty state -->
+      <div id="discover-empty" class="text-center py-16">
+        <h2 class="text-2xl font-bold text-white mb-2" data-i18n="discover_empty_title">Find your next read</h2>
+        <p class="text-slate-400" data-i18n="discover_empty_hint">Search by title or author to browse and request books</p>
+      </div>
+
+      <!-- No results -->
+      <div id="discover-no-results" class="hidden text-center py-16">
+        <h2 class="text-2xl font-bold text-white mb-2" data-i18n="no_results">No results found</h2>
+        <p class="text-slate-400" data-i18n="no_results_hint">Try different keywords or check your spelling</p>
+      </div>
+
+      <!-- Results grid -->
+      <div id="discover-results" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 mb-6"></div>
     </div>
 
     <!-- ==================== LIBRARY TAB ==================== -->

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -717,7 +717,13 @@ function showLoginModal() {
     // First user creates admin (no invite needed). After that, invite code required.
     const regLink = document.getElementById('login-register-link');
     regLink.classList.remove('hidden');
-    if (!data.has_users) {
+    // has_users alone used to decide this, which meant a legacy
+    // AUTH_USERNAME/AUTH_PASSWORD operator (intentionally zero DB users)
+    // saw only the "create admin account" screen and had no way to reach a
+    // login form for the credentials they'd actually configured. Only
+    // default to first-run registration when there's truly nothing to log
+    // into yet.
+    if (!data.has_users && !data.legacy_auth_enabled) {
       // First-run: default to the register form with a welcome banner. The
       // login form has nothing to log into yet, so showing it first wastes a
       // click and hides the actual setup step behind a "Register" link.

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -64,6 +64,17 @@ const I18N = {
     search_empty_hint: 'Try searching by title, author, or ISBN',
     no_results: 'No results found',
     no_results_hint: 'Try different keywords or check your spelling',
+    nav_discover: 'Discover',
+    discover_placeholder: 'Search for books to discover...',
+    discover_empty_title: 'Find your next read',
+    discover_empty_hint: 'Search by title or author to browse and request books',
+    request_button: 'Request',
+    requesting: 'Requesting...',
+    requested_badge: 'Requested',
+    request_sent: '"{title}" requested',
+    request_failed: 'Request failed: {msg}',
+    already_requested: '"{title}" has already been requested',
+    discover_detail_error: 'Failed to load book details',
     download: 'Download',
     download_added: 'Added',
     download_failed_state: 'Failed',
@@ -272,6 +283,17 @@ const I18N = {
     search_empty_hint: 'Попробуйте искать по названию, автору или ISBN',
     no_results: 'Ничего не найдено',
     no_results_hint: 'Попробуйте другие ключевые слова или проверьте написание',
+    nav_discover: 'Обзор',
+    discover_placeholder: 'Найти книги для просмотра...',
+    discover_empty_title: 'Найдите свою следующую книгу',
+    discover_empty_hint: 'Ищите по названию или автору, чтобы просматривать и запрашивать книги',
+    request_button: 'Запросить',
+    requesting: 'Запрос...',
+    requested_badge: 'Запрошено',
+    request_sent: '«{title}» запрошено',
+    request_failed: 'Ошибка запроса: {msg}',
+    already_requested: '«{title}» уже запрошено',
+    discover_detail_error: 'Не удалось загрузить информацию о книге',
     download: 'Скачать',
     download_added: 'Добавлено',
     download_failed_state: 'Ошибка',
@@ -1697,6 +1719,210 @@ function stopDownloadPolling() {
 }
 
 // ============================================================
+// DISCOVER — browse catalog metadata (Google Books + Open Library) and
+// Request a book, distinct from the Search tab above (indexer search for
+// a book you already know you want).
+// ============================================================
+let discoverTimeout = null;
+let discoverAbort = null;
+let discoverGeneration = 0;
+state.discoverResults = [];
+state.discoverRequesting = new Set(); // source_id currently being requested
+
+document.getElementById('discover-input').addEventListener('input', (e) => {
+  clearTimeout(discoverTimeout);
+  const q = e.target.value.trim();
+  if (q.length < 2) return;
+  discoverTimeout = setTimeout(() => doDiscoverSearch(q), 300);
+});
+
+document.getElementById('discover-input').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    clearTimeout(discoverTimeout);
+    const q = e.target.value.trim();
+    if (q.length >= 1) doDiscoverSearch(q);
+  }
+});
+
+async function doDiscoverSearch(query) {
+  if (discoverAbort) discoverAbort.abort();
+  discoverAbort = new AbortController();
+  const gen = ++discoverGeneration;
+
+  document.getElementById('discover-spinner').classList.remove('hidden');
+  document.getElementById('discover-empty').classList.add('hidden');
+  document.getElementById('discover-no-results').classList.add('hidden');
+
+  try {
+    const data = await apiJson(`/api/discover/search?q=${encodeURIComponent(query)}`, { signal: discoverAbort.signal });
+    if (gen !== discoverGeneration) return; // a newer search superseded this one
+    state.discoverResults = data.results || [];
+    renderDiscoverResults();
+    document.getElementById('discover-no-results').classList.toggle('hidden', state.discoverResults.length > 0);
+  } catch (err) {
+    if (err.name === 'AbortError') return;
+    if (err.message !== 'Unauthorized') {
+      showToast(t('search_failed', { msg: err.message }), 'error');
+    }
+  } finally {
+    if (gen === discoverGeneration) {
+      document.getElementById('discover-spinner').classList.add('hidden');
+    }
+  }
+}
+
+function renderDiscoverResults() {
+  const container = document.getElementById('discover-results');
+  container.innerHTML = state.discoverResults.map((r, i) => renderDiscoverCard(r, i)).join('');
+}
+
+function renderDiscoverCard(result, index) {
+  const coverHtml = result.cover_url
+    ? `<img src="${escapeHtml(result.cover_url)}" alt="" class="w-full h-48 object-cover" loading="lazy">`
+    : makePlaceholderHtml(result.title || '?', index);
+
+  const ownedBadge = result.in_library
+    ? `<span class="absolute top-2 right-2 px-2 py-0.5 rounded text-xs font-medium bg-emerald-600 text-white">${escapeHtml(t('in_library'))}</span>`
+    : (result.requested
+      ? `<span class="absolute top-2 right-2 px-2 py-0.5 rounded text-xs font-medium bg-amber-600 text-white">${escapeHtml(t('requested_badge'))}</span>`
+      : '');
+
+  const srcLabel = result.source === 'google_books' ? 'Google Books' : 'Open Library';
+
+  return `
+    <div class="book-card bg-slate-900 rounded-xl overflow-hidden border border-slate-800 hover:border-slate-600 flex flex-col cursor-pointer" data-action="openDiscoverDetail" data-idx="${index}">
+      <div class="relative">
+        ${coverHtml}
+        <span class="absolute top-2 left-2 px-2 py-0.5 rounded text-xs font-medium bg-slate-700 text-slate-200">${escapeHtml(srcLabel)}</span>
+        ${ownedBadge}
+      </div>
+      <div class="p-3 flex-1 flex flex-col">
+        <h3 class="text-sm font-semibold text-white line-clamp-2 mb-1" title="${escapeHtml(result.title || '')}">${escapeHtml(result.title || 'Unknown')}</h3>
+        <p class="text-xs text-slate-400 line-clamp-1">${escapeHtml(result.author || '')}</p>
+      </div>
+    </div>`;
+}
+
+let discoverDetailAbort = null;
+
+function openDiscoverDetail(index) {
+  const result = state.discoverResults[index];
+  if (!result) return;
+  state.discoverDetailResult = result;
+  showDiscoverModal(result);
+
+  // The search result carries only summary fields (no description) - fetch
+  // the full detail in the background and merge it in once it lands, so the
+  // modal opens instantly instead of blocking on a network round-trip.
+  if (discoverDetailAbort) discoverDetailAbort.abort();
+  discoverDetailAbort = new AbortController();
+  const signal = discoverDetailAbort.signal;
+
+  apiJson(`/api/discover/book/${encodeURIComponent(result.source)}/${encodeURIComponent(result.source_id)}`, { signal })
+    .then(detail => {
+      if (signal.aborted || state.discoverDetailResult !== result) return; // modal moved on
+      Object.assign(result, detail);
+      showDiscoverModal(result);
+    })
+    .catch(err => {
+      if (err.name === 'AbortError') return;
+      if (err.message !== 'Unauthorized') {
+        showToast(t('discover_detail_error'), 'error');
+      }
+    });
+}
+
+function showDiscoverModal(result) {
+  const modal = document.getElementById('discover-modal');
+  modal.classList.remove('hidden');
+  modal.classList.add('flex');
+
+  const coverHtml = result.cover_url
+    ? `<img src="${escapeHtml(result.cover_url)}" alt="" class="w-24 h-36 object-cover rounded-lg shrink-0">`
+    : `<div class="w-24 h-36 rounded-lg shrink-0 bg-gradient-to-br from-indigo-600 to-purple-700 flex items-center justify-center text-2xl font-bold text-white">${escapeHtml((result.title || '?').charAt(0).toUpperCase())}</div>`;
+
+  const metaBits = [result.published_date, result.page_count ? `${result.page_count}p` : '', (result.categories || [])[0]]
+    .filter(Boolean).map(escapeHtml).join(' · ');
+
+  document.getElementById('discover-modal-body').innerHTML = `
+    ${coverHtml}
+    <div class="min-w-0">
+      <h2 class="text-lg font-bold text-white leading-tight mb-1">${escapeHtml(result.title || 'Unknown')}</h2>
+      <p class="text-sm text-slate-400 mb-1">${escapeHtml(result.author || '')}</p>
+      <p class="text-xs text-slate-500">${metaBits}</p>
+    </div>`;
+  document.getElementById('discover-modal-description').textContent = result.description || '';
+  renderDiscoverModalActions(result);
+}
+
+function renderDiscoverModalActions(result) {
+  const el = document.getElementById('discover-modal-actions');
+  if (result.in_library) {
+    el.innerHTML = `<span class="inline-block px-3 py-1.5 rounded-lg bg-emerald-600/20 text-emerald-400 text-sm font-medium">${escapeHtml(t('in_library'))}</span>`;
+    return;
+  }
+  if (result.requested) {
+    el.innerHTML = `<span class="inline-block px-3 py-1.5 rounded-lg bg-amber-600/20 text-amber-400 text-sm font-medium">${escapeHtml(t('requested_badge'))}</span>`;
+    return;
+  }
+  const key = `${result.source}:${result.source_id}`;
+  const requesting = state.discoverRequesting.has(key);
+  el.innerHTML = `
+    <button data-action="requestDiscoverBook" ${requesting ? 'disabled aria-busy="true"' : ''} class="w-full sm:w-auto px-4 py-2 rounded-lg text-sm font-medium transition-colors ${requesting ? 'bg-indigo-500/70 text-white cursor-not-allowed' : 'bg-indigo-600 hover:bg-indigo-500 text-white'}">
+      ${requesting ? escapeHtml(t('requesting')) : escapeHtml(t('request_button'))}
+    </button>`;
+}
+
+function hideDiscoverModal() {
+  if (discoverDetailAbort) discoverDetailAbort.abort();
+  const modal = document.getElementById('discover-modal');
+  modal.classList.add('hidden');
+  modal.classList.remove('flex');
+}
+
+async function requestDiscoverBook() {
+  const result = state.discoverDetailResult;
+  if (!result) return;
+  const key = `${result.source}:${result.source_id}`;
+  state.discoverRequesting.add(key);
+  renderDiscoverModalActions(result);
+
+  try {
+    const data = await apiJson('/api/requests', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: result.title,
+        author: result.author || '',
+        book_type: 'ebook',
+        cover_url: result.cover_url || '',
+        description: result.description || '',
+        isbn: result.isbn || '',
+        source: result.source,
+        year: result.published_date || '',
+      }),
+    });
+    if (data.success) {
+      result.requested = true;
+      result.request_id = data.request?.id;
+      showToast(t('request_sent', { title: result.title }), 'success');
+      // Reflect on the grid card too, not just the modal, without a re-search.
+      const idx = state.discoverResults.findIndex(r => r.source === result.source && r.source_id === result.source_id);
+      if (idx !== -1) {
+        state.discoverResults[idx].requested = true;
+        renderDiscoverResults();
+      }
+    }
+  } catch (err) {
+    if (err.message !== 'Unauthorized') {
+      showToast(t('request_failed', { msg: err.message }), 'error');
+    }
+  } finally {
+    state.discoverRequesting.delete(key);
+    renderDiscoverModalActions(result);
+  }
+}
+
+// ============================================================
 // LIBRARY
 // ============================================================
 let librarySearchTimeout = null;
@@ -2834,6 +3060,9 @@ const CLICK_ACTIONS = {
     if (r) startDownload(r);
   },
   retryDownload: el => retryDownload(el.dataset.jobId),
+  openDiscoverDetail: el => openDiscoverDetail(+el.dataset.idx),
+  hideDiscoverModal: () => hideDiscoverModal(),
+  requestDiscoverBook: () => requestDiscoverBook(),
   deleteLibraryItem: el => deleteLibraryItem(el.dataset.id, el.dataset.type, el.dataset.title),
   goLibraryPage: el => goLibraryPage(+el.dataset.page),
   searchWishlistItem: el => searchWishlistItem(el.dataset.title, el.dataset.mediaType),

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -577,9 +577,30 @@ async function api(path, options = {}) {
   return resp;
 }
 
+// The backend sends a specific reason in the JSON body ("No torrent download
+// client configured", "SABnzbd not configured", etc.) on non-2xx responses.
+// pickErrorMessage/parseErrorMessage are the one shared rule every caller
+// uses for turning that into an Error message, whether it already has the
+// parsed body (pickErrorMessage) or still needs to read it (parseErrorMessage) -
+// falling back to the bare status only when the body isn't JSON or has no
+// error field, rather than always discarding it.
+function pickErrorMessage(data, status) {
+  return (data && data.error) || `API error: ${status}`;
+}
+
+async function parseErrorMessage(resp) {
+  let data = {};
+  try {
+    data = await resp.json();
+  } catch {
+    // Response body wasn't JSON (or already consumed) - data stays {}.
+  }
+  return pickErrorMessage(data, resp.status);
+}
+
 async function apiJson(path, options = {}) {
   const resp = await api(path, options);
-  if (!resp.ok) throw new Error(`API error: ${resp.status}`);
+  if (!resp.ok) throw new Error(await parseErrorMessage(resp));
   return resp.json();
 }
 
@@ -1042,7 +1063,8 @@ async function doStreamingSearch(endpoint, query, gen, signal) {
     signal,
     headers: { Accept: 'text/event-stream' },
   });
-  if (!resp.ok || !resp.body) throw new Error(`API error: ${resp.status}`);
+  if (!resp.ok) throw new Error(await parseErrorMessage(resp));
+  if (!resp.body) throw new Error(`API error: ${resp.status}`);
 
   const reader = resp.body.getReader();
   const decoder = new TextDecoder();
@@ -1411,7 +1433,10 @@ async function startDownload(result) {
       showToast(t('already_in_library', {title: data.library_title || result.title}), 'warning');
       return;
     }
-    if (!resp.ok) throw new Error(`API error: ${resp.status}`);
+    // data was already parsed above (falling back to {} if the body wasn't
+    // JSON) - reuse the same rule apiJson uses via pickErrorMessage, since
+    // this call bypasses apiJson itself for the 409 check above.
+    if (!resp.ok) throw new Error(pickErrorMessage(data, resp.status));
 
     if (result.source === 'annas' && data.job_id) {
       setDownloadOutcome(downloadKey, 'loading', true);
@@ -2368,7 +2393,10 @@ async function testConnection(service) {
       statusEl.className = 'text-xs text-red-400';
     }
   } catch (err) {
-    statusEl.textContent = t('conn_error');
+    // apiJson throws the backend's specific reason when it has one - show
+    // it instead of a generic message, same as the success-with-error-body
+    // branch above already does via data.error.
+    statusEl.textContent = err.message !== 'Unauthorized' ? (err.message || t('conn_error')) : t('conn_error');
     statusEl.className = 'text-xs text-red-400';
   }
 }


### PR DESCRIPTION
- api/download: stop letting an NZB result silently fall through to the torrent client when SABnzbd isn't configured; always route it through handleNZBDownload, which already returns a clear "SABnzbd not configured" error instead of a confusing torrent-client failure.
- search/filter: add "prowlarr_audiobooks" to isTorrentSource and sourcePriority so Prowlarr's audiobook-tab results get the same dedup/size-bound treatment the Books and Manga tabs already do.
- search/scorer: exempt usenet/NZB results from the seeder-count score, mirroring filter.go's existing exception - NZBs have no seeders by definition, so they were being scored identically to a dead torrent and could fall below the auto-download threshold for no real reason.
- api/library_external: run delete-handler DB errors through the existing errString() sanitizer instead of returning err.Error() raw, matching how download.go already handles this.
- web/app.js: extract pickErrorMessage/parseErrorMessage as one shared rule for surfacing the backend's specific error reason, used by apiJson, startDownload, testConnection, and doStreamingSearch (which still had the original bug: a bare "API error: <status>" instead of the backend's actual reason).
- download/sabnzbd: replace five hand-copied build-params/GET/status-check sequences with one doRequest helper, mirroring the pattern qbittorrent.go already uses. DeleteNZB now actually checks whether the delete succeeded instead of always reporting success.
- Dockerfile/entrypoint.sh: start as root, chown /data and /books/* to PUID:PGID (default 1000:1000), then exec via su-exec - fixes the "permission denied" crash loop on a fresh volume/bind mount on any host, not just Docker Desktop's Windows file-sharing layer.
- docker-compose.yml: local dev bind mounts instead of a named volume, to match the above.