### PR TITLE
Avoid repeated audiobook scanner imports

### DIFF
--- a/internal/db/library.go
+++ b/internal/db/library.go
@@ -158,6 +158,33 @@ func NormalizeLibraryPath(filePath string) string {
 	return filepath.Clean(cleaned)
 }
 
+// LibraryPaths returns the canonical paths recorded for a media type. A
+// library item may record either an individual file or the directory that
+// contains an imported tree, so callers can use the result to recognize both
+// forms without depending on the item's source ID.
+func (d *DB) LibraryPaths(mediaType string) (map[string]struct{}, error) {
+	rows, err := d.db.Query("SELECT file_path FROM library_items WHERE media_type = ?", mediaType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	paths := make(map[string]struct{})
+	for rows.Next() {
+		var filePath string
+		if err := rows.Scan(&filePath); err != nil {
+			return nil, err
+		}
+		if normalized := NormalizeLibraryPath(filePath); normalized != "" {
+			paths[normalized] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return paths, nil
+}
+
 func hashLibraryFile(filePath string) string {
 	filePath = filepath.Clean(strings.TrimSpace(filePath))
 	if filePath == "" || filePath == "." || strings.Contains(filePath, "..") {

--- a/internal/organize/scan.go
+++ b/internal/organize/scan.go
@@ -64,6 +64,12 @@ func (s *AudiobookScanner) scan() {
 	if _, err := os.Stat(s.cfg.AudiobookDir); os.IsNotExist(err) {
 		return
 	}
+	trackedPaths, err := s.db.LibraryPaths("audiobook")
+	if err != nil {
+		slog.Error("audiobook scanner could not load tracked paths", "error", err)
+		return
+	}
+	trackedRoot := db.NormalizeLibraryPath(s.cfg.AudiobookDir)
 
 	// Walk the audiobook directory looking for audio files.
 	var newFiles []string
@@ -76,9 +82,11 @@ func (s *AudiobookScanner) scan() {
 			return nil
 		}
 
-		// Check if this directory is already tracked (we track by dir, not file).
-		dir := filepath.Dir(path)
-		if s.db.HasSourceID("scan-" + dir) {
+		// A torrent import may track either the file or the destination
+		// directory, and its source ID is the torrent hash rather than the
+		// scanner's synthetic ID. Walk ancestors so both import shapes are
+		// recognized as already tracked.
+		if isTrackedAudiobookPath(path, trackedRoot, trackedPaths) {
 			return nil
 		}
 
@@ -128,7 +136,7 @@ func (s *AudiobookScanner) scan() {
 			}
 		}
 
-		_, _ = s.db.AddItem(&models.LibraryItem{
+		outcome, err := s.db.AddItemWithOutcome(&models.LibraryItem{
 			Title:     title,
 			Author:    author,
 			FilePath:  dir,
@@ -137,8 +145,17 @@ func (s *AudiobookScanner) scan() {
 			Source:    "scan",
 			SourceID:  "scan-" + dir,
 		})
+		if err != nil {
+			slog.Error("audiobook scanner library import failed", "path", dir, "error", err)
+			continue
+		}
+		if !outcome.Inserted {
+			continue
+		}
 
-		_ = s.db.LogEvent("scan_import", title, "Auto-imported from audiobook scan", nil, "")
+		if err := s.db.LogEvent("scan_import", title, "Auto-imported from audiobook scan", &outcome.ID, ""); err != nil {
+			slog.Warn("audiobook scanner activity log failed", "path", dir, "error", err)
+		}
 		imported++
 	}
 
@@ -146,5 +163,26 @@ func (s *AudiobookScanner) scan() {
 	if imported > 0 && s.targets != nil {
 		slog.Info("audiobook scanner triggering library scan", "imported", imported)
 		s.targets.ImportAudiobook()
+	}
+}
+
+// isTrackedAudiobookPath reports whether path or one of its parent
+// directories belongs to a previously recorded audiobook import. Directory
+// torrent imports record their destination directory while file imports
+// record the individual destination file.
+func isTrackedAudiobookPath(path, root string, trackedPaths map[string]struct{}) bool {
+	current := db.NormalizeLibraryPath(path)
+	if current == "" {
+		return false
+	}
+
+	for {
+		if _, ok := trackedPaths[current]; ok {
+			return true
+		}
+		if current == root || current == filepath.Dir(current) {
+			return false
+		}
+		current = filepath.Dir(current)
 	}
 }

--- a/internal/organize/scan.go
+++ b/internal/organize/scan.go
@@ -170,6 +170,12 @@ func (s *AudiobookScanner) scan() {
 // directories belongs to a previously recorded audiobook import. Directory
 // torrent imports record their destination directory while file imports
 // record the individual destination file.
+//
+// The library root itself is never treated as a match. No import records it —
+// OrganizeAudiobook always returns a path at least one level below it — but a
+// restored library export carries its file paths verbatim, so a single bad row
+// naming the root would otherwise mark every file in the tree as tracked and
+// silently blind the scanner.
 func isTrackedAudiobookPath(path, root string, trackedPaths map[string]struct{}) bool {
 	current := db.NormalizeLibraryPath(path)
 	if current == "" {
@@ -177,11 +183,11 @@ func isTrackedAudiobookPath(path, root string, trackedPaths map[string]struct{})
 	}
 
 	for {
-		if _, ok := trackedPaths[current]; ok {
-			return true
-		}
 		if current == root || current == filepath.Dir(current) {
 			return false
+		}
+		if _, ok := trackedPaths[current]; ok {
+			return true
 		}
 		current = filepath.Dir(current)
 	}

--- a/internal/organize/scan_test.go
+++ b/internal/organize/scan_test.go
@@ -1,0 +1,78 @@
+package organize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/JeremiahM37/librarr/internal/config"
+	"github.com/JeremiahM37/librarr/internal/db"
+	"github.com/JeremiahM37/librarr/internal/models"
+)
+
+func TestAudiobookScannerSkipsTorrentTrackedPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(root, audioPath string) string
+	}{
+		{
+			name: "file import",
+			path: func(_, audioPath string) string { return audioPath },
+		},
+		{
+			name: "directory import",
+			path: func(root, _ string) string { return filepath.Join(root, "Author", "Book") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			bookDir := filepath.Join(root, "Author", "Book")
+			if err := os.MkdirAll(bookDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			audioPath := filepath.Join(bookDir, "Book.m4b")
+			if err := os.WriteFile(audioPath, []byte("audiobook"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			database, err := db.New(filepath.Join(root, "library.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer database.Close()
+
+			trackedPath := tt.path(root, audioPath)
+			if _, err := database.AddItem(&models.LibraryItem{
+				Title:     "Book",
+				Author:    "Author",
+				FilePath:  trackedPath,
+				MediaType: "audiobook",
+				Source:    "torrent",
+				SourceID:  "torrent-hash",
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			scanner := NewAudiobookScanner(&config.Config{AudiobookDir: root}, database, nil)
+			scanner.scan()
+
+			scanEvents, err := database.GetActivityLogCount("", "scan_import")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scanEvents != 0 {
+				t.Fatalf("scan_import events = %d, want 0", scanEvents)
+			}
+
+			itemCount, err := database.CountItems("audiobook")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if itemCount != 1 {
+				t.Fatalf("audiobook library items = %d, want 1", itemCount)
+			}
+		})
+	}
+}

--- a/internal/organize/scan_test.go
+++ b/internal/organize/scan_test.go
@@ -76,3 +76,46 @@ func TestAudiobookScannerSkipsTorrentTrackedPaths(t *testing.T) {
 		})
 	}
 }
+
+// A library row naming the audiobook root must not mark the whole tree as
+// tracked. No import records the root, but a restored library export carries
+// its file paths verbatim, and treating that row as an ancestor match would
+// silently stop the scanner from ever importing again.
+func TestAudiobookScannerIgnoresRootLevelTrackedPath(t *testing.T) {
+	root := t.TempDir()
+	for _, book := range []string{"BookA", "BookB"} {
+		bookDir := filepath.Join(root, "Author", book)
+		if err := os.MkdirAll(bookDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(bookDir, "Book.m4b"), []byte(book), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	database, err := db.New(filepath.Join(root, "library.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	if _, err := database.AddItem(&models.LibraryItem{
+		Title:     "root row",
+		FilePath:  root,
+		MediaType: "audiobook",
+		Source:    "import",
+		SourceID:  "restored-root",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	NewAudiobookScanner(&config.Config{AudiobookDir: root}, database, nil).scan()
+
+	itemCount, err := database.CountItems("audiobook")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if itemCount != 3 {
+		t.Fatalf("audiobook library items = %d, want 3 (the root row plus both books)", itemCount)
+	}
+}


### PR DESCRIPTION
## Summary
- recognize audiobook paths recorded by torrent imports, whether the item records a file or directory
- only log `scan_import` and trigger external library scans when a new library row is inserted
- add regression coverage for file and directory torrent imports

## Context
Torrent imports use the torrent hash as their source ID, while the audiobook scanner only checked its synthetic `scan-*` IDs. As a result, every periodic scan treated already-imported audiobook files as untracked. Database deduplication prevented duplicate rows, but the scanner still emitted activity events and retriggered external scans.

## Tests
- `go test ./...`
- `go vet ./...`
