### PR TITLE
fix: handle Prowlarr redirects to magnet URLs

### DIFF
--- a/internal/download/qbittorrent.go
+++ b/internal/download/qbittorrent.go
@@ -37,6 +37,7 @@ type QBittorrentClient struct {
 	lastError      string
 	verifyTimeout  time.Duration
 	verifyInterval time.Duration
+	fetchTimeout   time.Duration
 }
 
 // TorrentVerificationWarning indicates that qBittorrent accepted the add
@@ -75,6 +76,7 @@ func NewQBittorrentClient(cfg *config.Config) *QBittorrentClient {
 		backoffSec:     3,
 		verifyTimeout:  25 * time.Second,
 		verifyInterval: 250 * time.Millisecond,
+		fetchTimeout:   30 * time.Second,
 	}
 }
 
@@ -251,6 +253,21 @@ func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category, ex
 		var fetched fetchedTorrent
 		if fetched, err = q.fetchTorrent(torrentURL); err == nil {
 			if fetched.magnetURL != "" {
+				magnetHash := infoHashFromMagnet(fetched.magnetURL)
+				if supplied := firstNonEmptyHash(expectedInfoHash); supplied != "" && supplied != magnetHash {
+					slog.Warn(
+						"redirected magnet info hash differs from search result",
+						"title", logTitle,
+						"expected_hash", netutil.SanitizeLogValue(supplied),
+						"magnet_hash", netutil.SanitizeLogValue(magnetHash),
+					)
+				}
+
+				// The hash carried by the magnet Prowlarr redirected to is what
+				// qBittorrent will register, so it is authoritative for
+				// verification.
+				expectedInfoHash = magnetHash
+
 				slog.Info(
 					"submitting redirected magnet to qBittorrent",
 					"title", logTitle,
@@ -493,7 +510,14 @@ func (q *QBittorrentClient) fetchTorrent(rawURL string) (fetchedTorrent, error) 
 
 	var redirectedMagnet string
 
+	timeout := q.fetchTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
 	client := &http.Client{
+		Timeout:   timeout,
+		Transport: q.client.Transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return fmt.Errorf("stopped after 5 redirects")

--- a/internal/download/qbittorrent.go
+++ b/internal/download/qbittorrent.go
@@ -249,15 +249,46 @@ func (q *QBittorrentClient) AddTorrent(torrentURL, title, savePath, category, ex
 	} else if isHTTPURL(torrentURL) && q.isProwlarrTorrentURL(torrentURL) {
 		slog.Info("fetching torrent before qBittorrent upload", "title", logTitle, "category", logCategory)
 		var fetched fetchedTorrent
-		fetched, err = q.fetchTorrent(torrentURL)
-		if err == nil {
-			if supplied := firstNonEmptyHash(expectedInfoHash); supplied != "" && supplied != fetched.infoHash {
-				slog.Warn("torrent info hash differs from search result", "title", logTitle, "expected_hash", netutil.SanitizeLogValue(supplied), "fetched_hash", netutil.SanitizeLogValue(fetched.infoHash))
+		if fetched, err = q.fetchTorrent(torrentURL); err == nil {
+			if fetched.magnetURL != "" {
+				slog.Info(
+					"submitting redirected magnet to qBittorrent",
+					"title", logTitle,
+					"category", logCategory,
+				)
+
+				ids, err = q.addTorrentURL(
+					fetched.magnetURL,
+					savePath,
+					category,
+				)
+			} else {
+				if supplied := firstNonEmptyHash(expectedInfoHash); supplied != "" && supplied != fetched.infoHash {
+					slog.Warn(
+						"torrent info hash differs from search result",
+						"title", logTitle,
+						"expected_hash", netutil.SanitizeLogValue(supplied),
+						"fetched_hash", netutil.SanitizeLogValue(fetched.infoHash),
+					)
+				}
+
+				// The hash of the fetched bytes is authoritative for verification.
+				expectedInfoHash = fetched.infoHash
+
+				slog.Info(
+					"uploading torrent bytes to qBittorrent",
+					"title", logTitle,
+					"category", logCategory,
+					"filename", netutil.SanitizeLogValue(fetched.filename),
+					"bytes", len(fetched.body),
+				)
+
+				ids, err = q.addTorrentFile(
+					fetched,
+					savePath,
+					category,
+				)
 			}
-			// The hash of the fetched bytes is authoritative for verification.
-			expectedInfoHash = fetched.infoHash
-			slog.Info("uploading torrent bytes to qBittorrent", "title", logTitle, "category", logCategory, "filename", netutil.SanitizeLogValue(fetched.filename), "bytes", len(fetched.body))
-			ids, err = q.addTorrentFile(fetched, savePath, category)
 		}
 	} else {
 		slog.Info("submitting torrent URL to qBittorrent", "title", logTitle, "category", logCategory)
@@ -425,9 +456,10 @@ func parseQBittorrentAddTorrentResponse(body []byte) (qbittorrentAddTorrentRespo
 const maxTorrentFetchBytes = 50 << 20
 
 type fetchedTorrent struct {
-	filename string
-	body     []byte
-	infoHash string
+	filename  string
+	body      []byte
+	infoHash  string
+	magnetURL string
 }
 
 // isProwlarrTorrentURL reports whether the URL belongs to the configured
@@ -459,18 +491,40 @@ func (q *QBittorrentClient) fetchTorrent(rawURL string) (fetchedTorrent, error) 
 	// path and query, so the fetched host and port always come from config.
 	requestURL := base.Scheme + "://" + base.Host + u.RequestURI()
 
+	var redirectedMagnet string
+
 	client := &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: q.client.Transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return fmt.Errorf("stopped after 5 redirects")
 			}
-			if _, err := netutil.ValidateSameOriginHTTPURL(req.URL.String(), q.cfg.ProwlarrURL); err != nil {
+
+			// Prowlarr may respond to its HTTP download URL with a
+			// magnet URI instead of returning a .torrent file.
+			//
+			// Do not attempt to make an HTTP request to the magnet.
+			// Capture it and let AddTorrent submit it directly to qBittorrent.
+			if strings.EqualFold(req.URL.Scheme, "magnet") {
+				magnet := req.URL.String()
+
+				if infoHashFromMagnet(magnet) == "" {
+					return fmt.Errorf("torrent redirect rejected: invalid magnet URL")
+				}
+
+				redirectedMagnet = magnet
+				return http.ErrUseLastResponse
+			}
+
+			if _, err := netutil.ValidateSameOriginHTTPURL(
+				req.URL.String(),
+				q.cfg.ProwlarrURL,
+			); err != nil {
 				req.Header.Del("X-Api-Key")
 				return fmt.Errorf("torrent redirect rejected: %w", err)
 			}
+
 			q.applyProwlarrAuth(req)
+
 			return nil
 		},
 	}
@@ -486,6 +540,12 @@ func (q *QBittorrentClient) fetchTorrent(rawURL string) (fetchedTorrent, error) 
 		return fetchedTorrent{}, fmt.Errorf("fetch torrent: %s", netutil.SanitizeSensitiveText(err.Error()))
 	}
 	defer resp.Body.Close()
+
+	if redirectedMagnet != "" {
+		return fetchedTorrent{
+			magnetURL: redirectedMagnet,
+		}, nil
+	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTorrentFetchBytes+1))
 	if err != nil {

--- a/internal/download/qbittorrent_test.go
+++ b/internal/download/qbittorrent_test.go
@@ -478,6 +478,98 @@ func TestQBittorrentHTTPURLFetchedAndUploadedAsMultipart(t *testing.T) {
 	}
 }
 
+func TestQBittorrentProwlarrRedirectToMagnet(t *testing.T) {
+	const hash = "0123456789abcdef0123456789abcdef01234567"
+	magnet := "magnet:?xt=urn:btih:" + hash
+
+	var sawDownload bool
+	var sawMagnet bool
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/download/book.torrent", func(w http.ResponseWriter, r *http.Request) {
+		sawDownload = true
+
+		if got := r.Header.Get("X-Api-Key"); got != "prowlarr-key" {
+			t.Fatalf("X-Api-Key = %q, want prowlarr-key", got)
+		}
+
+		http.Redirect(w, r, magnet, http.StatusFound)
+	})
+
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:  "QBT_SID",
+			Value: "abc123",
+			Path:  "/",
+		})
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ok."))
+	})
+
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+
+		if strings.HasPrefix(contentType, "multipart/form-data") {
+			t.Fatalf("expected URL form submission for magnet, got multipart: %q", contentType)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+
+		if got := r.FormValue("urls"); got != magnet {
+			t.Fatalf("urls = %q, want %q", got, magnet)
+		}
+
+		if got := r.FormValue("savepath"); got != "/downloads" {
+			t.Fatalf("savepath = %q, want /downloads", got)
+		}
+
+		if got := r.FormValue("category"); got != "librarr" {
+			t.Fatalf("category = %q, want librarr", got)
+		}
+
+		sawMagnet = true
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(
+			`{"added_torrent_ids":["` + hash + `"],"success_count":1}`,
+		))
+	})
+
+	mux.HandleFunc(
+		"/api/v2/torrents/info",
+		torrentInfoHandler(hash, "Actual qB Name"),
+	)
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = srv.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	if err := q.AddTorrent(
+		srv.URL+"/download/book.torrent",
+		"Search Result Name",
+		"",
+		"",
+		hash,
+	); err != nil {
+		t.Fatalf("AddTorrent returned error: %v", err)
+	}
+
+	if !sawDownload {
+		t.Fatal("expected Librarr to fetch torrent URL")
+	}
+
+	if !sawMagnet {
+		t.Fatal("expected redirected magnet to be submitted to qBittorrent")
+	}
+}
+
 func TestFetchTorrentAllowsConfiguredProwlarrOrigin(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Api-Key"); got != "prowlarr-key" {

--- a/internal/download/qbittorrent_test.go
+++ b/internal/download/qbittorrent_test.go
@@ -570,6 +570,154 @@ func TestQBittorrentProwlarrRedirectToMagnet(t *testing.T) {
 	}
 }
 
+func TestQBittorrentProwlarrRedirectMagnetHashIsAuthoritative(t *testing.T) {
+	// Prowlarr redirects to a magnet whose info hash differs from the one the
+	// search result carried. The magnet is what qBittorrent registers, so its
+	// hash must be the one verification looks for.
+	const searchHash = "1111111111111111111111111111111111111111"
+	const magnetHash = "2222222222222222222222222222222222222222"
+	magnet := "magnet:?xt=urn:btih:" + magnetHash
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/download/book.torrent", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, magnet, http.StatusFound)
+	})
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123", Path: "/"})
+		_, _ = w.Write([]byte("Ok."))
+	})
+	// Real qBittorrent answers "Ok." with no ids, so verification can only use
+	// the info hash.
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler(magnetHash, "Actual qB Name"))
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = srv.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	if err := q.AddTorrent(srv.URL+"/download/book.torrent", "Search Result Name", "", "", searchHash); err != nil {
+		t.Fatalf("AddTorrent returned error: %v", err)
+	}
+}
+
+func TestQBittorrentProwlarrRedirectMagnetHashUsedWhenNoneSupplied(t *testing.T) {
+	const magnetHash = "3333333333333333333333333333333333333333"
+	magnet := "magnet:?xt=urn:btih:" + magnetHash
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/download/book.torrent", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, magnet, http.StatusFound)
+	})
+	mux.HandleFunc("/api/v2/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "QBT_SID", Value: "abc123", Path: "/"})
+		_, _ = w.Write([]byte("Ok."))
+	})
+	mux.HandleFunc("/api/v2/torrents/add", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Ok."))
+	})
+	// qBittorrent renames the torrent, so the exact-title fallback cannot
+	// rescue verification here.
+	mux.HandleFunc("/api/v2/torrents/info", torrentInfoHandler(magnetHash, "Actual qB Name"))
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = srv.URL
+	q.cfg.ProwlarrAPIKey = "prowlarr-key"
+
+	if err := q.AddTorrent(srv.URL+"/download/book.torrent", "Search Result Name", "", "", ""); err != nil {
+		t.Fatalf("AddTorrent returned error: %v", err)
+	}
+}
+
+func TestFetchTorrentRejectsMagnetRedirectWithoutInfoHash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "magnet:?dn=book", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = srv.URL
+
+	fetched, err := q.fetchTorrent(srv.URL + "/download.torrent")
+	if err == nil {
+		t.Fatalf("expected error, got magnet %q", fetched.magnetURL)
+	}
+	if !strings.Contains(err.Error(), "invalid magnet") {
+		t.Fatalf("error = %v, want invalid magnet rejection", err)
+	}
+}
+
+func TestFetchTorrentUsesConfiguredTransport(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-bittorrent")
+		_, _ = w.Write(validTorrentBytes())
+	}))
+	defer srv.Close()
+
+	counted := &countingTransport{base: srv.Client().Transport}
+	q := newAddTorrentTestQBClient(srv.URL, &http.Client{Transport: counted})
+	q.cfg.ProwlarrURL = srv.URL
+
+	if _, err := q.fetchTorrent(srv.URL + "/download.torrent"); err != nil {
+		t.Fatalf("fetchTorrent: %v", err)
+	}
+	if counted.calls == 0 {
+		t.Fatal("fetchTorrent bypassed the configured Transport")
+	}
+}
+
+func TestFetchTorrentHonoursTimeout(t *testing.T) {
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	// Close(release) must run before srv.Close(), which blocks on in-flight
+	// handlers; defers run last-registered-first.
+	defer srv.Close()
+	defer close(release)
+
+	q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+	q.cfg.ProwlarrURL = srv.URL
+	q.fetchTimeout = 50 * time.Millisecond
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := q.fetchTorrent(srv.URL + "/download.torrent")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected fetch to time out")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetchTorrent did not honour its timeout")
+	}
+}
+
+type countingTransport struct {
+	base  http.RoundTripper
+	calls int
+}
+
+func (c *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.calls++
+	base := c.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
 func TestFetchTorrentAllowsConfiguredProwlarrOrigin(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Api-Key"); got != "prowlarr-key" {

--- a/internal/download/qbittorrent_test.go
+++ b/internal/download/qbittorrent_test.go
@@ -654,6 +654,28 @@ func TestFetchTorrentRejectsMagnetRedirectWithoutInfoHash(t *testing.T) {
 	}
 }
 
+func TestFetchTorrentRejectsNonHTTPNonMagnetRedirect(t *testing.T) {
+	// Magnet is the only non-HTTP redirect scheme that is allowed through;
+	// every other one must still hit the same-origin rejection.
+	for _, target := range []string{"ftp://example.com/book.torrent", "file:///etc/passwd"} {
+		t.Run(target, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, target, http.StatusFound)
+			}))
+			defer srv.Close()
+
+			q := newAddTorrentTestQBClient(srv.URL, srv.Client())
+			q.cfg.ProwlarrURL = srv.URL
+
+			if _, err := q.fetchTorrent(srv.URL + "/download.torrent"); err == nil {
+				t.Fatal("expected redirect rejection")
+			} else if !strings.Contains(err.Error(), "redirect rejected") {
+				t.Fatalf("error = %q, want redirect rejection", err.Error())
+			}
+		})
+	}
+}
+
 func TestFetchTorrentUsesConfiguredTransport(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/x-bittorrent")


### PR DESCRIPTION
## What does this PR do?

Handles Prowlarr torrent download URLs that respond with a redirect directly to a valid BitTorrent `magnet:` URI.

Previously, Librarr attempted to fetch the redirected magnet URI as an HTTP resource, resulting in:

`torrent redirect rejected: URL must use http or https`

The fix captures valid magnet redirects and submits them directly to qBittorrent.

## Changes

- Detect `magnet:` redirects during Prowlarr torrent fetching.
- Validate that the redirected magnet contains a valid BitTorrent info hash.
- Pass the magnet directly to qBittorrent.
- Preserve the existing same-origin validation for HTTP redirects.
- Preserve the existing `.torrent` download and info-hash verification path.
- Add a regression test covering the Prowlarr → magnet redirect → qBittorrent flow.

## Testing

Verified with:

- `go test ./internal/download -v`
- `go test ./...`
- Real Prowlarr → Librarr → qBittorrent download flow

The real-world flow was tested successfully after deploying the fix.

## Scope

Only these files are changed:

- `internal/download/qbittorrent.go`
- `internal/download/qbittorrent_test.go`